### PR TITLE
automated release for helm chart

### DIFF
--- a/.github/workflows/helm-auto-release-netmon.yml
+++ b/.github/workflows/helm-auto-release-netmon.yml
@@ -1,0 +1,116 @@
+name: Auto Release Helm Chart (zxporter-netmon)
+
+# Triggers on any merge to main that touches helm-chart/zxporter-netmon/**
+# EXCEPT Chart.yaml — that file is updated by this workflow itself via PR,
+# and we exclude it to prevent an infinite release loop.
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'helm-chart/zxporter-netmon/**'
+      - '!helm-chart/zxporter-netmon/Chart.yaml'
+
+env:
+  REGISTRY: registry-1.docker.io
+  CHART_NAME: zxporter-netmon
+  ORG: devzeroinc
+  CHART_TAG_PREFIX: chart-netmon-v
+
+jobs:
+  auto-release:
+    name: Patch release zxporter-netmon chart
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      packages: write
+      pull-requests: write
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Set up Helm
+        uses: azure/setup-helm@v4
+        with:
+          version: '3.12.3'
+
+      - name: Install yq
+        run: |
+          sudo wget -qO /usr/local/bin/yq https://github.com/mikefarah/yq/releases/latest/download/yq_linux_amd64
+          sudo chmod +x /usr/local/bin/yq
+
+      - name: Helm registry login
+        run: |
+          echo "${{ secrets.DOCKERHUB_ZXPORTER_BALANCE_TOKEN }}" | \
+            helm registry login registry-1.docker.io \
+              --username "${{ secrets.DOCKERHUB_ZXPORTER_BALANCE_USERNAME }}" \
+              --password-stdin
+
+      - name: Enable Helm OCI support
+        run: echo "HELM_EXPERIMENTAL_OCI=1" >> $GITHUB_ENV
+
+      - name: Fetch tags
+        run: git fetch --tags
+
+      - name: Bump patch version
+        id: version
+        run: |
+          LAST_TAG=$(git tag --list '${{ env.CHART_TAG_PREFIX }}*' --sort=-v:refname | head -n 1)
+          if [ -z "$LAST_TAG" ]; then
+            LAST_VERSION="0.0.0"
+          else
+            LAST_VERSION="${LAST_TAG#${{ env.CHART_TAG_PREFIX }}}"
+          fi
+          IFS='.' read -r MAJOR MINOR PATCH <<< "$LAST_VERSION"
+          PATCH=$((PATCH + 1))
+          NEW_VERSION="${MAJOR}.${MINOR}.${PATCH}"
+          echo "new_version=$NEW_VERSION" >> $GITHUB_OUTPUT
+          echo "Auto-releasing chart patch: $LAST_VERSION → $NEW_VERSION (triggered by: ${{ github.event.head_commit.message }})"
+
+      - name: Create and push chart tag
+        run: |
+          git config --global user.email "actions@github.com"
+          git config --global user.name "GitHub Actions"
+          git tag "${{ env.CHART_TAG_PREFIX }}${{ steps.version.outputs.new_version }}"
+          git push origin "${{ env.CHART_TAG_PREFIX }}${{ steps.version.outputs.new_version }}"
+
+      - name: Update chart dependencies
+        run: helm dependency update helm-chart/zxporter-netmon
+
+      - name: Lint Helm chart
+        run: helm lint helm-chart/zxporter-netmon
+
+      - name: Package Helm chart
+        run: |
+          mkdir -p helm-chart/packages
+          helm package helm-chart/zxporter-netmon \
+            --version ${{ steps.version.outputs.new_version }} \
+            --app-version ${{ steps.version.outputs.new_version }} \
+            --destination helm-chart/packages
+
+      - name: Push chart to Docker Hub OCI registry
+        run: |
+          helm push helm-chart/packages/zxporter-netmon-${{ steps.version.outputs.new_version }}.tgz \
+            oci://${{ env.REGISTRY }}/${{ env.ORG }}
+
+      - name: Update Chart.yaml version and appVersion
+        run: |
+          yq e -i '.version = "${{ steps.version.outputs.new_version }}"' helm-chart/zxporter-netmon/Chart.yaml
+          yq e -i '.appVersion = "${{ steps.version.outputs.new_version }}"' helm-chart/zxporter-netmon/Chart.yaml
+
+      - name: Create PR to update Chart.yaml
+        uses: peter-evans/create-pull-request@v6
+        with:
+          commit-message: "chore(helm): update Chart.yaml version to ${{ steps.version.outputs.new_version }}"
+          title: "chore(helm): update zxporter-netmon Chart.yaml version to ${{ steps.version.outputs.new_version }}"
+          body: |
+            Automated patch release triggered by changes to `helm-chart/zxporter-netmon/`.
+
+            This PR updates `version` and `appVersion` in `helm-chart/zxporter-netmon/Chart.yaml` to `${{ steps.version.outputs.new_version }}`.
+
+            Triggered by commit: ${{ github.event.head_commit.message }}
+          branch: "update/chart-version-netmon-${{ steps.version.outputs.new_version }}"
+          add-paths: |
+            helm-chart/zxporter-netmon/Chart.yaml

