### PR TITLE
[helm] add nodeSelector, tolerations, and affinity support in deployment templates

### DIFF
--- a/helm-chart/zxporter/templates/deployment.yaml
+++ b/helm-chart/zxporter/templates/deployment.yaml
@@ -19,6 +19,18 @@ spec:
       labels:
         control-plane: controller-manager
     spec:
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       containers:
         - args:
             - --metrics-bind-address=:8443

--- a/helm-chart/zxporter/templates/prometheus-deployments.yaml
+++ b/helm-chart/zxporter/templates/prometheus-deployments.yaml
@@ -37,6 +37,18 @@ spec:
       automountServiceAccountToken: true
       hostNetwork: false
       serviceAccountName: prometheus-kube-state-metrics
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       securityContext:
         fsGroup: 65534
         runAsGroup: 65534
@@ -121,6 +133,18 @@ spec:
     spec:
       enableServiceLinks: true
       serviceAccountName: prometheus-dz-prometheus-server
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       containers:
         - name: dz-prometheus-server-configmap-reload
           image: "quay.io/prometheus-operator/prometheus-config-reloader:v0.83.0"


### PR DESCRIPTION
this enable setting tolerations and nodeSelector for arm instance types which otherwise fails

or we should do this as similar to https://github.com/devzero-inc/zxporter/blob/main/helm-chart/zxporter/templates/node-exporter-daemonset.yaml#L106-#L123?