### PR TITLE
Fix build-installer and build-chart targets to be able to generate helm charts

### DIFF
--- a/dist/install.yaml
+++ b/dist/install.yaml
@@ -6,7 +6,6 @@
 #  comment out the section from "START PROM NODE EXPORTER" to "END PROM NODE EXPORTER"
 # 
 
----
 apiVersion: v1
 kind: Namespace
 metadata:
@@ -14,7 +13,6 @@ metadata:
     control-plane: controller-manager
     app.kubernetes.io/name: devzero-zxporter
   name: devzero-zxporter
----
 # ----- START PROM SERVER -----
 ---
 # Source: prometheus/charts/kube-state-metrics/templates/serviceaccount.yaml
@@ -1121,7 +1119,6 @@ spec:
         - name: storage-volume
           emptyDir:
             {}
----
 # ----- END PROM SERVER -----
 # ----- START PROM NODE EXPORTER -----
 ---
@@ -1280,7 +1277,6 @@ spec:
         - name: root
           hostPath:
             path: /
----
 # ----- END PROM NODE EXPORTER -----
 # ----- START METRICS SERVER -----
 ---
@@ -1536,8 +1532,8 @@ spec:
     port: 443
   version: v1beta1
   versionPriority: 100
----
 # ----- END METRICS SERVER -----
+---
 apiVersion: v1
 kind: Namespace
 metadata:

--- a/dist/metrics-server.yaml
+++ b/dist/metrics-server.yaml
@@ -1,4 +1,3 @@
-# ----- START METRICS SERVER -----
 ---
 # Source: metrics-server/templates/serviceaccount.yaml
 apiVersion: v1
@@ -252,5 +251,3 @@ spec:
     port: 443
   version: v1beta1
   versionPriority: 100
----
-# ----- END METRICS SERVER -----

--- a/dist/node-exporter.yaml
+++ b/dist/node-exporter.yaml
@@ -1,4 +1,3 @@
-# ----- START PROM NODE EXPORTER -----
 ---
 # Source: prometheus-node-exporter/templates/serviceaccount.yaml
 apiVersion: v1
@@ -155,5 +154,3 @@ spec:
         - name: root
           hostPath:
             path: /
----
-# ----- END PROM NODE EXPORTER -----

--- a/dist/prometheus.yaml
+++ b/dist/prometheus.yaml
@@ -1,4 +1,3 @@
-# ----- START PROM SERVER -----
 ---
 # Source: prometheus/charts/kube-state-metrics/templates/serviceaccount.yaml
 apiVersion: v1
@@ -1104,5 +1103,3 @@ spec:
         - name: storage-volume
           emptyDir:
             {}
----
-# ----- END PROM SERVER -----


### PR DESCRIPTION
Also changes the output to be nicer:

```
[INFO] Adding Prometheus repo
[INFO] Fetching prometheus repo data
[INFO] Generate prometheus manifest
[INFO] Generate Node Exporter manifest
[INFO] Adding Metrics Server repo
[INFO] Fetching Metrics Server repo data
[INFO] Generate Metrics Server manifest
[INFO] Monitoring manifests generated.
[INFO] Generating installer bundle...
[INFO] Adding namespace to the main installer
[INFO] Append prometheus-server to the main installer
[INFO] Append prometheus-node-exporter to the main installer
[INFO] Append Metrics Server to the main installer
[INFO] Append zxporter-manager to the installer bundle
[INFO] Replacing env variables in configmap
[INFO] Generating helm chart from the installer bundle
[INFO] Helm chart generated in the 'chart' directory
```