--- a/.github/workflows/helm-auto-release.yml
+++ b/.github/workflows/helm-auto-release.yml
@@ -1,0 +1,116 @@
+name: Auto Release Helm Chart (zxporter)
+
+# Triggers on any merge to main that touches helm-chart/zxporter/**
+# EXCEPT Chart.yaml — that file is updated by this workflow itself via PR,
+# and we exclude it to prevent an infinite release loop.
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'helm-chart/zxporter/**'
+      - '!helm-chart/zxporter/Chart.yaml'
+
+env:
+  REGISTRY: registry-1.docker.io
+  CHART_NAME: zxporter
+  ORG: devzeroinc
+  CHART_TAG_PREFIX: chart-v
+
+jobs:
+  auto-release:
+    name: Patch release zxporter chart
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      packages: write
+      pull-requests: write
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Set up Helm
+        uses: azure/setup-helm@v4
+        with:
+          version: '3.12.3'
+
+      - name: Install yq
+        run: |
+          sudo wget -qO /usr/local/bin/yq https://github.com/mikefarah/yq/releases/latest/download/yq_linux_amd64
+          sudo chmod +x /usr/local/bin/yq
+
+      - name: Helm registry login
+        run: |
+          echo "${{ secrets.DOCKERHUB_ZXPORTER_BALANCE_TOKEN }}" | \
+            helm registry login registry-1.docker.io \
+              --username "${{ secrets.DOCKERHUB_ZXPORTER_BALANCE_USERNAME }}" \
+              --password-stdin
+
+      - name: Enable Helm OCI support
+        run: echo "HELM_EXPERIMENTAL_OCI=1" >> $GITHUB_ENV
+
+      - name: Fetch tags
+        run: git fetch --tags
+
+      - name: Bump patch version
+        id: version
+        run: |
+          LAST_TAG=$(git tag --list '${{ env.CHART_TAG_PREFIX }}*' --sort=-v:refname | head -n 1)
+          if [ -z "$LAST_TAG" ]; then
+            LAST_VERSION="0.0.0"
+          else
+            LAST_VERSION="${LAST_TAG#${{ env.CHART_TAG_PREFIX }}}"
+          fi
+          IFS='.' read -r MAJOR MINOR PATCH <<< "$LAST_VERSION"
+          PATCH=$((PATCH + 1))
+          NEW_VERSION="${MAJOR}.${MINOR}.${PATCH}"
+          echo "new_version=$NEW_VERSION" >> $GITHUB_OUTPUT
+          echo "Auto-releasing chart patch: $LAST_VERSION → $NEW_VERSION (triggered by: ${{ github.event.head_commit.message }})"
+
+      - name: Create and push chart tag
+        run: |
+          git config --global user.email "actions@github.com"
+          git config --global user.name "GitHub Actions"
+          git tag "${{ env.CHART_TAG_PREFIX }}${{ steps.version.outputs.new_version }}"
+          git push origin "${{ env.CHART_TAG_PREFIX }}${{ steps.version.outputs.new_version }}"
+
+      - name: Update chart dependencies
+        run: helm dependency update helm-chart/zxporter
+
+      - name: Lint Helm chart
+        run: helm lint helm-chart/zxporter
+
+      - name: Package Helm chart
+        run: |
+          mkdir -p helm-chart/packages
+          helm package helm-chart/zxporter \
+            --version ${{ steps.version.outputs.new_version }} \
+            --app-version ${{ steps.version.outputs.new_version }} \
+            --destination helm-chart/packages
+
+      - name: Push chart to Docker Hub OCI registry
+        run: |
+          helm push helm-chart/packages/zxporter-${{ steps.version.outputs.new_version }}.tgz \
+            oci://${{ env.REGISTRY }}/${{ env.ORG }}
+
+      - name: Update Chart.yaml version and appVersion
+        run: |
+          yq e -i '.version = "${{ steps.version.outputs.new_version }}"' helm-chart/zxporter/Chart.yaml
+          yq e -i '.appVersion = "${{ steps.version.outputs.new_version }}"' helm-chart/zxporter/Chart.yaml
+
+      - name: Create PR to update Chart.yaml
+        uses: peter-evans/create-pull-request@v6
+        with:
+          commit-message: "chore(helm): update Chart.yaml version to ${{ steps.version.outputs.new_version }}"
+          title: "chore(helm): update Chart.yaml version to ${{ steps.version.outputs.new_version }}"
+          body: |
+            Automated patch release triggered by changes to `helm-chart/zxporter/`.
+
+            This PR updates `version` and `appVersion` in `helm-chart/zxporter/Chart.yaml` to `${{ steps.version.outputs.new_version }}`.
+
+            Triggered by commit: ${{ github.event.head_commit.message }}
+          branch: "update/chart-version-${{ steps.version.outputs.new_version }}"
+          add-paths: |
+            helm-chart/zxporter/Chart.yaml

