### PR TITLE
Make zxporter call DAKR directly

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -56,7 +56,7 @@ TESTSERVER_IMG ?= ttl.sh/zxporter-testserver:latest
 # Stress test image URL
 STRESS_IMG ?= ttl.sh/zxporter-stress:latest
 # DAKR URL to use for deployment
-DAKR_URL ?= https://api.devzero.io/dakr
+DAKR_URL ?= https://dakr.devzero.io
 # PROMETHEUS URL for metrics collection
 PROMETHEUS_URL ?= http://prometheus-dz-prometheus-server.$(DEVZERO_MONITORING_NAMESPACE).svc.cluster.local:80
 # TARGET_NAMESPACES for limiting collection to specific namespaces (comma-separated)

--- a/config/manager/env_configmap.yaml
+++ b/config/manager/env_configmap.yaml
@@ -6,7 +6,7 @@ metadata:
 data:
   CLUSTER_TOKEN: "{{ .cluster_token }}"
   KUBE_CONTEXT_NAME: '{{ .kube_context_name }}'
-  DAKR_URL: "https://api.devzero.io/dakr"
+  DAKR_URL: "https://dakr.devzero.io"
   PROMETHEUS_URL: "http://prometheus-dz-prometheus-server.devzero-zxporter.svc.cluster.local:80"
   K8S_PROVIDER: "{{ .k8s_provider }}"
   COLLECTION_FREQUENCY: ""

--- a/dist/collection_bundle.yaml
+++ b/dist/collection_bundle.yaml
@@ -15,7 +15,7 @@ spec:
   policies:
     frequency: "30s"
     bufferSize: 1000000
-    dakrURL: "https://api.devzero.io/dakr"
+    dakrURL: "https://dakr.devzero.io"
     # IMPORTANT: point this to existing prometheus installation, if not using DevZero-provided defaults
     prometheusURL: "http://prometheus-server.devzero-zxporter.svc.cluster.local:9090"
 ---

--- a/dist/env_configmap.yaml
+++ b/dist/env_configmap.yaml
@@ -5,7 +5,7 @@ data:
   CLUSTER_TOKEN: '{{ .cluster_token }}'
   KUBE_CONTEXT_NAME: '{{ .kube_context_name }}'
   COLLECTION_FREQUENCY: ""
-  DAKR_URL: https://api.devzero.io/dakr
+  DAKR_URL: https://dakr.devzero.io
   DISABLE_NETWORK_IO_METRICS: ""
   DISABLE_GPU_METRICS: ""
   DISABLED_COLLECTORS: ""

--- a/dist/install.yaml
+++ b/dist/install.yaml
@@ -403,7 +403,7 @@ spec:
         livenessProbe:
           failureThreshold: 3
           httpGet:
-            httpHeaders:
+            httpHeaders: []
             path: /livez
             port: 8080
             scheme: HTTP
@@ -414,7 +414,7 @@ spec:
         readinessProbe:
           failureThreshold: 3
           httpGet:
-            httpHeaders:
+            httpHeaders: []
             path: /readyz
             port: 8081
             scheme: HTTP
@@ -664,7 +664,7 @@ spec:
           livenessProbe:
             failureThreshold: 3
             httpGet:
-              httpHeaders:
+              httpHeaders: []
               path: /
               port: 9101
               scheme: HTTP
@@ -675,7 +675,7 @@ spec:
           readinessProbe:
             failureThreshold: 3
             httpGet:
-              httpHeaders:
+              httpHeaders: []
               path: /
               port: 9101
               scheme: HTTP
@@ -1166,7 +1166,7 @@ data:
   BUFFER_SIZE: ""
   CLUSTER_TOKEN: '{{ .cluster_token }}'
   COLLECTION_FREQUENCY: ""
-  DAKR_URL: https://api.devzero.io/dakr
+  DAKR_URL: https://dakr.devzero.io
   DISABLE_NETWORK_IO_METRICS: ""
   DISABLED_COLLECTORS: ""
   EXCLUDED_CLUSTERROLEBINDINGS: ""

--- a/dist/zxporter.yaml
+++ b/dist/zxporter.yaml
@@ -437,7 +437,7 @@ data:
   BUFFER_SIZE: ""
   CLUSTER_TOKEN: '{{ .cluster_token }}'
   COLLECTION_FREQUENCY: ""
-  DAKR_URL: https://api.devzero.io/dakr
+  DAKR_URL: https://dakr.devzero.io
   DISABLE_NETWORK_IO_METRICS: ""
   DISABLED_COLLECTORS: ""
   EXCLUDED_CLUSTERROLEBINDINGS: ""


### PR DESCRIPTION
Up until now ZXporter called dakr through API gateway which handled request authentication, now the DAKR service is able to authenticate requests so we can skip API GW