### PR TITLE
Fix report from karpenter

### DIFF
--- a/internal/health/node_operator_monitor.go
+++ b/internal/health/node_operator_monitor.go
@@ -81,18 +81,20 @@ func (m *NodeOperatorMonitor) BuildNodeOperatorReport(ctx context.Context) (map[
 	report := make(map[string]ComponentStatus, 1)
 	status := m.buildDeploymentStatus(dep)
 
-	// Override deployment status with service health probe if it indicates unhealthy
-	if !probe.healthzOK || !probe.readyzOK {
-		if status.Status == HealthStatusHealthy {
-			status.Status = HealthStatusDegraded
-		}
-		status.Message = fmt.Sprintf("%s (service healthz=%t readyz=%t)", status.Message, probe.healthzOK, probe.readyzOK)
-	}
 	if status.Metadata == nil {
 		status.Metadata = make(map[string]string)
 	}
 	status.Metadata["service_healthz"] = fmt.Sprintf("%t", probe.healthzOK)
 	status.Metadata["service_readyz"] = fmt.Sprintf("%t", probe.readyzOK)
+
+	// Annotate the message with probe results when probes fail, but do not
+	// downgrade a healthy deployment: K8s replica health is the authoritative
+	// signal. Probe failures on a ready deployment are typically transient
+	// (network policy, brief endpoint churn during rollouts, service port
+	// mismatches) and should not cause false DEGRADED alerts.
+	if !probe.healthzOK || !probe.readyzOK {
+		status.Message = fmt.Sprintf("%s (service healthz=%t readyz=%t)", status.Message, probe.healthzOK, probe.readyzOK)
+	}
 
 	report[ComponentKarpenterDeployment] = status
 

--- a/internal/health/node_operator_monitor_test.go
+++ b/internal/health/node_operator_monitor_test.go
@@ -414,9 +414,10 @@ func TestNodeOperatorMonitor_BuildReport(t *testing.T) {
 
 		deployComp, ok := report[ComponentKarpenterDeployment]
 		require.True(t, ok)
-		// Service endpoint is unreachable in tests (DNS), so status is degraded
-		assert.Equal(t, HealthStatusDegraded, deployComp.Status)
+		// Service endpoint is unreachable in tests (DNS), but deployment is 1/1 so status stays healthy.
+		assert.Equal(t, HealthStatusHealthy, deployComp.Status)
 		assert.Equal(t, "false", deployComp.Metadata["service_healthz"])
+		assert.Contains(t, deployComp.Message, "service healthz=false")
 	})
 
 	t.Run("no service falls back to deployment status only", func(t *testing.T) {


### PR DESCRIPTION
<!--
  Please provide a short, descriptive title for your pull request.

  🚨 Please do not remove any of the sections below.
-->

# [Fix transient report from karpenter]

## 📚 Description of Changes

We ping karpenter liveness + readiness probes via zxporter, and we'd normaly report status `DEGRADED` if both of th conditions weren't met, but we forgot to encounter the transient data - deployment, rollout, TCP connection down, etc. 

- **What Changed:**  
Minor change in logic to remove false positives for DEGRADED 

- **Why This Change:**  

- **Affected Components:**
  (Which component does this change affect? - put x for all components)
- [ ] Compose
- [x] K8s
- [ ] Other (please specify)

## ❓ Motivation and Context

_Why is this change required? What problem does it solve?_

- **Context:**  
  (Provide background information or link to related discussions/issues.)

- **Relevant Tasks/Issues:**  
  (e.g., Fixes: #GitHub Issue)

## 🔍 Types of Changes

_Indicate which type of changes your code introduces (check all that apply):_

- [x] **BUGFIX:** Non-breaking fix for an issue.
- [ ] **NEW FEATURE:** Non-breaking addition of functionality.
- [ ] **BREAKING CHANGE:** Fix or feature that causes existing functionality to not work as expected.
- [ ] **ENHANCEMENT:** Improvement to existing functionality.
- [x] **CHORE:** Changes that do not affect production (e.g., documentation, build tooling, CI).

## 🔬 QA / Verification Steps

_Describe the steps a reviewer should take to verify your changes:_

1. (Step one: e.g., "Run `make test` to verify all tests pass.")
2. (Step two: e.g., "Deploy to a Kind cluster with `make create-kind && make deploy`.")
3. (Additional steps as needed.)

## ✅ Global Checklist

_Please check all boxes that apply:_

- [x] I have read and followed the [CONTRIBUTING guidelines](.github/CONTRIBUTING.md).
- [x] My code follows the code style of this project.
- [x] I have updated the documentation as needed.
- [x] I have added tests that cover my changes.
- [x] All new and existing tests have passed locally.
- [x] I have run this code in a local environment to verify functionality.
- [x] I have considered the security implications of this change.