--- a/.github/workflows/helm-chart-validation.yml
+++ b/.github/workflows/helm-chart-validation.yml
@@ -1,0 +1,59 @@
+name: Helm Chart Validation
+
+on:
+  pull_request:
+    paths:
+      - 'helm-chart/zxporter/**'
+      - 'helm-chart/zxporter-netmon/**'
+  workflow_dispatch:
+
+jobs:
+  validate-zxporter:
+    name: Lint & template zxporter chart
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Helm
+        uses: azure/setup-helm@v4
+        with:
+          version: '3.12.3'
+
+      - name: Update chart dependencies
+        run: helm dependency update helm-chart/zxporter
+
+      - name: Lint chart
+        run: helm lint helm-chart/zxporter
+
+      - name: Template render check
+        run: |
+          helm template zxporter helm-chart/zxporter \
+            --set zxporter.clusterToken=ci-test-token \
+            --set zxporter.kubeContextName=ci-test-cluster \
+            --set zxporter.k8sProvider=other \
+            > /dev/null
+          echo "zxporter chart rendered successfully"
+
+  validate-netmon:
+    name: Lint & template zxporter-netmon chart
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Helm
+        uses: azure/setup-helm@v4
+        with:
+          version: '3.12.3'
+
+      - name: Update chart dependencies
+        run: helm dependency update helm-chart/zxporter-netmon
+
+      - name: Lint chart
+        run: helm lint helm-chart/zxporter-netmon
+
+      - name: Template render check
+        run: |
+          helm template zxporter-netmon helm-chart/zxporter-netmon > /dev/null
+          echo "zxporter-netmon chart rendered successfully"


### PR DESCRIPTION
this CI changes make sure to release  the helm chart whenever there is a helm chart , it will automatically make a release !

----
## Summary by Gitar

- **CI workflows for Helm chart automation:**
  - Added `helm-auto-release.yml` to automatically release `zxporter` chart on changes, bumping patch version and pushing to Docker Hub OCI registry
  - Added `helm-auto-release-netmon.yml` to automatically release `zxporter-netmon` chart with same automation pattern
  - Added `helm-chart-validation.yml` to lint and template-render both charts on pull requests

<sub>This will update automatically on new commits.</sub>