### PR TITLE
fix: detect GPU capacity changes in nodeStatusChanged

### DIFF
--- a/internal/collector/node_collector.go
+++ b/internal/collector/node_collector.go
@@ -463,15 +463,25 @@ func (c *NodeCollector) nodeStatusChanged(oldNode, newNode *corev1.Node) bool {
 		}
 	}
 
-	// Check if allocatable resources changed
+	// Check if allocatable resources changed (CPU, memory, GPU)
 	if !oldNode.Status.Allocatable.Cpu().Equal(*newNode.Status.Allocatable.Cpu()) ||
 		!oldNode.Status.Allocatable.Memory().Equal(*newNode.Status.Allocatable.Memory()) {
 		return true
 	}
+	oldAllocGPU := oldNode.Status.Allocatable[corev1.ResourceName(gpuconst.GpuResource)]
+	newAllocGPU := newNode.Status.Allocatable[corev1.ResourceName(gpuconst.GpuResource)]
+	if !oldAllocGPU.Equal(newAllocGPU) {
+		return true
+	}
 
-	// Check if capacity changed
+	// Check if capacity changed (CPU, memory, GPU)
 	if !oldNode.Status.Capacity.Cpu().Equal(*newNode.Status.Capacity.Cpu()) ||
 		!oldNode.Status.Capacity.Memory().Equal(*newNode.Status.Capacity.Memory()) {
+		return true
+	}
+	oldCapGPU := oldNode.Status.Capacity[corev1.ResourceName(gpuconst.GpuResource)]
+	newCapGPU := newNode.Status.Capacity[corev1.ResourceName(gpuconst.GpuResource)]
+	if !oldCapGPU.Equal(newCapGPU) {
 		return true
 	}
 


### PR DESCRIPTION
## Summary

- Fix `nodeStatusChanged` to detect when `nvidia.com/gpu` appears or changes in `node.Status.Capacity` and `node.Status.Allocatable`

## Problem

When a GPU node starts up, the NVIDIA device plugin takes time to register. The Kubernetes node object is initially created **without** `nvidia.com/gpu` in `status.Capacity`. Once the device plugin is ready, the kubelet updates the node's capacity to include the GPU resource.

`nodeStatusChanged` is the gate that decides whether a node update is meaningful enough to re-send to dakr (the backend). It checked:
- ✅ Node conditions
- ✅ CPU allocatable/capacity
- ✅ Memory allocatable/capacity
- ✅ Labels, annotations, UID
- ❌ **GPU allocatable/capacity — not checked**

This meant the transition from `nvidia.com/gpu: 0` (or absent) → `nvidia.com/gpu: 1` was **silently ignored**. The updated node object was never re-sent, so the server-side `ExtractGPUCapacity()` kept seeing the stale node where GPUs weren't registered yet. Result: `gpu_capacity = 0` in `k8s_nodes` for nodes that actually have GPUs.

### Impact

This affects cost attribution for GPU nodes. The cost service uses `gpu_capacity` from `k8s_nodes` to determine whether a node has GPUs. With `gpu_capacity = 0`, GPU nodes are priced as CPU-only nodes (e.g., `n1-standard-1` at $0.0475/hr instead of `n1-standard-1` + T4 GPU at $0.73/hr).

Observed in a test cluster with `n1-standard-1` nodes in 3 pools (0 GPU, 1× T4, 2× T4) — all reported `gpu_capacity = 0`.

## Fix

Add `nvidia.com/gpu` resource checks to both the allocatable and capacity comparisons in `nodeStatusChanged`, using the existing `gpuconst.GpuResource` constant (`github.com/NVIDIA/KAI-scheduler/pkg/common/constants`) that's already imported and used elsewhere in this file.

When the NVIDIA device plugin registers and the kubelet updates the node's capacity, `nodeStatusChanged` will now return `true`, triggering `handleNodeEvent` → re-sending the full node object → server's `ExtractGPUCapacity()` correctly stores the GPU count.

## Test plan

- [ ] Verify `go build ./internal/collector/` compiles cleanly
- [ ] Deploy to test cluster with GPU node pools
- [ ] Confirm `k8s_nodes.gpu_capacity` is non-zero for GPU nodes after device plugin registration
- [ ] Verify non-GPU nodes are unaffected (no spurious updates)

🤖 Generated with [Claude Code](https://claude.com/claude-code)