### PR TITLE
add crd binding

### DIFF
--- a/internal/collector/workload_rule_collector.go
+++ b/internal/collector/workload_rule_collector.go
@@ -17,8 +17,10 @@ import (
 	"k8s.io/client-go/tools/cache"
 )
 
-// WorkloadRuleCollector watches WorkloadRule CRD status changes and sends OOM events
+// WorkloadRuleCollector watches WorkloadRule CRDs and sends spec/status changes
 // back to the control plane via SendResourceBatch.
+// Handles two-way sync: sends on Add (kubectl apply), Delete (kubectl delete),
+// and Update (spec changes or OOM/throttle status changes).
 type WorkloadRuleCollector struct {
 	client          dynamic.Interface
 	informerFactory dynamicinformer.DynamicSharedInformerFactory
@@ -94,6 +96,16 @@ func (c *WorkloadRuleCollector) Start(ctx context.Context) error {
 	c.wrInformer = c.informerFactory.ForResource(workloadRuleGVR).Informer()
 
 	_, err := c.wrInformer.AddEventHandler(cache.ResourceEventHandlerFuncs{
+		AddFunc: func(obj interface{}) {
+			wr, ok := obj.(*unstructured.Unstructured)
+			if !ok {
+				c.logger.Error(nil, "WorkloadRule AddFunc: failed to convert object to unstructured")
+				return
+			}
+			c.logger.Info("WorkloadRule added, sending to control plane",
+				"namespace", wr.GetNamespace(), "name", wr.GetName())
+			c.handleWorkloadRuleEvent(wr, EventTypeAdd)
+		},
 		UpdateFunc: func(oldObj, newObj interface{}) {
 			oldWR := oldObj.(*unstructured.Unstructured)
 			newWR := newObj.(*unstructured.Unstructured)
@@ -106,10 +118,29 @@ func (c *WorkloadRuleCollector) Start(ctx context.Context) error {
 				return
 			}
 
-			// Only send when OOM events have changed
-			if c.oomEventsChanged(oldWR, newWR) {
+			// Send when spec or OOM/throttle status has changed
+			if c.specChanged(oldWR, newWR) || c.oomEventsChanged(oldWR, newWR) {
 				c.handleWorkloadRuleEvent(newWR, EventTypeUpdate)
 			}
+		},
+		DeleteFunc: func(obj interface{}) {
+			wr, ok := obj.(*unstructured.Unstructured)
+			if !ok {
+				// Handle tombstone (object already deleted from cache)
+				if tombstone, ok := obj.(cache.DeletedFinalStateUnknown); ok {
+					if wr, ok = tombstone.Obj.(*unstructured.Unstructured); ok {
+						c.logger.Info("WorkloadRule deleted (tombstone), sending to control plane",
+							"namespace", wr.GetNamespace(), "name", wr.GetName())
+						c.handleWorkloadRuleEvent(wr, EventTypeDelete)
+						return
+					}
+				}
+				c.logger.Error(nil, "WorkloadRule DeleteFunc: failed to convert object")
+				return
+			}
+			c.logger.Info("WorkloadRule deleted, sending to control plane",
+				"namespace", wr.GetNamespace(), "name", wr.GetName())
+			c.handleWorkloadRuleEvent(wr, EventTypeDelete)
 		},
 	})
 	if err != nil {
@@ -140,7 +171,7 @@ func (c *WorkloadRuleCollector) Start(ctx context.Context) error {
 	return nil
 }
 
-// handleWorkloadRuleEvent processes a WorkloadRule status update containing OOM events
+// handleWorkloadRuleEvent processes a WorkloadRule event (add, update, or delete)
 func (c *WorkloadRuleCollector) handleWorkloadRuleEvent(wr *unstructured.Unstructured, eventType EventType) {
 	c.mu.RLock()
 	defer c.mu.RUnlock()
@@ -151,9 +182,10 @@ func (c *WorkloadRuleCollector) handleWorkloadRuleEvent(wr *unstructured.Unstruc
 	namespace := wr.GetNamespace()
 	name := wr.GetName()
 
-	c.logger.Info("Sending WorkloadRule status with OOM events to control plane",
+	c.logger.Info("Sending WorkloadRule event to control plane",
 		"namespace", namespace,
 		"name", name,
+		"eventType", eventType.String(),
 	)
 	c.batchChan <- CollectedResource{
 		ResourceType: WorkloadRule,
@@ -178,6 +210,15 @@ func (c *WorkloadRuleCollector) oomEventsChanged(oldWR, newWR *unstructured.Unst
 	oldEvents, _, _ := unstructured.NestedSlice(oldWR.Object, "status", "oomEvents")
 	newEvents, _, _ := unstructured.NestedSlice(newWR.Object, "status", "oomEvents")
 	return !reflect.DeepEqual(oldEvents, newEvents)
+}
+
+// specChanged detects if the WorkloadRule spec has changed between old and new versions.
+// Used for two-way sync: when a user edits the CRD via kubectl, the spec changes
+// and the CP needs to be notified.
+func (c *WorkloadRuleCollector) specChanged(oldWR, newWR *unstructured.Unstructured) bool {
+	oldSpec, _, _ := unstructured.NestedMap(oldWR.Object, "spec")
+	newSpec, _, _ := unstructured.NestedMap(newWR.Object, "spec")
+	return !reflect.DeepEqual(oldSpec, newSpec)
 }
 
 // Stop gracefully shuts down the WorkloadRule collector


### PR DESCRIPTION
● MPA V3: WorkloadRule two-way CRD sync — collector Add/Delete/Update handlers

  📚 Description of Changes

  - What Changed:
  Extended the WorkloadRule collector to handle the full CRD lifecycle — AddFunc, DeleteFunc, and spec-change UpdateFunc — so kubectl-applied or CP-pushed CRDs
  are reported back to the control plane via SendResourceBatch. Previously the collector only sent on OOM/throttle status changes.
  - Why This Change:
  MPA V3 introduces two-way sync between WorkloadRule CRDs and the control plane DB. When a user applies a WorkloadRule via kubectl, the control plane needs to
  know about it to create a DB record. When a CRD is deleted from the cluster, the CP needs to clean up. Without these handlers, only OOM events were sent —
  spec additions and deletions were silently ignored.
  - Affected Components:
  - Compose
  - K8s
  - Other

  ❓ Motivation and Context

  - Context:
  Part of the MPA V3 initiative that replaces the policy→target→recommendation model with per-workload WorkloadRule CRDs. The control plane already handles
  ingestion of Add/Update/Delete events (RESOURCE_TYPE_WORKLOAD_RULE in metrics_collector.go) — this PR is the zxporter-side counterpart that generates those
  events.
  - Relevant Tasks/Issues:
  Related services PR: crd-binding branch (implements CP ingestion, new optimization policies, deletion flow, and UI)

  🔍 Types of Changes

  - BUGFIX: Non-breaking fix for an issue.
  - NEW FEATURE: Non-breaking addition of functionality.
  - BREAKING CHANGE: Fix or feature that causes existing functionality to not work as expected.
  - ENHANCEMENT: Improvement to existing functionality.
  - CHORE: Changes that do not affect production.

  🔬 QA / Verification Steps

  1. Deploy zxporter to a Kind cluster with the dakr CRD installed
  2. Apply a CollectionPolicy and verify the workload-rule-collector starts ("workload_rule" collector started in logs)
  3. kubectl apply a WorkloadRule CRD — verify zxporter logs "WorkloadRule added, sending to control plane" and sends a workload_rule batch
  4. Edit the CRD spec — verify zxporter detects the spec change and sends an update event
  5. kubectl delete the CRD — verify zxporter logs "WorkloadRule deleted, sending to control plane" with EVENT_TYPE_DELETE
  6. Existing OOM/throttle event extraction continues to work unchanged

  ✅ Global Checklist

  - I have read and followed the .github/CONTRIBUTING.md.
  - My code follows the code style of this project.
  - I have updated the documentation as needed.
  - I have added tests that cover my changes.
  - All new and existing tests have passed locally.
  - I have run this code in a local environment to verify functionality.
  - I have considered the security implications of this change.