### PR TITLE
Lower health report tick to 15 seconds

### DIFF
--- a/internal/controller/custom.go
+++ b/internal/controller/custom.go
@@ -256,7 +256,11 @@ func (c *EnvBasedController) sendHealthReport(ctx context.Context) {
 		)
 		if err := c.Reconciler.DakrClient.ReportHealth(ctx, req); err != nil {
 			c.Log.Error(err, "Failed to send health heartbeat to dakr, retrying in 5s")
-			time.Sleep(5 * time.Second)
+			select {
+			case <-time.After(5 * time.Second):
+			case <-ctx.Done():
+				return
+			}
 			if err := c.Reconciler.DakrClient.ReportHealth(ctx, req); err != nil {
 				c.Log.Error(err, "Retry also failed for health heartbeat")
 			}
@@ -297,7 +301,11 @@ func (c *EnvBasedController) sendNodeOperatorHealthReport(ctx context.Context) {
 		)
 		if err := c.Reconciler.DakrClient.ReportHealth(ctx, req); err != nil {
 			c.Log.Error(err, "Failed to send node operator health heartbeat to dakr, retrying in 5s")
-			time.Sleep(5 * time.Second)
+			select {
+			case <-time.After(5 * time.Second):
+			case <-ctx.Done():
+				return
+			}
 			if err := c.Reconciler.DakrClient.ReportHealth(ctx, req); err != nil {
 				c.Log.Error(err, "Retry also failed for node operator health heartbeat")
 			}

--- a/internal/controller/custom.go
+++ b/internal/controller/custom.go
@@ -206,7 +206,7 @@ func (c *EnvBasedController) Start(ctx context.Context) error {
 // runHealthReporting periodically logs the health status of all registered components
 // and sends a heartbeat to dakr via the ReportHealth RPC.
 func (c *EnvBasedController) runHealthReporting(ctx context.Context) {
-	ticker := time.NewTicker(60 * time.Second)
+	ticker := time.NewTicker(15 * time.Second)
 	defer ticker.Stop()
 
 	// Send initial heartbeat immediately so dakr sees the operator right away
@@ -255,7 +255,11 @@ func (c *EnvBasedController) sendHealthReport(ctx context.Context) {
 			c.startTime,
 		)
 		if err := c.Reconciler.DakrClient.ReportHealth(ctx, req); err != nil {
-			c.Log.Error(err, "Failed to send health heartbeat to dakr")
+			c.Log.Error(err, "Failed to send health heartbeat to dakr, retrying in 5s")
+			time.Sleep(5 * time.Second)
+			if err := c.Reconciler.DakrClient.ReportHealth(ctx, req); err != nil {
+				c.Log.Error(err, "Retry also failed for health heartbeat")
+			}
 		}
 	}
 }
@@ -292,7 +296,11 @@ func (c *EnvBasedController) sendNodeOperatorHealthReport(ctx context.Context) {
 			uptimeSince,
 		)
 		if err := c.Reconciler.DakrClient.ReportHealth(ctx, req); err != nil {
-			c.Log.Error(err, "Failed to send node operator health heartbeat to dakr")
+			c.Log.Error(err, "Failed to send node operator health heartbeat to dakr, retrying in 5s")
+			time.Sleep(5 * time.Second)
+			if err := c.Reconciler.DakrClient.ReportHealth(ctx, req); err != nil {
+				c.Log.Error(err, "Retry also failed for node operator health heartbeat")
+			}
 		}
 	}
 }


### PR DESCRIPTION
<!--
  Please provide a short, descriptive title for your pull request.

  🚨 Please do not remove any of the sections below.
-->

# [Health report heartbeat interval]

## 📚 Description of Changes

We lowered the interval from 60 seconds to 15 seconds

- **What Changed:**  
Heartbeat is too fragile (the actual incident cause)  60-second heartbeat + 5-minute threshold = only 5 chances to deliver before the operator is marked unhealthy. One missed send (connection reset, transient error) burns 20% of the budget. Two misses in a row = degraded.

- **Why This Change:**  
  This gives 20 chances per window. A connection reset only burns 1 of 20. In zxporter/internal/controller/custom.go:209:

- **Affected Components:**
  (Which component does this change affect? - put x for all components)
- [ ] Compose
- [x] K8s
- [ ] Other (please specify)

## ❓ Motivation and Context

Less troubles with restarts and rollouts

- **Context:**  
none

- **Relevant Tasks/Issues:**  
  (e.g., Fixes: #GitHub Issue)
none

## 🔍 Types of Changes

_Indicate which type of changes your code introduces (check all that apply):_

- [x] **BUGFIX:** Non-breaking fix for an issue.
- [ ] **NEW FEATURE:** Non-breaking addition of functionality.
- [ ] **BREAKING CHANGE:** Fix or feature that causes existing functionality to not work as expected.
- [x] **ENHANCEMENT:** Improvement to existing functionality.
- [ ] **CHORE:** Changes that do not affect production (e.g., documentation, build tooling, CI).

## 🔬 QA / Verification Steps

_Describe the steps a reviewer should take to verify your changes:_

1. (Step one: e.g., "Run `make test` to verify all tests pass.")
2. (Step two: e.g., "Deploy to a Kind cluster with `make create-kind && make deploy`.")
3. (Additional steps as needed.)

## ✅ Global Checklist

_Please check all boxes that apply:_

- [x] I have read and followed the [CONTRIBUTING guidelines](.github/CONTRIBUTING.md).
- [x] My code follows the code style of this project.
- [x] I have updated the documentation as needed.
- [x] I have added tests that cover my changes.
- [x] All new and existing tests have passed locally.
- [x] I have run this code in a local environment to verify functionality.
- [x] I have considered the security implications of this change.
