### PR TITLE
ci: update K8s test matrix to cover v1.27–v1.35

### DIFF
--- a/.github/workflows/k8s-compatibility-test.yml
+++ b/.github/workflows/k8s-compatibility-test.yml
@@ -61,15 +61,18 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
+        # Test against K8s versions from the last ~2 years
+        # See https://kubernetes.io/releases/ for release/EOL dates
         k8s-version:
-          - v1.25.16
-          - v1.26.15
           - v1.27.16
           - v1.28.15
           - v1.29.14
-          - v1.30.8
-          - v1.31.6
-          - v1.32.3
+          - v1.30.13
+          - v1.31.14
+          - v1.32.11
+          - v1.33.7
+          - v1.34.3
+          - v1.35.1
         deployment-method:
           - helm
           - manifest
@@ -99,7 +102,7 @@ jobs:
       - name: Create k8s Kind Cluster
         uses: helm/kind-action@v1
         with:
-          version: v0.27.0
+          version: v0.31.0
           node_image: kindest/node:${{ matrix.k8s-version }}
           cluster_name: kind-${{ matrix.k8s-version }}
           wait: 120s

--- a/.github/workflows/metrics-server-lifecycle-test.yml
+++ b/.github/workflows/metrics-server-lifecycle-test.yml
@@ -42,7 +42,7 @@ jobs:
           make docker-build docker-push IMG=${{ env.ZXPORTER_IMG }}
 
   test:
-    name: Test Metrics Server Lifecycle on K8s v1.32.3
+    name: Test Metrics Server Lifecycle on K8s v1.35.1
     needs: build
     runs-on: ubuntu-xl
     
@@ -63,8 +63,8 @@ jobs:
       - name: Create k8s Kind Cluster
         uses: helm/kind-action@v1
         with:
-          version: v0.27.0
-          node_image: kindest/node:v1.32.3
+          version: v0.31.0
+          node_image: kindest/node:v1.35.1
           cluster_name: kind-metrics-test
           wait: 120s
 


### PR DESCRIPTION
## Summary
- Update Kind from v0.27.0 to v0.31.0
- Drop EOL versions v1.25, v1.26 (>2 years old), keep v1.27+ to cover the last ~2 years per https://kubernetes.io/releases/
- Update existing versions to latest patches: v1.30.13, v1.31.14, v1.32.11
- Add new K8s versions: v1.33.7, v1.34.3, v1.35.1
- Update metrics-server-lifecycle-test to K8s v1.35.1 with Kind v0.31.0

## Test plan
- [ ] Verify k8s-compatibility-test workflow passes on all 9 versions × 2 deployment methods
- [ ] Verify metrics-server-lifecycle-test passes on v1.35.1

🤖 Generated with [Claude Code](https://claude.com/claude-code)