### PR TITLE
feat: migrate default namespace from devzero-zxporter to devzero-system

### DIFF
--- a/.github/workflows/k8s-compatibility-test.yml
+++ b/.github/workflows/k8s-compatibility-test.yml
@@ -119,7 +119,7 @@ jobs:
       - name: Deploy testserver to Kubernetes
         run: |
           # Create namespace if it doesn't exist
-          kubectl create namespace devzero-zxporter --dry-run=client -o yaml | kubectl apply -f -
+          kubectl create namespace devzero-system --dry-run=client -o yaml | kubectl apply -f -
           
           # Replace the image placeholder in the testserver Kubernetes manifest
           sed "s|\${TESTSERVER_IMG}|${{ env.TESTSERVER_IMG }}|g" test/testserver/kubernetes.yaml > testserver-k8s.yaml
@@ -129,15 +129,15 @@ jobs:
           
           # Wait for the testserver pod to be ready
           echo "Waiting for testserver pod to be ready..."
-          kubectl wait --for=condition=ready pod -l app=testserver -n devzero-zxporter --timeout=120s
+          kubectl wait --for=condition=ready pod -l app=testserver -n devzero-system --timeout=120s
           
           # Get the testserver pod name
-          TESTSERVER_POD=$(kubectl get pods -n devzero-zxporter -l app=testserver -o jsonpath='{.items[0].metadata.name}')
+          TESTSERVER_POD=$(kubectl get pods -n devzero-system -l app=testserver -o jsonpath='{.items[0].metadata.name}')
           echo "Testserver pod: $TESTSERVER_POD"
           
           # Check the testserver logs
           echo "Testserver logs:"
-          kubectl logs $TESTSERVER_POD -n devzero-zxporter
+          kubectl logs $TESTSERVER_POD -n devzero-system
 
       - name: Create dztest namespace and deploy stress test pod
         run: |
@@ -190,14 +190,14 @@ jobs:
         run: |
           # Set DAKR_URL to point to the testserver service in the same namespace
           # Set TARGET_NAMESPACES to dztest to limit collection to that namespace
-          echo "Setting DAKR_URL to http://testserver.devzero-zxporter.svc.cluster.local:50051"
+          echo "Setting DAKR_URL to http://testserver.devzero-system.svc.cluster.local:50051"
           echo "Setting TARGET_NAMESPACES to dztest"
           
           if [ "${{ matrix.deployment-method }}" = "helm" ]; then
             echo "Deploying ZXporter using Helm..."
             yq eval '.image.repository = "'"${ZXPORTER_IMG%:*}"'"' -i helm-chart/zxporter/values.yaml
             yq eval '.image.tag = "'"${ZXPORTER_IMG##*:}"'"' -i helm-chart/zxporter/values.yaml
-            yq eval '.zxporter.dakrUrl = "http://testserver.devzero-zxporter.svc.cluster.local:50051"' -i helm-chart/zxporter/values.yaml
+            yq eval '.zxporter.dakrUrl = "http://testserver.devzero-system.svc.cluster.local:50051"' -i helm-chart/zxporter/values.yaml
             yq eval '.zxporter.targetNamespaces = "dztest"' -i helm-chart/zxporter/values.yaml
             yq eval '.zxporter.clusterToken = "test-token-for-ci"' -i helm-chart/zxporter/values.yaml
             yq eval '.zxporter.kubeContextName = "test-kind-cluster"' -i helm-chart/zxporter/values.yaml
@@ -209,26 +209,26 @@ jobs:
             make helm-chart-install YQ=/usr/local/bin/yq
           else
             echo "Deploying ZXporter using make deploy..."
-            make deploy IMG=${{ env.ZXPORTER_IMG }} DAKR_URL=http://testserver.devzero-zxporter.svc.cluster.local:50051 TARGET_NAMESPACES=dztest
+            make deploy IMG=${{ env.ZXPORTER_IMG }} DAKR_URL=http://testserver.devzero-system.svc.cluster.local:50051 TARGET_NAMESPACES=dztest
           fi
 
       - name: Wait for deployment to be ready
         run: |
           echo "Waiting for deployment to be ready..."
-          kubectl wait --for=condition=available --timeout=300s deployment/devzero-zxporter-controller-manager -n devzero-zxporter || true
+          kubectl wait --for=condition=available --timeout=300s deployment/devzero-zxporter-controller-manager -n devzero-system || true
           
           echo "Getting pod status..."
-          kubectl get pods -n devzero-zxporter -o wide
+          kubectl get pods -n devzero-system -o wide
           
           echo "Describing deployment..."
-          kubectl describe deployment devzero-zxporter-controller-manager -n devzero-zxporter
+          kubectl describe deployment devzero-zxporter-controller-manager -n devzero-system
           
           echo "Getting pod details..."
-          POD_NAME=$(kubectl get pods -n devzero-zxporter -l control-plane=controller-manager -o jsonpath='{.items[0].metadata.name}')
-          kubectl describe pod $POD_NAME -n devzero-zxporter
+          POD_NAME=$(kubectl get pods -n devzero-system -l control-plane=controller-manager -o jsonpath='{.items[0].metadata.name}')
+          kubectl describe pod $POD_NAME -n devzero-system
           
           echo "Getting events for the namespace..."
-          kubectl get events -n devzero-zxporter --sort-by='.lastTimestamp'
+          kubectl get events -n devzero-system --sort-by='.lastTimestamp'
           
           echo "Checking node status..."
           kubectl describe nodes
@@ -239,14 +239,14 @@ jobs:
       - name: Verify ZXporter is running
         run: |
           echo "Getting all devzero resource status..."
-          kubectl get all -n devzero-zxporter -o wide
+          kubectl get all -n devzero-system -o wide
           
           echo "Getting pod logs (if any)..."
-          POD_NAME=$(kubectl get pods -n devzero-zxporter -l control-plane=controller-manager -o jsonpath='{.items[0].metadata.name}')
-          kubectl logs $POD_NAME -n devzero-zxporter --tail=100 || echo "No logs available"
+          POD_NAME=$(kubectl get pods -n devzero-system -l control-plane=controller-manager -o jsonpath='{.items[0].metadata.name}')
+          kubectl logs $POD_NAME -n devzero-system --tail=100 || echo "No logs available"
           
           echo "Getting pod events..."
-          kubectl get events -n devzero-zxporter --field-selector involvedObject.name=$POD_NAME --sort-by='.lastTimestamp'
+          kubectl get events -n devzero-system --field-selector involvedObject.name=$POD_NAME --sort-by='.lastTimestamp'
 
       - name: Wait for data collection (2 minutes)
         run: |
@@ -254,56 +254,56 @@ jobs:
           sleep 120
 
           echo "Getting pod logs (if any)..."
-          POD_NAME=$(kubectl get pods -n devzero-zxporter -l control-plane=controller-manager -o jsonpath='{.items[0].metadata.name}')
-          kubectl logs $POD_NAME -n devzero-zxporter --tail=100 || echo "No logs available"
-          kubectl logs -n devzero-zxporter -l app.kubernetes.io/name=dz-prometheus --all-containers
+          POD_NAME=$(kubectl get pods -n devzero-system -l control-plane=controller-manager -o jsonpath='{.items[0].metadata.name}')
+          kubectl logs $POD_NAME -n devzero-system --tail=100 || echo "No logs available"
+          kubectl logs -n devzero-system -l app.kubernetes.io/name=dz-prometheus --all-containers
 
 
       - name: Debug Prometheus status and logs
         run: |
-          PROM_POD=$(kubectl get pod -n devzero-zxporter -l app.kubernetes.io/name=dz-prometheus,app.kubernetes.io/component=server -o jsonpath='{.items[0].metadata.name}')
+          PROM_POD=$(kubectl get pod -n devzero-system -l app.kubernetes.io/name=dz-prometheus,app.kubernetes.io/component=server -o jsonpath='{.items[0].metadata.name}')
           echo "Prometheus Pod: $PROM_POD"
         
           echo "Describing Prometheus pod..."
-          kubectl describe pod $PROM_POD -n devzero-zxporter || echo "Describe failed"
+          kubectl describe pod $PROM_POD -n devzero-system || echo "Describe failed"
         
           echo "Getting logs from Prometheus containers..."
-          kubectl logs $PROM_POD -n devzero-zxporter -c dz-prometheus-server || echo "No prometheus-server logs"
-          kubectl logs $PROM_POD -n devzero-zxporter -c dz-prometheus-server-configmap-reload || echo "No configmap-reload logs"
+          kubectl logs $PROM_POD -n devzero-system -c dz-prometheus-server || echo "No prometheus-server logs"
+          kubectl logs $PROM_POD -n devzero-system -c dz-prometheus-server-configmap-reload || echo "No configmap-reload logs"
         
           echo "Spawning debug pod to test Prometheus readiness endpoint..."
 
           # Create a temporary curl pod
           kubectl run curlbox \
-            -n devzero-zxporter \
+            -n devzero-system \
             --image=curlimages/curl:latest \
             --restart=Never \
             --command -- sleep 120
 
           # Wait for it to be ready
-          kubectl wait --for=condition=Ready pod/curlbox -n devzero-zxporter --timeout=30s
+          kubectl wait --for=condition=Ready pod/curlbox -n devzero-system --timeout=30s
 
           # Run curl against the Prometheus /-/ready endpoint
-          kubectl exec -n devzero-zxporter curlbox -- \
-            curl -v http://prometheus-dz-prometheus-server.devzero-zxporter.svc.cluster.local:80/-/ready || echo "Prometheus not responding to /-/ready"
+          kubectl exec -n devzero-system curlbox -- \
+            curl -v http://prometheus-dz-prometheus-server.devzero-system.svc.cluster.local:80/-/ready || echo "Prometheus not responding to /-/ready"
 
           # Clean up
-          kubectl delete pod curlbox -n devzero-zxporter --ignore-not-found
+          kubectl delete pod curlbox -n devzero-system --ignore-not-found
 
           echo "Checking Prometheus config mounted in pod..."
-          kubectl exec -n devzero-zxporter $PROM_POD -c dz-prometheus-server -- cat /etc/config/prometheus.yml || echo "Could not read prometheus.yml"        
+          kubectl exec -n devzero-system $PROM_POD -c dz-prometheus-server -- cat /etc/config/prometheus.yml || echo "Could not read prometheus.yml"        
         
       - name: Check testserver stats and validate resource usage
         run: |
           echo "Checking testserver stats..."
           
           # Get the testserver pod name
-          TESTSERVER_POD=$(kubectl get pods -n devzero-zxporter -l app=testserver -o jsonpath='{.items[0].metadata.name}')
+          TESTSERVER_POD=$(kubectl get pods -n devzero-system -l app=testserver -o jsonpath='{.items[0].metadata.name}')
           echo "Testserver pod: $TESTSERVER_POD"
           
           # Display the testserver logs
           echo "=== TESTSERVER LOGS ==="
-          kubectl logs $TESTSERVER_POD -n devzero-zxporter
+          kubectl logs $TESTSERVER_POD -n devzero-system
           echo "=== END TESTSERVER LOGS ==="
           
           # Call the stats endpoint
@@ -311,18 +311,18 @@ jobs:
           
           # Create a temporary curl pod
           kubectl run curlbox \
-            -n devzero-zxporter \
+            -n devzero-system \
             --image=curlimages/curl:latest \
             --restart=Never \
             --command -- sleep 120
 
           # Wait for it to be ready
-          kubectl wait --for=condition=Ready pod/curlbox -n devzero-zxporter --timeout=30s
+          kubectl wait --for=condition=Ready pod/curlbox -n devzero-system --timeout=30s
 
           # Run curl against the stats endpoint and save to a file
           echo "=== STATS ENDPOINT RESPONSE ==="
-          STATS_RESPONSE=$(kubectl exec -n devzero-zxporter curlbox -- \
-            curl -s http://testserver.devzero-zxporter.svc.cluster.local:8080/stats)
+          STATS_RESPONSE=$(kubectl exec -n devzero-system curlbox -- \
+            curl -s http://testserver.devzero-system.svc.cluster.local:8080/stats)
           echo "$STATS_RESPONSE"
           echo "=== END STATS ENDPOINT RESPONSE ==="
           
@@ -362,7 +362,7 @@ jobs:
           EOF
           
           # Clean up the curl pod
-          kubectl delete pod curlbox -n devzero-zxporter --ignore-not-found
+          kubectl delete pod curlbox -n devzero-system --ignore-not-found
           
           # Check if there was any data received
           TOTAL_MESSAGES=$(echo "$STATS_RESPONSE" | grep -o '"total_messages": [0-9]*' | awk '{print $2}')
@@ -401,5 +401,5 @@ jobs:
       - name: Check zxporter logs again for any errors
         run: |
           echo "Checking ZXporter logs for errors..."
-          POD_NAME=$(kubectl get pods -n devzero-zxporter -l control-plane=controller-manager -o jsonpath='{.items[0].metadata.name}')
-          kubectl logs $POD_NAME -n devzero-zxporter
+          POD_NAME=$(kubectl get pods -n devzero-system -l control-plane=controller-manager -o jsonpath='{.items[0].metadata.name}')
+          kubectl logs $POD_NAME -n devzero-system

--- a/.github/workflows/k8s-compatibility-test.yml
+++ b/.github/workflows/k8s-compatibility-test.yml
@@ -209,7 +209,7 @@ jobs:
             make helm-chart-install YQ=/usr/local/bin/yq
           else
             echo "Deploying ZXporter using make deploy..."
-            make deploy IMG=${{ env.ZXPORTER_IMG }} DAKR_URL=http://testserver.devzero-system.svc.cluster.local:50051 TARGET_NAMESPACES=dztest
+            make deploy IMG=${{ env.ZXPORTER_IMG }} DAKR_URL=http://testserver.devzero-system.svc.cluster.local:50051 TARGET_NAMESPACES=dztest CLUSTER_TOKEN=test-token-for-ci
           fi
 
       - name: Wait for deployment to be ready

--- a/.github/workflows/metrics-server-lifecycle-test.yml
+++ b/.github/workflows/metrics-server-lifecycle-test.yml
@@ -186,9 +186,9 @@ jobs:
           while [ $ATTEMPTS -lt $MAX_ATTEMPTS ]; do
             LOGS=$(kubectl logs $ZXPORTER_POD -n devzero-system)
             
-            if echo "$LOGS" | grep -q "apiservice.apiregistration.k8s.io/v1beta1.metrics.k8s.io configured"; then
+            if echo "$LOGS" | grep -qE "apiservice.apiregistration.k8s.io/v1beta1.metrics.k8s.io (configured|unchanged)"; then
               if [ "$FOUND_APISERVICE_MESSAGE" = false ]; then
-                echo "✅ Found 'apiservice.apiregistration.k8s.io/v1beta1.metrics.k8s.io configured' message in ZXporter logs!"
+                echo "✅ Found apiservice v1beta1.metrics.k8s.io applied message in ZXporter logs!"
                 FOUND_APISERVICE_MESSAGE=true
               fi
             fi
@@ -213,7 +213,7 @@ jobs:
           done
           
           if [ "$FOUND_APISERVICE_MESSAGE" = false ]; then
-            echo "❌ Did not find 'apiservice.apiregistration.k8s.io/v1beta1.metrics.k8s.io configured' message in ZXporter logs"
+            echo "❌ Did not find apiservice v1beta1.metrics.k8s.io configured/unchanged message in ZXporter logs"
             echo "Final ZXporter logs:"
             kubectl logs $ZXPORTER_POD -n devzero-system --tail=200
             exit 1

--- a/.github/workflows/metrics-server-lifecycle-test.yml
+++ b/.github/workflows/metrics-server-lifecycle-test.yml
@@ -160,22 +160,22 @@ jobs:
       - name: Wait for ZXporter deployment to be ready
         run: |
           echo "Waiting for ZXporter deployment to be ready..."
-          kubectl wait --for=condition=available --timeout=300s deployment/devzero-zxporter-controller-manager -n devzero-zxporter
+          kubectl wait --for=condition=available --timeout=300s deployment/devzero-zxporter-controller-manager -n devzero-system
           
           echo "Getting ZXporter pod status..."
-          kubectl get pods -n devzero-zxporter -o wide
+          kubectl get pods -n devzero-system -o wide
           
           echo "Getting ZXporter pod name..."
-          ZXPORTER_POD=$(kubectl get pods -n devzero-zxporter -l control-plane=controller-manager -o jsonpath='{.items[0].metadata.name}')
+          ZXPORTER_POD=$(kubectl get pods -n devzero-system -l control-plane=controller-manager -o jsonpath='{.items[0].metadata.name}')
           echo "ZXporter pod: $ZXPORTER_POD"
 
       - name: Monitor ZXporter logs for metrics-server installation
         run: |
           echo "Monitoring ZXporter logs for metrics-server installation..."
-          ZXPORTER_POD=$(kubectl get pods -n devzero-zxporter -l control-plane=controller-manager -o jsonpath='{.items[0].metadata.name}')
+          ZXPORTER_POD=$(kubectl get pods -n devzero-system -l control-plane=controller-manager -o jsonpath='{.items[0].metadata.name}')
           
           echo "Getting initial ZXporter logs..."
-          kubectl logs $ZXPORTER_POD -n devzero-zxporter | head -n 100
+          kubectl logs $ZXPORTER_POD -n devzero-system | head -n 100
           
           echo "Waiting and monitoring for apiservice configuration and 'metrics-server is now ready' messages..."
           ATTEMPTS=0
@@ -184,7 +184,7 @@ jobs:
           FOUND_READY_MESSAGE=false
           
           while [ $ATTEMPTS -lt $MAX_ATTEMPTS ]; do
-            LOGS=$(kubectl logs $ZXPORTER_POD -n devzero-zxporter)
+            LOGS=$(kubectl logs $ZXPORTER_POD -n devzero-system)
             
             if echo "$LOGS" | grep -q "apiservice.apiregistration.k8s.io/v1beta1.metrics.k8s.io configured"; then
               if [ "$FOUND_APISERVICE_MESSAGE" = false ]; then
@@ -215,14 +215,14 @@ jobs:
           if [ "$FOUND_APISERVICE_MESSAGE" = false ]; then
             echo "❌ Did not find 'apiservice.apiregistration.k8s.io/v1beta1.metrics.k8s.io configured' message in ZXporter logs"
             echo "Final ZXporter logs:"
-            kubectl logs $ZXPORTER_POD -n devzero-zxporter --tail=200
+            kubectl logs $ZXPORTER_POD -n devzero-system --tail=200
             exit 1
           fi
           
           if [ "$FOUND_READY_MESSAGE" = false ]; then
             echo "❌ Did not find 'metrics-server is now ready' message in ZXporter logs within timeout"
             echo "Final ZXporter logs:"
-            kubectl logs $ZXPORTER_POD -n devzero-zxporter --tail=200
+            kubectl logs $ZXPORTER_POD -n devzero-system --tail=200
             exit 1
           fi
 
@@ -282,8 +282,8 @@ jobs:
           echo "Running final validation..."
           
           echo "Final ZXporter logs:"
-          ZXPORTER_POD=$(kubectl get pods -n devzero-zxporter -l control-plane=controller-manager -o jsonpath='{.items[0].metadata.name}')
-          kubectl logs $ZXPORTER_POD -n devzero-zxporter --tail=100
+          ZXPORTER_POD=$(kubectl get pods -n devzero-system -l control-plane=controller-manager -o jsonpath='{.items[0].metadata.name}')
+          kubectl logs $ZXPORTER_POD -n devzero-system --tail=100
           
           echo "Final kubectl top nodes test:"
           kubectl top nodes
@@ -307,16 +307,16 @@ jobs:
           echo "All pods in kube-system:"
           kubectl get pods -n kube-system -o wide
           
-          echo "All pods in devzero-zxporter:"
-          kubectl get pods -n devzero-zxporter -o wide
+          echo "All pods in devzero-system:"
+          kubectl get pods -n devzero-system -o wide
           
           echo "ZXporter deployment status:"
-          kubectl describe deployment devzero-zxporter-controller-manager -n devzero-zxporter
+          kubectl describe deployment devzero-zxporter-controller-manager -n devzero-system
           
           echo "ZXporter pod logs:"
-          ZXPORTER_POD=$(kubectl get pods -n devzero-zxporter -l control-plane=controller-manager -o jsonpath='{.items[0].metadata.name}' 2>/dev/null || echo "")
+          ZXPORTER_POD=$(kubectl get pods -n devzero-system -l control-plane=controller-manager -o jsonpath='{.items[0].metadata.name}' 2>/dev/null || echo "")
           if [ ! -z "$ZXPORTER_POD" ]; then
-            kubectl logs $ZXPORTER_POD -n devzero-zxporter --tail=200
+            kubectl logs $ZXPORTER_POD -n devzero-system --tail=200
           else
             echo "No ZXporter pod found"
           fi
@@ -324,8 +324,8 @@ jobs:
           echo "Metrics server pods (if any):"
           kubectl get pods -n kube-system -l k8s-app=metrics-server -o wide || echo "No metrics-server pods found"
           
-          echo "Events in devzero-zxporter namespace:"
-          kubectl get events -n devzero-zxporter --sort-by='.lastTimestamp'
+          echo "Events in devzero-system namespace:"
+          kubectl get events -n devzero-system --sort-by='.lastTimestamp'
           
           echo "Events in kube-system namespace (last 20):"
           kubectl get events -n kube-system --sort-by='.lastTimestamp' | tail -20

--- a/Makefile
+++ b/Makefile
@@ -320,7 +320,13 @@ final-installer:
 	@cp dist/install.yaml $(DIST_BACKEND_INSTALL_BUNDLE)
 	@$(YQ) -i '(select(.kind == "ConfigMap" and .metadata.name == "devzero-zxporter-env-config") | .data.DAKR_URL) = "{{ .api_url }}/dakr"' $(DIST_BACKEND_INSTALL_BUNDLE)
 	@$(YQ) -i '(select(.kind == "Deployment") | .spec.template.spec.containers[]? | select(.image == "ttl.sh/zxporter:latest")).image = "docker.io/devzeroinc/zxporter:latest"' $(DIST_BACKEND_INSTALL_BUNDLE)
+	@$(YQ) -i '(select(.kind == "Secret" and .metadata.name == "devzero-zxporter-devzero-zxporter-token") | .stringData.CLUSTER_TOKEN) = "{{ .cluster_token }}"' $(DIST_BACKEND_INSTALL_BUNDLE)
 	@$(MAKE) installer-without-configmap
+	@if [ -d "$(DAKR_DIR)/services/dakr_installers" ]; then \
+		cp $(DIST_BACKEND_INSTALL_BUNDLE) $(DAKR_DIR)/services/dakr_installers/install.yaml; \
+		cp $(DIST_DIR)/installer_updater.yaml $(DAKR_DIR)/services/dakr_installers/installer_updater.yaml; \
+		echo "[INFO] Synced installer files to $(DAKR_DIR)/services/dakr_installers/"; \
+	fi
 
 .PHONY: installer-without-configmap
 installer-without-configmap:

--- a/Makefile
+++ b/Makefile
@@ -65,6 +65,11 @@ TARGET_NAMESPACES ?=
 COLLECTION_FILE ?= env_configmap.yaml
 # ENV_CONFIGMAP_FILE is used to control the zxporter-manager deployment.
 ENV_CONFIGMAP_FILE ?= config/manager/env_configmap.yaml
+# ENV_SECRET_FILE holds the cluster token secret template.
+ENV_SECRET_FILE ?= config/manager/env_secret.yaml
+# CLUSTER_TOKEN: when set, patches the token Secret during build-installer (e.g. for CI test deployments).
+# Leave empty for production builds — keeps the '{{ .cluster_token }}' template placeholder.
+CLUSTER_TOKEN ?=
 
 # Monitoring resources
 PROMETHEUS_CHART_VERSION ?= 27.20.0
@@ -373,6 +378,10 @@ build-installer: manifests generate kustomize yq ## Generate a consolidated YAML
 	@$(YQ) e '.data.DAKR_URL = "$(DAKR_URL)"' -i $(ENV_CONFIGMAP_FILE)
 	@$(YQ) e '.data.PROMETHEUS_URL = "$(PROMETHEUS_URL)"' -i $(ENV_CONFIGMAP_FILE)
 	@$(YQ) e '.data.TARGET_NAMESPACES = "$(TARGET_NAMESPACES)"' -i $(ENV_CONFIGMAP_FILE)
+	@if [ -n "$(CLUSTER_TOKEN)" ]; then \
+		echo "[INFO] Patching cluster token into Secret (test/override deployment)"; \
+		$(YQ) e '.stringData.CLUSTER_TOKEN = "$(CLUSTER_TOKEN)"' -i $(ENV_SECRET_FILE); \
+	fi
 
 	@$(KUSTOMIZE) build config/default > $(DIST_ZXPORTER_BUNDLE)
 	@cat $(DIST_ZXPORTER_BUNDLE) >> $(DIST_INSTALL_BUNDLE)

--- a/Makefile
+++ b/Makefile
@@ -65,10 +65,8 @@ TARGET_NAMESPACES ?=
 COLLECTION_FILE ?= env_configmap.yaml
 # ENV_CONFIGMAP_FILE is used to control the zxporter-manager deployment.
 ENV_CONFIGMAP_FILE ?= config/manager/env_configmap.yaml
-# ENV_SECRET_FILE holds the cluster token secret template.
-ENV_SECRET_FILE ?= config/manager/env_secret.yaml
-# CLUSTER_TOKEN: when set, patches the token Secret during build-installer (e.g. for CI test deployments).
-# Leave empty for production builds — keeps the '{{ .cluster_token }}' template placeholder.
+# CLUSTER_TOKEN: optional token to embed in the generated dist/install.yaml.
+# When empty, the Secret keeps the '{{ .cluster_token }}' placeholder (for curl installer templating).
 CLUSTER_TOKEN ?=
 
 # Monitoring resources
@@ -378,10 +376,10 @@ build-installer: manifests generate kustomize yq ## Generate a consolidated YAML
 	@$(YQ) e '.data.DAKR_URL = "$(DAKR_URL)"' -i $(ENV_CONFIGMAP_FILE)
 	@$(YQ) e '.data.PROMETHEUS_URL = "$(PROMETHEUS_URL)"' -i $(ENV_CONFIGMAP_FILE)
 	@$(YQ) e '.data.TARGET_NAMESPACES = "$(TARGET_NAMESPACES)"' -i $(ENV_CONFIGMAP_FILE)
-	@echo "[INFO] Patching cluster token into Secret"
-	@$(YQ) e '.stringData.CLUSTER_TOKEN = "$(CLUSTER_TOKEN)"' -i $(ENV_SECRET_FILE)
 
 	@$(KUSTOMIZE) build config/default > $(DIST_ZXPORTER_BUNDLE)
+	@echo "[INFO] Patching cluster token into generated bundle"
+	@sed "s|CLUSTER_TOKEN: '{{ .cluster_token }}'|CLUSTER_TOKEN: \"$(CLUSTER_TOKEN)\"|g" $(DIST_ZXPORTER_BUNDLE) > $(DIST_ZXPORTER_BUNDLE).tmp && mv $(DIST_ZXPORTER_BUNDLE).tmp $(DIST_ZXPORTER_BUNDLE)
 	@cat $(DIST_ZXPORTER_BUNDLE) >> $(DIST_INSTALL_BUNDLE)
 
 	@echo "[INFO] Building backend installer"

--- a/Makefile
+++ b/Makefile
@@ -378,10 +378,8 @@ build-installer: manifests generate kustomize yq ## Generate a consolidated YAML
 	@$(YQ) e '.data.DAKR_URL = "$(DAKR_URL)"' -i $(ENV_CONFIGMAP_FILE)
 	@$(YQ) e '.data.PROMETHEUS_URL = "$(PROMETHEUS_URL)"' -i $(ENV_CONFIGMAP_FILE)
 	@$(YQ) e '.data.TARGET_NAMESPACES = "$(TARGET_NAMESPACES)"' -i $(ENV_CONFIGMAP_FILE)
-	@if [ -n "$(CLUSTER_TOKEN)" ]; then \
-		echo "[INFO] Patching cluster token into Secret (test/override deployment)"; \
-		$(YQ) e '.stringData.CLUSTER_TOKEN = "$(CLUSTER_TOKEN)"' -i $(ENV_SECRET_FILE); \
-	fi
+	@echo "[INFO] Patching cluster token into Secret"
+	@$(YQ) e '.stringData.CLUSTER_TOKEN = "$(CLUSTER_TOKEN)"' -i $(ENV_SECRET_FILE)
 
 	@$(KUSTOMIZE) build config/default > $(DIST_ZXPORTER_BUNDLE)
 	@cat $(DIST_ZXPORTER_BUNDLE) >> $(DIST_INSTALL_BUNDLE)

--- a/Makefile
+++ b/Makefile
@@ -320,7 +320,7 @@ final-installer:
 	@cp dist/install.yaml $(DIST_BACKEND_INSTALL_BUNDLE)
 	@$(YQ) -i '(select(.kind == "ConfigMap" and .metadata.name == "devzero-zxporter-env-config") | .data.DAKR_URL) = "{{ .api_url }}/dakr"' $(DIST_BACKEND_INSTALL_BUNDLE)
 	@$(YQ) -i '(select(.kind == "Deployment") | .spec.template.spec.containers[]? | select(.image == "ttl.sh/zxporter:latest")).image = "docker.io/devzeroinc/zxporter:latest"' $(DIST_BACKEND_INSTALL_BUNDLE)
-	@$(YQ) -i '(select(.kind == "Secret" and .metadata.name == "devzero-zxporter-devzero-zxporter-token") | .stringData.CLUSTER_TOKEN) = "{{ .cluster_token }}"' $(DIST_BACKEND_INSTALL_BUNDLE)
+	@$(YQ) -i '(select(.kind == "Secret" and .metadata.name == "devzero-zxporter-token") | .stringData.CLUSTER_TOKEN) = "{{ .cluster_token }}"' $(DIST_BACKEND_INSTALL_BUNDLE)
 	@$(MAKE) installer-without-configmap
 	@if [ -d "$(DAKR_DIR)/services/dakr_installers" ]; then \
 		cp $(DIST_BACKEND_INSTALL_BUNDLE) $(DAKR_DIR)/services/dakr_installers/install.yaml; \

--- a/Makefile
+++ b/Makefile
@@ -68,7 +68,7 @@ ENV_CONFIGMAP_FILE ?= config/manager/env_configmap.yaml
 
 # Monitoring resources
 PROMETHEUS_CHART_VERSION ?= 27.20.0
-DEVZERO_MONITORING_NAMESPACE ?= devzero-zxporter
+DEVZERO_MONITORING_NAMESPACE ?= devzero-system
 NODE_EXPORTER_CHART_VERSION ?= 4.47.0
 METRICS_SERVER_CHART_VERSION ?= 3.12.2
 
@@ -213,7 +213,7 @@ docker-build: helm ## Build docker image with the manager.
 	@echo "[INFO] Generate Metrics Server manifest"
 	@$(HELM) template metrics-server metrics-server/metrics-server \
 		--version $(METRICS_SERVER_CHART_VERSION) \
-		--namespace devzero-zxporter \
+		--namespace devzero-system \
 		--set args="{--kubelet-insecure-tls}" \
 		--set nameOverride="dz-metrics-server" \
 		--set fullnameOverride="dz-metrics-server" \
@@ -425,14 +425,14 @@ helm-chart-lint: helm ## Lint the Helm chart
 helm-chart-template: helm ## Generate Kubernetes manifests from the Helm chart
 	@echo "[INFO] Generating manifests from Helm chart..."
 	@$(HELM) template zxporter $(HELM_CHART_DIR) \
-		--namespace devzero-zxporter \
+		--namespace devzero-system \
 		--output-dir $(DIST_DIR)/helm-manifests
 
 .PHONY: helm-chart-install
 helm-chart-install: helm-chart-build ## Install the Helm chart locally for testing
 	@echo "[INFO] Installing Helm chart locally..."
 	@$(HELM) upgrade --install zxporter $(HELM_CHART_DIR) \
-		--namespace devzero-zxporter \
+		--namespace devzero-system \
 		--create-namespace \
 		--wait
 
@@ -440,7 +440,7 @@ helm-chart-install: helm-chart-build ## Install the Helm chart locally for testi
 helm-chart-install-minimal: helm-chart-build ## Install only zxporter without monitoring components
 	@echo "[INFO] Installing minimal zxporter chart (no monitoring)..."
 	@$(HELM) upgrade --install zxporter $(HELM_CHART_DIR) \
-		--namespace devzero-zxporter \
+		--namespace devzero-system \
 		--create-namespace \
 		--set monitoring.enabled=false \
 		--set zxporter.prometheusUrl="$(PROMETHEUS_URL)" \
@@ -449,7 +449,7 @@ helm-chart-install-minimal: helm-chart-build ## Install only zxporter without mo
 .PHONY: helm-chart-uninstall
 helm-chart-uninstall: helm ## Uninstall the Helm chart
 	@echo "[INFO] Uninstalling Helm chart..."
-	@$(HELM) uninstall zxporter --namespace devzero-zxporter || true
+	@$(HELM) uninstall zxporter --namespace devzero-system || true
 
 .PHONY: helm-chart-push
 helm-chart-push: helm-chart-build ## Push Helm chart to OCI registry (requires HELM_REGISTRY)
@@ -730,7 +730,7 @@ verify-local: setup-lima
 	@./verification/verify_local.sh $(LIMA_INSTANCE)
 
 # for local, this will be something like: 
-#         make verify-e2e CLUSTER_CONTEXT=kind-zxporter-e2e NAMESPACE=devzero-zxporter
+#         make verify-e2e CLUSTER_CONTEXT=kind-zxporter-e2e NAMESPACE=devzero-system
 .PHONY: verify-e2e
 verify-e2e: ## Run E2E verification on a Kind or Cloud cluster
 	@echo "Running E2E verification..."
@@ -750,7 +750,7 @@ delete-kind: ## Delete Kind cluster
 
 .PHONY: verify-e2e-kind-lifecycle
 verify-e2e-kind-lifecycle: delete-kind create-kind ## Full Kind E2E (Delete -> Create -> Verify)
-	$(MAKE) verify-e2e CLUSTER_CONTEXT=kind-$(KIND_CLUSTER_NAME) NAMESPACE=devzero-zxporter
+	$(MAKE) verify-e2e CLUSTER_CONTEXT=kind-$(KIND_CLUSTER_NAME) NAMESPACE=devzero-system
 
 .PHONY: provision-eks
 provision-eks: ## Create EKS cluster
@@ -771,7 +771,7 @@ verify-e2e-eks: ## Run verification against an existing EKS cluster (reads state
 	echo "Using cached config for cluster $${CLUSTER_NAME} in $${REGION}..." && \
 	AWS_PROFILE=self-hosted aws eks update-kubeconfig --region $${REGION} --name $${CLUSTER_NAME} && \
 	CONTEXT=$$(kubectl config current-context) && \
-	$(MAKE) verify-e2e CLUSTER_CONTEXT="$${CONTEXT}" NAMESPACE=devzero-zxporter CNI_TYPE="$${CNI_TYPE}"
+	$(MAKE) verify-e2e CLUSTER_CONTEXT="$${CONTEXT}" NAMESPACE=devzero-system CNI_TYPE="$${CNI_TYPE}"
 
 .PHONY: verify-e2e-eks-lifecycle
 verify-e2e-eks-lifecycle: provision-eks ## Full EKS E2E (Provision -> Verify -> Deprovision)
@@ -801,7 +801,7 @@ verify-e2e-aks: ## Run verification against an existing AKS cluster (reads state
 	echo "Using cached config for cluster $${CLUSTER_NAME} in $${RESOURCE_GROUP}..." && \
 	az aks get-credentials --resource-group $${RESOURCE_GROUP} --name $${CLUSTER_NAME} --overwrite-existing && \
 	CONTEXT=$$(kubectl config current-context) && \
-	$(MAKE) verify-e2e CLUSTER_CONTEXT="$${CONTEXT}" NAMESPACE=devzero-zxporter CNI_TYPE="$${CNI_TYPE}"
+	$(MAKE) verify-e2e CLUSTER_CONTEXT="$${CONTEXT}" NAMESPACE=devzero-system CNI_TYPE="$${CNI_TYPE}"
 
 .PHONY: verify-e2e-aks-lifecycle
 verify-e2e-aks-lifecycle: provision-aks ## Full AKS E2E (Provision -> Verify -> Deprovision). Use CNI_TYPE=cilium|kubenet (default: cilium).
@@ -829,7 +829,7 @@ verify-e2e-gke: ## Run verification against an existing GKE cluster (reads state
 	echo "Using cached config for cluster $${CLUSTER_NAME} in $${REGION} in $${ZONE}..." && \
 	gcloud container clusters get-credentials $${CLUSTER_NAME} --zone $${ZONE} && \
 	CONTEXT=$$(kubectl config current-context) && \
-	$(MAKE) verify-e2e CLUSTER_CONTEXT="$${CONTEXT}" NAMESPACE=devzero-zxporter CNI_TYPE="$${CNI_TYPE}"
+	$(MAKE) verify-e2e CLUSTER_CONTEXT="$${CONTEXT}" NAMESPACE=devzero-system CNI_TYPE="$${CNI_TYPE}"
 
 .PHONY: verify-e2e-gke-lifecycle
 verify-e2e-gke-lifecycle: provision-gke ## Full GKE E2E (Provision -> Verify -> Deprovision)

--- a/README.md
+++ b/README.md
@@ -140,7 +140,7 @@ ZXporter can also be deployed using Helm, which provides a more flexible and cus
 #### Quick Install
 
 ```sh
-helm install zxporter ./helm-chart/zxporter --namespace devzero-zxporter --create-namespace
+helm install zxporter ./helm-chart/zxporter --namespace devzero-system --create-namespace
 
 # With Makefile
 make helm-chart-install
@@ -170,7 +170,7 @@ If you already have Prometheus and Node Exporter running in your cluster:
 helm install zxporter ./helm-chart/zxporter \
   --set monitoring.enabled=false \
   --set zxporter.prometheusUrl="http://your-prometheus.monitoring.svc.cluster.local:9090" \
-  --namespace devzero-zxporter \
+  --namespace devzero-system \
   --create-namespace
 
 # Or use the Makefile target
@@ -215,7 +215,7 @@ apiVersion: devzero.io/v1
 kind: CollectionPolicy
 metadata:
   name: advanced-policy
-  namespace: devzero-zxporter
+  namespace: devzero-system
 spec:
   targetSelector:
     namespaces: ["app1", "app2"]
@@ -249,7 +249,7 @@ spec:
    Solution: Ensure the operator has the necessary RBAC permissions:
 
    ```sh
-   kubectl create clusterrolebinding zxporter-admin --clusterrole=cluster-admin --serviceaccount=devzero-zxporter:zxporter-controller-manager
+   kubectl create clusterrolebinding zxporter-admin --clusterrole=cluster-admin --serviceaccount=devzero-system:zxporter-controller-manager
    ```
 
 2. **Collection Policy Not Applied**
@@ -261,7 +261,7 @@ spec:
    Solution: Verify the CollectionPolicy CR is properly created:
 
    ```sh
-   kubectl get collectionpolicy -n devzero-zxporter
+   kubectl get collectionpolicy -n devzero-system
    ```
 
 3. **High Resource Usage**
@@ -272,7 +272,7 @@ spec:
 View operator logs:
 
 ```sh
-kubectl logs -n devzero-zxporter deployment/zxporter-controller-manager
+kubectl logs -n devzero-system deployment/zxporter-controller-manager
 ```
 
 Enable debug logging:

--- a/collection.yaml
+++ b/collection.yaml
@@ -2,7 +2,7 @@ apiVersion: devzero.io/v1
 kind: CollectionPolicy
 metadata:
   name: default-policy
-  namespace: devzero-zxporter
+  namespace: devzero-system
 spec:
   targetSelector:
     namespaces: [] # Empty means all namespaces

--- a/config/default/kustomization.yaml
+++ b/config/default/kustomization.yaml
@@ -1,5 +1,5 @@
 # Adds namespace to all resources.
-namespace: devzero-zxporter
+namespace: devzero-system
 
 # Value of this field is prepended to the
 # names of all resources, e.g. a deployment named

--- a/config/manager/env_configmap.yaml
+++ b/config/manager/env_configmap.yaml
@@ -4,12 +4,12 @@ metadata:
   name: env-config
   namespace: system
 data:
-  # If using PAT token, you can comment out CLUSTER_TOKEN and use PAT_TOKEN in the Secret
-  CLUSTER_TOKEN: "{{ .cluster_token }}"
+  # CLUSTER_TOKEN is stored in the Secret (env_secret.yaml) when USE_SECRET_FOR_TOKEN=true
+  CLUSTER_TOKEN: ""
   # PAT_TOKEN: "{{ .pat_token }}"  # Uncomment to use PAT token (recommended to use Secret instead)
   KUBE_CONTEXT_NAME: '{{ .kube_context_name }}'
   DAKR_URL: "https://dakr.devzero.io"
-  PROMETHEUS_URL: "http://prometheus-dz-prometheus-server.devzero-zxporter.svc.cluster.local:80"
+  PROMETHEUS_URL: "http://prometheus-dz-prometheus-server.devzero-system.svc.cluster.local:80"
   K8S_PROVIDER: "{{ .k8s_provider }}"
   COLLECTION_FREQUENCY: ""
   BUFFER_SIZE: ""
@@ -55,4 +55,4 @@ data:
   TOKEN_RUNTIME_SECRET_NAME: "devzero-zxporter-token"
   TOKEN_SECRET_NAME: "devzero-zxporter-token" # Deprecated, use TOKEN_RUNTIME_SECRET_NAME
   TOKEN_CONFIGMAP_NAME: "devzero-zxporter-env-config"
-  USE_SECRET_FOR_TOKEN: "false"
+  USE_SECRET_FOR_TOKEN: "true"

--- a/config/manager/env_secret.yaml
+++ b/config/manager/env_secret.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: Secret
 metadata:
-  name: devzero-zxporter-token
+  name: token
 type: Opaque
 stringData:
   CLUSTER_TOKEN: "{{ .cluster_token }}"

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -76,19 +76,12 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: metadata.namespace
-          # Uncomment the following to inject tokens from a Secret (recommended for production)
-          # Additional env vars can be added below:
-          # - name: CLUSTER_TOKEN
-          #   valueFrom:
-          #     secretKeyRef:
-          #       name: devzero-zxporter-token
-          #       key: CLUSTER_TOKEN
-          # # Uncomment if using PAT token instead of or in addition to CLUSTER_TOKEN
-          # - name: PAT_TOKEN
-          #   valueFrom:
-          #     secretKeyRef:
-          #       name: devzero-zxporter-token
-          #       key: PAT_TOKEN
+            - name: CLUSTER_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: devzero-zxporter-token
+                  key: CLUSTER_TOKEN
+                  optional: true
           securityContext:
             allowPrivilegeEscalation: false
             capabilities:

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -79,7 +79,7 @@ spec:
             - name: CLUSTER_TOKEN
               valueFrom:
                 secretKeyRef:
-                  name: devzero-zxporter-token
+                  name: token
                   key: CLUSTER_TOKEN
                   optional: true
           securityContext:

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -47,7 +47,7 @@ rules:
 - apiGroups:
   - ""
   resourceNames:
-  - devzero-zxporter-token
+  - token
   resources:
   - secrets
   verbs:

--- a/config/zxporter-netmon.yaml
+++ b/config/zxporter-netmon.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: zxporter-netmon
-  namespace: devzero-zxporter
+  namespace: devzero-system
   labels:
     app: zxporter-netmon
 ---
@@ -10,7 +10,7 @@ apiVersion: apps/v1
 kind: DaemonSet
 metadata:
   name: zxporter-netmon
-  namespace: devzero-zxporter
+  namespace: devzero-system
   labels:
     app: zxporter-netmon
 spec:

--- a/dist/backend-install.yaml
+++ b/dist/backend-install.yaml
@@ -1001,7 +1001,7 @@ rules:
   - apiGroups:
       - ""
     resourceNames:
-      - devzero-zxporter-devzero-zxporter-token
+      - devzero-zxporter-token
     resources:
       - secrets
     verbs:
@@ -1419,10 +1419,10 @@ metadata:
 apiVersion: v1
 kind: Secret
 metadata:
-  name: devzero-zxporter-devzero-zxporter-token
+  name: devzero-zxporter-token
   namespace: devzero-system
 stringData:
-  CLUSTER_TOKEN: ""
+  CLUSTER_TOKEN: "{{ .cluster_token }}"
 type: Opaque
 ---
 apiVersion: v1
@@ -1508,7 +1508,7 @@ spec:
               valueFrom:
                 secretKeyRef:
                   key: CLUSTER_TOKEN
-                  name: devzero-zxporter-devzero-zxporter-token
+                  name: devzero-zxporter-token
                   optional: true
           image: docker.io/devzeroinc/zxporter:latest
           livenessProbe:

--- a/dist/backend-install.yaml
+++ b/dist/backend-install.yaml
@@ -29,7 +29,7 @@ metadata:
     app.kubernetes.io/instance: prometheus
     app.kubernetes.io/version: "2.15.0"
   name: prometheus-kube-state-metrics
-  namespace: devzero-zxporter
+  namespace: devzero-system
 ---
 # Source: prometheus/templates/serviceaccount.yaml
 apiVersion: v1
@@ -43,7 +43,7 @@ metadata:
     helm.sh/chart: prometheus-27.20.0
     app.kubernetes.io/part-of: dz-prometheus
   name: prometheus-dz-prometheus-server
-  namespace: devzero-zxporter
+  namespace: devzero-system
   annotations: {}
 ---
 # Source: prometheus/templates/cm.yaml
@@ -58,7 +58,7 @@ metadata:
     helm.sh/chart: prometheus-27.20.0
     app.kubernetes.io/part-of: dz-prometheus
   name: prometheus-dz-prometheus-server
-  namespace: devzero-zxporter
+  namespace: devzero-system
 data:
   allow-snippet-annotations: "false"
   alerting_rules.yml: |
@@ -336,7 +336,7 @@ roleRef:
 subjects:
   - kind: ServiceAccount
     name: prometheus-kube-state-metrics
-    namespace: devzero-zxporter
+    namespace: devzero-system
 ---
 # Source: prometheus/templates/clusterrolebinding.yaml
 apiVersion: rbac.authorization.k8s.io/v1
@@ -353,7 +353,7 @@ metadata:
 subjects:
   - kind: ServiceAccount
     name: prometheus-dz-prometheus-server
-    namespace: devzero-zxporter
+    namespace: devzero-system
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
@@ -364,7 +364,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: prometheus-kube-state-metrics
-  namespace: devzero-zxporter
+  namespace: devzero-system
   labels:
     helm.sh/chart: kube-state-metrics-5.33.2
     app.kubernetes.io/managed-by: Helm
@@ -398,7 +398,7 @@ metadata:
     helm.sh/chart: prometheus-27.20.0
     app.kubernetes.io/part-of: dz-prometheus
   name: prometheus-dz-prometheus-server
-  namespace: devzero-zxporter
+  namespace: devzero-system
 spec:
   ports:
     - name: http
@@ -417,7 +417,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: prometheus-kube-state-metrics
-  namespace: devzero-zxporter
+  namespace: devzero-system
   labels:
     helm.sh/chart: kube-state-metrics-5.33.2
     app.kubernetes.io/managed-by: Helm
@@ -514,7 +514,7 @@ metadata:
     helm.sh/chart: prometheus-27.20.0
     app.kubernetes.io/part-of: dz-prometheus
   name: prometheus-dz-prometheus-server
-  namespace: devzero-zxporter
+  namespace: devzero-system
 spec:
   selector:
     matchLabels:
@@ -637,7 +637,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: dz-prometheus-node-exporter
-  namespace: devzero-zxporter
+  namespace: devzero-system
   labels:
     helm.sh/chart: prometheus-node-exporter-4.47.0
     app.kubernetes.io/managed-by: Helm
@@ -653,7 +653,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: dz-prometheus-node-exporter
-  namespace: devzero-zxporter
+  namespace: devzero-system
   labels:
     helm.sh/chart: prometheus-node-exporter-4.47.0
     app.kubernetes.io/managed-by: Helm
@@ -680,7 +680,7 @@ apiVersion: apps/v1
 kind: DaemonSet
 metadata:
   name: dz-prometheus-node-exporter
-  namespace: devzero-zxporter
+  namespace: devzero-system
   labels:
     helm.sh/chart: prometheus-node-exporter-4.47.0
     app.kubernetes.io/managed-by: Helm
@@ -830,7 +830,7 @@ metadata:
     app.kubernetes.io/managed-by: kustomize
     app.kubernetes.io/name: devzero-zxporter
   name: devzero-zxporter-controller-manager
-  namespace: devzero-zxporter
+  namespace: devzero-system
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
@@ -839,7 +839,7 @@ metadata:
     app.kubernetes.io/managed-by: kustomize
     app.kubernetes.io/name: devzero-zxporter
   name: devzero-zxporter-leader-election-role
-  namespace: devzero-zxporter
+  namespace: devzero-system
 rules:
   - apiGroups:
       - ""
@@ -1321,7 +1321,7 @@ metadata:
     app.kubernetes.io/managed-by: kustomize
     app.kubernetes.io/name: devzero-zxporter
   name: devzero-zxporter-leader-election-rolebinding
-  namespace: devzero-zxporter
+  namespace: devzero-system
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
@@ -1329,7 +1329,7 @@ roleRef:
 subjects:
   - kind: ServiceAccount
     name: devzero-zxporter-controller-manager
-    namespace: devzero-zxporter
+    namespace: devzero-system
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
@@ -1345,7 +1345,7 @@ roleRef:
 subjects:
   - kind: ServiceAccount
     name: devzero-zxporter-controller-manager
-    namespace: devzero-zxporter
+    namespace: devzero-system
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
@@ -1358,7 +1358,7 @@ roleRef:
 subjects:
   - kind: ServiceAccount
     name: devzero-zxporter-controller-manager
-    namespace: devzero-zxporter
+    namespace: devzero-system
 ---
 apiVersion: v1
 data:
@@ -1414,13 +1414,13 @@ data:
 kind: ConfigMap
 metadata:
   name: devzero-zxporter-env-config
-  namespace: devzero-zxporter
+  namespace: devzero-system
 ---
 apiVersion: v1
 kind: Secret
 metadata:
   name: devzero-zxporter-devzero-zxporter-token
-  namespace: devzero-zxporter
+  namespace: devzero-system
 stringData:
   CLUSTER_TOKEN: '{{ .cluster_token }}'
 type: Opaque
@@ -1433,7 +1433,7 @@ metadata:
     app.kubernetes.io/name: devzero-zxporter
     control-plane: controller-manager
   name: devzero-zxporter-controller-manager-metrics-service
-  namespace: devzero-zxporter
+  namespace: devzero-system
 spec:
   ports:
     - name: https
@@ -1450,7 +1450,7 @@ metadata:
     app.kubernetes.io/name: devzero-zxporter
     control-plane: controller-manager
   name: devzero-zxporter-controller-manager-mpa
-  namespace: devzero-zxporter
+  namespace: devzero-system
 spec:
   ports:
     - name: mpa-grpc
@@ -1478,7 +1478,7 @@ metadata:
     app.kubernetes.io/name: devzero-zxporter
     control-plane: controller-manager
   name: devzero-zxporter-controller-manager
-  namespace: devzero-zxporter
+  namespace: devzero-system
 spec:
   replicas: 2
   selector:
@@ -1549,7 +1549,7 @@ apiVersion: policy/v1
 kind: PodDisruptionBudget
 metadata:
   name: devzero-zxporter-devzero-zxporter-pdb
-  namespace: devzero-zxporter
+  namespace: devzero-system
 spec:
   minAvailable: 1
   selector:

--- a/dist/backend-install.yaml
+++ b/dist/backend-install.yaml
@@ -11,8 +11,8 @@ kind: Namespace
 metadata:
   labels:
     control-plane: controller-manager
-    app.kubernetes.io/name: devzero-zxporter
-  name: devzero-zxporter
+    app.kubernetes.io/name: devzero-system
+  name: devzero-system
 # ----- START PROM SERVER -----
 ---
 # Source: prometheus/charts/kube-state-metrics/templates/serviceaccount.yaml
@@ -821,7 +821,7 @@ metadata:
     app.kubernetes.io/managed-by: kustomize
     app.kubernetes.io/name: devzero-zxporter
     control-plane: controller-manager
-  name: devzero-zxporter
+  name: devzero-system
 ---
 apiVersion: v1
 kind: ServiceAccount
@@ -1363,7 +1363,7 @@ subjects:
 apiVersion: v1
 data:
   BUFFER_SIZE: ""
-  CLUSTER_TOKEN: '{{ .cluster_token }}'
+  CLUSTER_TOKEN: ""
   COLLECTION_FREQUENCY: ""
   DAKR_URL: '{{ .api_url }}/dakr'
   DISABLE_NETWORK_IO_METRICS: ""
@@ -1403,13 +1403,13 @@ data:
   KUBE_CONTEXT_NAME: '{{ .kube_context_name }}'
   MASK_SECRET_DATA: ""
   NODE_METRICS_INTERVAL: ""
-  PROMETHEUS_URL: http://prometheus-dz-prometheus-server.devzero-zxporter.svc.cluster.local:80
+  PROMETHEUS_URL: http://prometheus-dz-prometheus-server.devzero-system.svc.cluster.local:80
   TARGET_NAMESPACES: ""
   TOKEN_CONFIGMAP_NAME: devzero-zxporter-env-config
   TOKEN_CREDENTIALS_SECRET_NAME: devzero-zxporter-credentials
   TOKEN_RUNTIME_SECRET_NAME: devzero-zxporter-token
   TOKEN_SECRET_NAME: devzero-zxporter-token
-  USE_SECRET_FOR_TOKEN: "false"
+  USE_SECRET_FOR_TOKEN: "true"
   WATCHED_CRDS: ""
 kind: ConfigMap
 metadata:
@@ -1422,7 +1422,7 @@ metadata:
   name: devzero-zxporter-devzero-zxporter-token
   namespace: devzero-system
 stringData:
-  CLUSTER_TOKEN: '{{ .cluster_token }}'
+  CLUSTER_TOKEN: ""
 type: Opaque
 ---
 apiVersion: v1
@@ -1504,6 +1504,12 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: metadata.namespace
+            - name: CLUSTER_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  key: CLUSTER_TOKEN
+                  name: devzero-zxporter-devzero-zxporter-token
+                  optional: true
           image: docker.io/devzeroinc/zxporter:latest
           livenessProbe:
             httpGet:

--- a/dist/collection_bundle.yaml
+++ b/dist/collection_bundle.yaml
@@ -3,7 +3,7 @@ apiVersion: devzero.io/v1
 kind: CollectionPolicy
 metadata:
   name: default-policy
-  namespace: devzero-zxporter
+  namespace: devzero-system
 spec:
   targetSelector:
     namespaces: [] # Empty means all namespaces

--- a/dist/env_configmap.yaml
+++ b/dist/env_configmap.yaml
@@ -48,4 +48,4 @@ data:
 kind: ConfigMap
 metadata:
   name: devzero-zxporter-env-config
-  namespace: devzero-zxporter
+  namespace: devzero-system

--- a/dist/install.yaml
+++ b/dist/install.yaml
@@ -12,7 +12,7 @@ metadata:
   labels:
     control-plane: controller-manager
     app.kubernetes.io/name: devzero-zxporter
-  name: devzero-zxporter
+  name: devzero-system
 # ----- START PROM SERVER -----
 ---
 # Source: prometheus/charts/kube-state-metrics/templates/serviceaccount.yaml
@@ -826,7 +826,7 @@ metadata:
     app.kubernetes.io/managed-by: kustomize
     app.kubernetes.io/name: devzero-zxporter
     control-plane: controller-manager
-  name: devzero-zxporter
+  name: devzero-system
 ---
 apiVersion: v1
 kind: ServiceAccount
@@ -1408,7 +1408,7 @@ data:
   KUBE_CONTEXT_NAME: '{{ .kube_context_name }}'
   MASK_SECRET_DATA: ""
   NODE_METRICS_INTERVAL: ""
-  PROMETHEUS_URL: http://prometheus-dz-prometheus-server.devzero-zxporter.svc.cluster.local:80
+  PROMETHEUS_URL: http://prometheus-dz-prometheus-server.devzero-system.svc.cluster.local:80
   TARGET_NAMESPACES: ""
   TOKEN_CONFIGMAP_NAME: devzero-zxporter-env-config
   TOKEN_CREDENTIALS_SECRET_NAME: devzero-zxporter-credentials

--- a/dist/install.yaml
+++ b/dist/install.yaml
@@ -1427,7 +1427,7 @@ metadata:
   name: devzero-zxporter-devzero-zxporter-token
   namespace: devzero-system
 stringData:
-  CLUSTER_TOKEN: '{{ .cluster_token }}'
+  CLUSTER_TOKEN: ""
 type: Opaque
 ---
 apiVersion: v1
@@ -1509,6 +1509,12 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
+        - name: CLUSTER_TOKEN
+          valueFrom:
+            secretKeyRef:
+              key: CLUSTER_TOKEN
+              name: devzero-zxporter-devzero-zxporter-token
+              optional: true
         image: ttl.sh/zxporter:latest
         livenessProbe:
           httpGet:

--- a/dist/install.yaml
+++ b/dist/install.yaml
@@ -1006,7 +1006,7 @@ rules:
 - apiGroups:
   - ""
   resourceNames:
-  - devzero-zxporter-devzero-zxporter-token
+  - devzero-zxporter-token
   resources:
   - secrets
   verbs:
@@ -1424,7 +1424,7 @@ metadata:
 apiVersion: v1
 kind: Secret
 metadata:
-  name: devzero-zxporter-devzero-zxporter-token
+  name: devzero-zxporter-token
   namespace: devzero-system
 stringData:
   CLUSTER_TOKEN: ""
@@ -1513,7 +1513,7 @@ spec:
           valueFrom:
             secretKeyRef:
               key: CLUSTER_TOKEN
-              name: devzero-zxporter-devzero-zxporter-token
+              name: devzero-zxporter-token
               optional: true
         image: ttl.sh/zxporter:latest
         livenessProbe:

--- a/dist/install.yaml
+++ b/dist/install.yaml
@@ -29,7 +29,7 @@ metadata:
     app.kubernetes.io/instance: prometheus
     app.kubernetes.io/version: "2.15.0"
   name: prometheus-kube-state-metrics
-  namespace: devzero-zxporter
+  namespace: devzero-system
 ---
 # Source: prometheus/templates/serviceaccount.yaml
 apiVersion: v1
@@ -43,7 +43,7 @@ metadata:
     helm.sh/chart: prometheus-27.20.0
     app.kubernetes.io/part-of: dz-prometheus
   name: prometheus-dz-prometheus-server
-  namespace: devzero-zxporter
+  namespace: devzero-system
   annotations:
     {}
 ---
@@ -59,7 +59,7 @@ metadata:
     helm.sh/chart: prometheus-27.20.0
     app.kubernetes.io/part-of: dz-prometheus
   name: prometheus-dz-prometheus-server
-  namespace: devzero-zxporter
+  namespace: devzero-system
 data:
   allow-snippet-annotations: "false"
   alerting_rules.yml: |
@@ -338,7 +338,7 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: prometheus-kube-state-metrics
-  namespace: devzero-zxporter
+  namespace: devzero-system
 ---
 # Source: prometheus/templates/clusterrolebinding.yaml
 apiVersion: rbac.authorization.k8s.io/v1
@@ -355,7 +355,7 @@ metadata:
 subjects:
   - kind: ServiceAccount
     name: prometheus-dz-prometheus-server
-    namespace: devzero-zxporter
+    namespace: devzero-system
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
@@ -366,7 +366,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: prometheus-kube-state-metrics
-  namespace: devzero-zxporter
+  namespace: devzero-system
   labels:    
     helm.sh/chart: kube-state-metrics-5.33.2
     app.kubernetes.io/managed-by: Helm
@@ -401,7 +401,7 @@ metadata:
     helm.sh/chart: prometheus-27.20.0
     app.kubernetes.io/part-of: dz-prometheus
   name: prometheus-dz-prometheus-server
-  namespace: devzero-zxporter
+  namespace: devzero-system
 spec:
   ports:
     - name: http
@@ -420,7 +420,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: prometheus-kube-state-metrics
-  namespace: devzero-zxporter
+  namespace: devzero-system
   labels:    
     helm.sh/chart: kube-state-metrics-5.33.2
     app.kubernetes.io/managed-by: Helm
@@ -517,7 +517,7 @@ metadata:
     helm.sh/chart: prometheus-27.20.0
     app.kubernetes.io/part-of: dz-prometheus
   name: prometheus-dz-prometheus-server
-  namespace: devzero-zxporter
+  namespace: devzero-system
 spec:
   selector:
     matchLabels:
@@ -642,7 +642,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: dz-prometheus-node-exporter
-  namespace: devzero-zxporter
+  namespace: devzero-system
   labels:
     helm.sh/chart: prometheus-node-exporter-4.47.0
     app.kubernetes.io/managed-by: Helm
@@ -658,7 +658,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: dz-prometheus-node-exporter
-  namespace: devzero-zxporter
+  namespace: devzero-system
   labels:
     helm.sh/chart: prometheus-node-exporter-4.47.0
     app.kubernetes.io/managed-by: Helm
@@ -685,7 +685,7 @@ apiVersion: apps/v1
 kind: DaemonSet
 metadata:
   name: dz-prometheus-node-exporter
-  namespace: devzero-zxporter
+  namespace: devzero-system
   labels:
     helm.sh/chart: prometheus-node-exporter-4.47.0
     app.kubernetes.io/managed-by: Helm
@@ -835,7 +835,7 @@ metadata:
     app.kubernetes.io/managed-by: kustomize
     app.kubernetes.io/name: devzero-zxporter
   name: devzero-zxporter-controller-manager
-  namespace: devzero-zxporter
+  namespace: devzero-system
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
@@ -844,7 +844,7 @@ metadata:
     app.kubernetes.io/managed-by: kustomize
     app.kubernetes.io/name: devzero-zxporter
   name: devzero-zxporter-leader-election-role
-  namespace: devzero-zxporter
+  namespace: devzero-system
 rules:
 - apiGroups:
   - ""
@@ -1326,7 +1326,7 @@ metadata:
     app.kubernetes.io/managed-by: kustomize
     app.kubernetes.io/name: devzero-zxporter
   name: devzero-zxporter-leader-election-rolebinding
-  namespace: devzero-zxporter
+  namespace: devzero-system
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
@@ -1334,7 +1334,7 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: devzero-zxporter-controller-manager
-  namespace: devzero-zxporter
+  namespace: devzero-system
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
@@ -1350,7 +1350,7 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: devzero-zxporter-controller-manager
-  namespace: devzero-zxporter
+  namespace: devzero-system
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
@@ -1363,7 +1363,7 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: devzero-zxporter-controller-manager
-  namespace: devzero-zxporter
+  namespace: devzero-system
 ---
 apiVersion: v1
 data:
@@ -1419,13 +1419,13 @@ data:
 kind: ConfigMap
 metadata:
   name: devzero-zxporter-env-config
-  namespace: devzero-zxporter
+  namespace: devzero-system
 ---
 apiVersion: v1
 kind: Secret
 metadata:
   name: devzero-zxporter-devzero-zxporter-token
-  namespace: devzero-zxporter
+  namespace: devzero-system
 stringData:
   CLUSTER_TOKEN: '{{ .cluster_token }}'
 type: Opaque
@@ -1438,7 +1438,7 @@ metadata:
     app.kubernetes.io/name: devzero-zxporter
     control-plane: controller-manager
   name: devzero-zxporter-controller-manager-metrics-service
-  namespace: devzero-zxporter
+  namespace: devzero-system
 spec:
   ports:
   - name: https
@@ -1455,7 +1455,7 @@ metadata:
     app.kubernetes.io/name: devzero-zxporter
     control-plane: controller-manager
   name: devzero-zxporter-controller-manager-mpa
-  namespace: devzero-zxporter
+  namespace: devzero-system
 spec:
   ports:
   - name: mpa-grpc
@@ -1483,7 +1483,7 @@ metadata:
     app.kubernetes.io/name: devzero-zxporter
     control-plane: controller-manager
   name: devzero-zxporter-controller-manager
-  namespace: devzero-zxporter
+  namespace: devzero-system
 spec:
   replicas: 2
   selector:
@@ -1554,7 +1554,7 @@ apiVersion: policy/v1
 kind: PodDisruptionBudget
 metadata:
   name: devzero-zxporter-devzero-zxporter-pdb
-  namespace: devzero-zxporter
+  namespace: devzero-system
 spec:
   minAvailable: 1
   selector:

--- a/dist/install.yaml
+++ b/dist/install.yaml
@@ -1368,7 +1368,7 @@ subjects:
 apiVersion: v1
 data:
   BUFFER_SIZE: ""
-  CLUSTER_TOKEN: '{{ .cluster_token }}'
+  CLUSTER_TOKEN: ""
   COLLECTION_FREQUENCY: ""
   DAKR_URL: https://dakr.devzero.io
   DISABLE_NETWORK_IO_METRICS: ""
@@ -1414,7 +1414,7 @@ data:
   TOKEN_CREDENTIALS_SECRET_NAME: devzero-zxporter-credentials
   TOKEN_RUNTIME_SECRET_NAME: devzero-zxporter-token
   TOKEN_SECRET_NAME: devzero-zxporter-token
-  USE_SECRET_FOR_TOKEN: "false"
+  USE_SECRET_FOR_TOKEN: "true"
   WATCHED_CRDS: ""
 kind: ConfigMap
 metadata:

--- a/dist/install.yaml
+++ b/dist/install.yaml
@@ -11,7 +11,7 @@ kind: Namespace
 metadata:
   labels:
     control-plane: controller-manager
-    app.kubernetes.io/name: devzero-zxporter
+    app.kubernetes.io/name: devzero-system
   name: devzero-system
 # ----- START PROM SERVER -----
 ---

--- a/dist/installer_updater.yaml
+++ b/dist/installer_updater.yaml
@@ -11,8 +11,8 @@ kind: Namespace
 metadata:
   labels:
     control-plane: controller-manager
-    app.kubernetes.io/name: devzero-zxporter
-  name: devzero-zxporter
+    app.kubernetes.io/name: devzero-system
+  name: devzero-system
 # ----- START PROM SERVER -----
 ---
 # Source: prometheus/charts/kube-state-metrics/templates/serviceaccount.yaml
@@ -821,7 +821,7 @@ metadata:
     app.kubernetes.io/managed-by: kustomize
     app.kubernetes.io/name: devzero-zxporter
     control-plane: controller-manager
-  name: devzero-zxporter
+  name: devzero-system
 ---
 apiVersion: v1
 kind: ServiceAccount
@@ -1366,7 +1366,7 @@ metadata:
   name: devzero-zxporter-devzero-zxporter-token
   namespace: devzero-system
 stringData:
-  CLUSTER_TOKEN: '{{ .cluster_token }}'
+  CLUSTER_TOKEN: ""
 type: Opaque
 ---
 apiVersion: v1
@@ -1448,6 +1448,12 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: metadata.namespace
+            - name: CLUSTER_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  key: CLUSTER_TOKEN
+                  name: devzero-zxporter-devzero-zxporter-token
+                  optional: true
           image: docker.io/devzeroinc/zxporter:latest
           livenessProbe:
             httpGet:

--- a/dist/installer_updater.yaml
+++ b/dist/installer_updater.yaml
@@ -29,7 +29,7 @@ metadata:
     app.kubernetes.io/instance: prometheus
     app.kubernetes.io/version: "2.15.0"
   name: prometheus-kube-state-metrics
-  namespace: devzero-zxporter
+  namespace: devzero-system
 ---
 # Source: prometheus/templates/serviceaccount.yaml
 apiVersion: v1
@@ -43,7 +43,7 @@ metadata:
     helm.sh/chart: prometheus-27.20.0
     app.kubernetes.io/part-of: dz-prometheus
   name: prometheus-dz-prometheus-server
-  namespace: devzero-zxporter
+  namespace: devzero-system
   annotations: {}
 ---
 # Source: prometheus/templates/cm.yaml
@@ -58,7 +58,7 @@ metadata:
     helm.sh/chart: prometheus-27.20.0
     app.kubernetes.io/part-of: dz-prometheus
   name: prometheus-dz-prometheus-server
-  namespace: devzero-zxporter
+  namespace: devzero-system
 data:
   allow-snippet-annotations: "false"
   alerting_rules.yml: |
@@ -336,7 +336,7 @@ roleRef:
 subjects:
   - kind: ServiceAccount
     name: prometheus-kube-state-metrics
-    namespace: devzero-zxporter
+    namespace: devzero-system
 ---
 # Source: prometheus/templates/clusterrolebinding.yaml
 apiVersion: rbac.authorization.k8s.io/v1
@@ -353,7 +353,7 @@ metadata:
 subjects:
   - kind: ServiceAccount
     name: prometheus-dz-prometheus-server
-    namespace: devzero-zxporter
+    namespace: devzero-system
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
@@ -364,7 +364,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: prometheus-kube-state-metrics
-  namespace: devzero-zxporter
+  namespace: devzero-system
   labels:
     helm.sh/chart: kube-state-metrics-5.33.2
     app.kubernetes.io/managed-by: Helm
@@ -398,7 +398,7 @@ metadata:
     helm.sh/chart: prometheus-27.20.0
     app.kubernetes.io/part-of: dz-prometheus
   name: prometheus-dz-prometheus-server
-  namespace: devzero-zxporter
+  namespace: devzero-system
 spec:
   ports:
     - name: http
@@ -417,7 +417,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: prometheus-kube-state-metrics
-  namespace: devzero-zxporter
+  namespace: devzero-system
   labels:
     helm.sh/chart: kube-state-metrics-5.33.2
     app.kubernetes.io/managed-by: Helm
@@ -514,7 +514,7 @@ metadata:
     helm.sh/chart: prometheus-27.20.0
     app.kubernetes.io/part-of: dz-prometheus
   name: prometheus-dz-prometheus-server
-  namespace: devzero-zxporter
+  namespace: devzero-system
 spec:
   selector:
     matchLabels:
@@ -637,7 +637,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: dz-prometheus-node-exporter
-  namespace: devzero-zxporter
+  namespace: devzero-system
   labels:
     helm.sh/chart: prometheus-node-exporter-4.47.0
     app.kubernetes.io/managed-by: Helm
@@ -653,7 +653,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: dz-prometheus-node-exporter
-  namespace: devzero-zxporter
+  namespace: devzero-system
   labels:
     helm.sh/chart: prometheus-node-exporter-4.47.0
     app.kubernetes.io/managed-by: Helm
@@ -680,7 +680,7 @@ apiVersion: apps/v1
 kind: DaemonSet
 metadata:
   name: dz-prometheus-node-exporter
-  namespace: devzero-zxporter
+  namespace: devzero-system
   labels:
     helm.sh/chart: prometheus-node-exporter-4.47.0
     app.kubernetes.io/managed-by: Helm
@@ -830,7 +830,7 @@ metadata:
     app.kubernetes.io/managed-by: kustomize
     app.kubernetes.io/name: devzero-zxporter
   name: devzero-zxporter-controller-manager
-  namespace: devzero-zxporter
+  namespace: devzero-system
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
@@ -839,7 +839,7 @@ metadata:
     app.kubernetes.io/managed-by: kustomize
     app.kubernetes.io/name: devzero-zxporter
   name: devzero-zxporter-leader-election-role
-  namespace: devzero-zxporter
+  namespace: devzero-system
 rules:
   - apiGroups:
       - ""
@@ -1321,7 +1321,7 @@ metadata:
     app.kubernetes.io/managed-by: kustomize
     app.kubernetes.io/name: devzero-zxporter
   name: devzero-zxporter-leader-election-rolebinding
-  namespace: devzero-zxporter
+  namespace: devzero-system
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
@@ -1329,7 +1329,7 @@ roleRef:
 subjects:
   - kind: ServiceAccount
     name: devzero-zxporter-controller-manager
-    namespace: devzero-zxporter
+    namespace: devzero-system
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
@@ -1345,7 +1345,7 @@ roleRef:
 subjects:
   - kind: ServiceAccount
     name: devzero-zxporter-controller-manager
-    namespace: devzero-zxporter
+    namespace: devzero-system
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
@@ -1358,13 +1358,13 @@ roleRef:
 subjects:
   - kind: ServiceAccount
     name: devzero-zxporter-controller-manager
-    namespace: devzero-zxporter
+    namespace: devzero-system
 ---
 apiVersion: v1
 kind: Secret
 metadata:
   name: devzero-zxporter-devzero-zxporter-token
-  namespace: devzero-zxporter
+  namespace: devzero-system
 stringData:
   CLUSTER_TOKEN: '{{ .cluster_token }}'
 type: Opaque
@@ -1377,7 +1377,7 @@ metadata:
     app.kubernetes.io/name: devzero-zxporter
     control-plane: controller-manager
   name: devzero-zxporter-controller-manager-metrics-service
-  namespace: devzero-zxporter
+  namespace: devzero-system
 spec:
   ports:
     - name: https
@@ -1394,7 +1394,7 @@ metadata:
     app.kubernetes.io/name: devzero-zxporter
     control-plane: controller-manager
   name: devzero-zxporter-controller-manager-mpa
-  namespace: devzero-zxporter
+  namespace: devzero-system
 spec:
   ports:
     - name: mpa-grpc
@@ -1422,7 +1422,7 @@ metadata:
     app.kubernetes.io/name: devzero-zxporter
     control-plane: controller-manager
   name: devzero-zxporter-controller-manager
-  namespace: devzero-zxporter
+  namespace: devzero-system
 spec:
   replicas: 2
   selector:
@@ -1493,7 +1493,7 @@ apiVersion: policy/v1
 kind: PodDisruptionBudget
 metadata:
   name: devzero-zxporter-devzero-zxporter-pdb
-  namespace: devzero-zxporter
+  namespace: devzero-system
 spec:
   minAvailable: 1
   selector:

--- a/dist/installer_updater.yaml
+++ b/dist/installer_updater.yaml
@@ -1001,7 +1001,7 @@ rules:
   - apiGroups:
       - ""
     resourceNames:
-      - devzero-zxporter-devzero-zxporter-token
+      - devzero-zxporter-token
     resources:
       - secrets
     verbs:
@@ -1363,10 +1363,10 @@ subjects:
 apiVersion: v1
 kind: Secret
 metadata:
-  name: devzero-zxporter-devzero-zxporter-token
+  name: devzero-zxporter-token
   namespace: devzero-system
 stringData:
-  CLUSTER_TOKEN: ""
+  CLUSTER_TOKEN: "{{ .cluster_token }}"
 type: Opaque
 ---
 apiVersion: v1
@@ -1452,7 +1452,7 @@ spec:
               valueFrom:
                 secretKeyRef:
                   key: CLUSTER_TOKEN
-                  name: devzero-zxporter-devzero-zxporter-token
+                  name: devzero-zxporter-token
                   optional: true
           image: docker.io/devzeroinc/zxporter:latest
           livenessProbe:

--- a/dist/metrics-server.yaml
+++ b/dist/metrics-server.yaml
@@ -4,7 +4,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: dz-metrics-server
-  namespace: devzero-zxporter
+  namespace: devzero-system
   labels:
     helm.sh/chart: metrics-server-3.12.2
     app.kubernetes.io/name: dz-metrics-server
@@ -85,7 +85,7 @@ roleRef:
 subjects:
   - kind: ServiceAccount
     name: dz-metrics-server
-    namespace: devzero-zxporter
+    namespace: devzero-system
 ---
 # Source: metrics-server/templates/clusterrolebinding.yaml
 apiVersion: rbac.authorization.k8s.io/v1
@@ -105,7 +105,7 @@ roleRef:
 subjects:
   - kind: ServiceAccount
     name: dz-metrics-server
-    namespace: devzero-zxporter
+    namespace: devzero-system
 ---
 # Source: metrics-server/templates/rolebinding.yaml
 apiVersion: rbac.authorization.k8s.io/v1
@@ -126,14 +126,14 @@ roleRef:
 subjects:
   - kind: ServiceAccount
     name: dz-metrics-server
-    namespace: devzero-zxporter
+    namespace: devzero-system
 ---
 # Source: metrics-server/templates/service.yaml
 apiVersion: v1
 kind: Service
 metadata:
   name: dz-metrics-server
-  namespace: devzero-zxporter
+  namespace: devzero-system
   labels:
     helm.sh/chart: metrics-server-3.12.2
     app.kubernetes.io/name: dz-metrics-server
@@ -157,7 +157,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: dz-metrics-server
-  namespace: devzero-zxporter
+  namespace: devzero-system
   labels:
     helm.sh/chart: metrics-server-3.12.2
     app.kubernetes.io/name: dz-metrics-server
@@ -247,7 +247,7 @@ spec:
   insecureSkipTLSVerify: true
   service:
     name: dz-metrics-server
-    namespace: devzero-zxporter
+    namespace: devzero-system
     port: 443
   version: v1beta1
   versionPriority: 100

--- a/dist/node-exporter.yaml
+++ b/dist/node-exporter.yaml
@@ -4,7 +4,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: dz-prometheus-node-exporter
-  namespace: devzero-zxporter
+  namespace: devzero-system
   labels:
     helm.sh/chart: prometheus-node-exporter-4.47.0
     app.kubernetes.io/managed-by: Helm
@@ -20,7 +20,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: dz-prometheus-node-exporter
-  namespace: devzero-zxporter
+  namespace: devzero-system
   labels:
     helm.sh/chart: prometheus-node-exporter-4.47.0
     app.kubernetes.io/managed-by: Helm
@@ -47,7 +47,7 @@ apiVersion: apps/v1
 kind: DaemonSet
 metadata:
   name: dz-prometheus-node-exporter
-  namespace: devzero-zxporter
+  namespace: devzero-system
   labels:
     helm.sh/chart: prometheus-node-exporter-4.47.0
     app.kubernetes.io/managed-by: Helm

--- a/dist/prometheus.yaml
+++ b/dist/prometheus.yaml
@@ -13,7 +13,7 @@ metadata:
     app.kubernetes.io/instance: prometheus
     app.kubernetes.io/version: "2.15.0"
   name: prometheus-kube-state-metrics
-  namespace: devzero-zxporter
+  namespace: devzero-system
 ---
 # Source: prometheus/templates/serviceaccount.yaml
 apiVersion: v1
@@ -27,7 +27,7 @@ metadata:
     helm.sh/chart: prometheus-27.20.0
     app.kubernetes.io/part-of: dz-prometheus
   name: prometheus-dz-prometheus-server
-  namespace: devzero-zxporter
+  namespace: devzero-system
   annotations:
     {}
 ---
@@ -43,7 +43,7 @@ metadata:
     helm.sh/chart: prometheus-27.20.0
     app.kubernetes.io/part-of: dz-prometheus
   name: prometheus-dz-prometheus-server
-  namespace: devzero-zxporter
+  namespace: devzero-system
 data:
   allow-snippet-annotations: "false"
   alerting_rules.yml: |
@@ -322,7 +322,7 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: prometheus-kube-state-metrics
-  namespace: devzero-zxporter
+  namespace: devzero-system
 ---
 # Source: prometheus/templates/clusterrolebinding.yaml
 apiVersion: rbac.authorization.k8s.io/v1
@@ -339,7 +339,7 @@ metadata:
 subjects:
   - kind: ServiceAccount
     name: prometheus-dz-prometheus-server
-    namespace: devzero-zxporter
+    namespace: devzero-system
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
@@ -350,7 +350,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: prometheus-kube-state-metrics
-  namespace: devzero-zxporter
+  namespace: devzero-system
   labels:    
     helm.sh/chart: kube-state-metrics-5.33.2
     app.kubernetes.io/managed-by: Helm
@@ -385,7 +385,7 @@ metadata:
     helm.sh/chart: prometheus-27.20.0
     app.kubernetes.io/part-of: dz-prometheus
   name: prometheus-dz-prometheus-server
-  namespace: devzero-zxporter
+  namespace: devzero-system
 spec:
   ports:
     - name: http
@@ -404,7 +404,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: prometheus-kube-state-metrics
-  namespace: devzero-zxporter
+  namespace: devzero-system
   labels:    
     helm.sh/chart: kube-state-metrics-5.33.2
     app.kubernetes.io/managed-by: Helm
@@ -501,7 +501,7 @@ metadata:
     helm.sh/chart: prometheus-27.20.0
     app.kubernetes.io/part-of: dz-prometheus
   name: prometheus-dz-prometheus-server
-  namespace: devzero-zxporter
+  namespace: devzero-system
 spec:
   selector:
     matchLabels:

--- a/dist/zxporter.yaml
+++ b/dist/zxporter.yaml
@@ -185,7 +185,7 @@ rules:
 - apiGroups:
   - ""
   resourceNames:
-  - devzero-zxporter-devzero-zxporter-token
+  - devzero-zxporter-token
   resources:
   - secrets
   verbs:
@@ -603,7 +603,7 @@ metadata:
 apiVersion: v1
 kind: Secret
 metadata:
-  name: devzero-zxporter-devzero-zxporter-token
+  name: devzero-zxporter-token
   namespace: devzero-system
 stringData:
   CLUSTER_TOKEN: ""
@@ -692,7 +692,7 @@ spec:
           valueFrom:
             secretKeyRef:
               key: CLUSTER_TOKEN
-              name: devzero-zxporter-devzero-zxporter-token
+              name: devzero-zxporter-token
               optional: true
         image: ttl.sh/zxporter:latest
         livenessProbe:

--- a/dist/zxporter.yaml
+++ b/dist/zxporter.yaml
@@ -14,7 +14,7 @@ metadata:
     app.kubernetes.io/managed-by: kustomize
     app.kubernetes.io/name: devzero-zxporter
   name: devzero-zxporter-controller-manager
-  namespace: devzero-zxporter
+  namespace: devzero-system
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
@@ -23,7 +23,7 @@ metadata:
     app.kubernetes.io/managed-by: kustomize
     app.kubernetes.io/name: devzero-zxporter
   name: devzero-zxporter-leader-election-role
-  namespace: devzero-zxporter
+  namespace: devzero-system
 rules:
 - apiGroups:
   - ""
@@ -505,7 +505,7 @@ metadata:
     app.kubernetes.io/managed-by: kustomize
     app.kubernetes.io/name: devzero-zxporter
   name: devzero-zxporter-leader-election-rolebinding
-  namespace: devzero-zxporter
+  namespace: devzero-system
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
@@ -513,7 +513,7 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: devzero-zxporter-controller-manager
-  namespace: devzero-zxporter
+  namespace: devzero-system
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
@@ -529,7 +529,7 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: devzero-zxporter-controller-manager
-  namespace: devzero-zxporter
+  namespace: devzero-system
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
@@ -542,7 +542,7 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: devzero-zxporter-controller-manager
-  namespace: devzero-zxporter
+  namespace: devzero-system
 ---
 apiVersion: v1
 data:
@@ -598,13 +598,13 @@ data:
 kind: ConfigMap
 metadata:
   name: devzero-zxporter-env-config
-  namespace: devzero-zxporter
+  namespace: devzero-system
 ---
 apiVersion: v1
 kind: Secret
 metadata:
   name: devzero-zxporter-devzero-zxporter-token
-  namespace: devzero-zxporter
+  namespace: devzero-system
 stringData:
   CLUSTER_TOKEN: '{{ .cluster_token }}'
 type: Opaque
@@ -617,7 +617,7 @@ metadata:
     app.kubernetes.io/name: devzero-zxporter
     control-plane: controller-manager
   name: devzero-zxporter-controller-manager-metrics-service
-  namespace: devzero-zxporter
+  namespace: devzero-system
 spec:
   ports:
   - name: https
@@ -634,7 +634,7 @@ metadata:
     app.kubernetes.io/name: devzero-zxporter
     control-plane: controller-manager
   name: devzero-zxporter-controller-manager-mpa
-  namespace: devzero-zxporter
+  namespace: devzero-system
 spec:
   ports:
   - name: mpa-grpc
@@ -662,7 +662,7 @@ metadata:
     app.kubernetes.io/name: devzero-zxporter
     control-plane: controller-manager
   name: devzero-zxporter-controller-manager
-  namespace: devzero-zxporter
+  namespace: devzero-system
 spec:
   replicas: 2
   selector:
@@ -733,7 +733,7 @@ apiVersion: policy/v1
 kind: PodDisruptionBudget
 metadata:
   name: devzero-zxporter-devzero-zxporter-pdb
-  namespace: devzero-zxporter
+  namespace: devzero-system
 spec:
   minAvailable: 1
   selector:

--- a/dist/zxporter.yaml
+++ b/dist/zxporter.yaml
@@ -5,7 +5,7 @@ metadata:
     app.kubernetes.io/managed-by: kustomize
     app.kubernetes.io/name: devzero-zxporter
     control-plane: controller-manager
-  name: devzero-zxporter
+  name: devzero-system
 ---
 apiVersion: v1
 kind: ServiceAccount
@@ -547,7 +547,7 @@ subjects:
 apiVersion: v1
 data:
   BUFFER_SIZE: ""
-  CLUSTER_TOKEN: '{{ .cluster_token }}'
+  CLUSTER_TOKEN: ""
   COLLECTION_FREQUENCY: ""
   DAKR_URL: https://dakr.devzero.io
   DISABLE_NETWORK_IO_METRICS: ""
@@ -587,13 +587,13 @@ data:
   KUBE_CONTEXT_NAME: '{{ .kube_context_name }}'
   MASK_SECRET_DATA: ""
   NODE_METRICS_INTERVAL: ""
-  PROMETHEUS_URL: http://prometheus-dz-prometheus-server.devzero-zxporter.svc.cluster.local:80
+  PROMETHEUS_URL: http://prometheus-dz-prometheus-server.devzero-system.svc.cluster.local:80
   TARGET_NAMESPACES: ""
   TOKEN_CONFIGMAP_NAME: devzero-zxporter-env-config
   TOKEN_CREDENTIALS_SECRET_NAME: devzero-zxporter-credentials
   TOKEN_RUNTIME_SECRET_NAME: devzero-zxporter-token
   TOKEN_SECRET_NAME: devzero-zxporter-token
-  USE_SECRET_FOR_TOKEN: "false"
+  USE_SECRET_FOR_TOKEN: "true"
   WATCHED_CRDS: ""
 kind: ConfigMap
 metadata:
@@ -606,7 +606,7 @@ metadata:
   name: devzero-zxporter-devzero-zxporter-token
   namespace: devzero-system
 stringData:
-  CLUSTER_TOKEN: '{{ .cluster_token }}'
+  CLUSTER_TOKEN: ""
 type: Opaque
 ---
 apiVersion: v1
@@ -688,6 +688,12 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
+        - name: CLUSTER_TOKEN
+          valueFrom:
+            secretKeyRef:
+              key: CLUSTER_TOKEN
+              name: devzero-zxporter-devzero-zxporter-token
+              optional: true
         image: ttl.sh/zxporter:latest
         livenessProbe:
           httpGet:

--- a/docs/nodemon.md
+++ b/docs/nodemon.md
@@ -19,7 +19,7 @@ The Nodemon scrapes metrics from NVIDIA DCGM (Data Center GPU Manager) exporters
 
 ```bash
 helm install zxporter-nodemon helm-chart/zxporter-nodemon \
-  --namespace devzero-zxporter --create-namespace \
+  --namespace devzero-system --create-namespace \
   --set provider=gcp \
   --set dcgmExporter.enabled=true
 ```
@@ -28,7 +28,7 @@ helm install zxporter-nodemon helm-chart/zxporter-nodemon \
 
 ```bash
 helm install zxporter-nodemon helm-chart/zxporter-nodemon \
-  --namespace devzero-zxporter --create-namespace \
+  --namespace devzero-system --create-namespace \
   --set provider=gcp \
   --set dcgmExporter.enabled=false \
   --set gpuMetricsExporter.config.DCGM_LABELS="app.kubernetes.io/name=dcgm-exporter"
@@ -214,7 +214,7 @@ curl http://<pod-ip>:6061/healthz
 
 ```bash
 # Check DCGM exporter logs
-kubectl logs -n devzero-zxporter <pod-name> -c dcgm-exporter
+kubectl logs -n devzero-system <pod-name> -c dcgm-exporter
 
 # Common issues:
 # - "Could not load NVML library" → NVIDIA drivers not installed
@@ -225,18 +225,18 @@ kubectl logs -n devzero-zxporter <pod-name> -c dcgm-exporter
 
 ```bash
 # Verify DCGM exporter is accessible
-kubectl exec -n devzero-zxporter <nodemon-pod> -- \
+kubectl exec -n devzero-system <nodemon-pod> -- \
   curl http://localhost:9400/metrics
 
 # Check nodemon logs
-kubectl logs -n devzero-zxporter <pod-name> -c zxporter-nodemon
+kubectl logs -n devzero-system <pod-name> -c zxporter-nodemon
 ```
 
 ### Pod Discovery Issues
 
 ```bash
 # Verify RBAC permissions
-kubectl auth can-i list pods --as=system:serviceaccount:devzero-zxporter:zxporter-nodemon
+kubectl auth can-i list pods --as=system:serviceaccount:devzero-system:zxporter-nodemon
 
 # Check configured labels match DCGM exporter
 kubectl get pods -A -l <your-dcgm-labels>

--- a/env_configmap.yaml
+++ b/env_configmap.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: devzero-zxporter-env-config
-  namespace: devzero-zxporter
+  namespace: devzero-system
 data:
   CLUSTER_TOKEN: "{{ .cluster_token }}"
   DAKR_URL: "$(DAKR_URL)"

--- a/helm-chart/zxporter-netmon/templates/daemonset.yaml
+++ b/helm-chart/zxporter-netmon/templates/daemonset.yaml
@@ -41,6 +41,11 @@ spec:
             - configMapRef:
                 name: {{ .Values.config.mainConfigMapName }}
                 optional: true
+            {{- if .Values.config.tokenSecretName }}
+            - secretRef:
+                name: {{ .Values.config.tokenSecretName }}
+                optional: true
+            {{- end }}
           env:
             - name: NODE_NAME
               valueFrom:

--- a/helm-chart/zxporter-netmon/values.yaml
+++ b/helm-chart/zxporter-netmon/values.yaml
@@ -63,3 +63,6 @@ config:
   collectorMode: "netfilter"
   dakrUrl: ""
   clusterToken: ""
+  # Name of the Secret containing CLUSTER_TOKEN (created by the zxporter installer).
+  # Takes precedence over the token in mainConfigMapName when present.
+  tokenSecretName: "devzero-zxporter-token"

--- a/helm-chart/zxporter/templates/deployment.yaml
+++ b/helm-chart/zxporter/templates/deployment.yaml
@@ -57,13 +57,12 @@ spec:
                 fieldRef:
                   fieldPath: metadata.namespace
           {{- if .Values.zxporter.useSecretForToken }}
-            {{- if .Values.zxporter.clusterToken }}
             - name: CLUSTER_TOKEN
               valueFrom:
                 secretKeyRef:
-                  name: {{ .Values.zxporter.tokenCredentialsSecretName }}
+                  name: {{ .Values.zxporter.tokenSecretName }}
                   key: CLUSTER_TOKEN
-            {{- end }}
+                  optional: true
             {{- if .Values.zxporter.patToken }}
             - name: PAT_TOKEN
               valueFrom:

--- a/helm-chart/zxporter/templates/secret.yaml
+++ b/helm-chart/zxporter/templates/secret.yaml
@@ -13,7 +13,8 @@ metadata:
     app.kubernetes.io/name: zxporter
     app.kubernetes.io/component: runtime-tokens
 type: Opaque
+{{- if .Values.zxporter.clusterToken }}
 data:
-  # Empty by default - will be populated by application during PAT exchange
-  # CLUSTER_TOKEN: <base64-encoded-exchanged-token>
+  CLUSTER_TOKEN: {{ .Values.zxporter.clusterToken | b64enc | quote }}
+{{- end }}
 {{- end }}

--- a/helm-chart/zxporter/values.yaml
+++ b/helm-chart/zxporter/values.yaml
@@ -16,7 +16,7 @@ image:
 # ZXPorter configuration
 zxporter:
   dakrUrl: "https://dakr.devzero.io"
-  prometheusUrl: "http://prometheus-dz-prometheus-server.devzero-zxporter.svc.cluster.local:80"
+  prometheusUrl: "http://prometheus-dz-prometheus-server.devzero-system.svc.cluster.local:80"
   targetNamespaces: ""
   # Cluster token for authentication with the DevZero platform
   # Required: Either clusterToken or patToken must be provided
@@ -45,7 +45,7 @@ zxporter:
   k8sProvider: ""
   # Set to true to store CLUSTER_TOKEN and PAT_TOKEN in Kubernetes Secrets instead of ConfigMap
   # Default is false for backward compatibility
-  useSecretForToken: false
+  useSecretForToken: true
 
   # Log level for the zxporter application
   # Valid values: debug, info, error

--- a/internal/collector/container_resource_collector.go
+++ b/internal/collector/container_resource_collector.go
@@ -179,7 +179,7 @@ func (c *ContainerResourceCollector) Start(ctx context.Context) error {
 	if !c.config.DisableGPUMetrics {
 		ns := os.Getenv("POD_NAMESPACE")
 		if ns == "" {
-			ns = "devzero-zxporter"
+			ns = "devzero-system"
 		}
 		c.nodemonClient = NewNodemonClient(c.k8sClient, ns, c.logger)
 		c.logger.Info("Initialized nodemon client (auto-discovery)", "namespace", ns)

--- a/internal/collector/node_collector.go
+++ b/internal/collector/node_collector.go
@@ -214,7 +214,7 @@ func (c *NodeCollector) Start(ctx context.Context) error {
 	if !c.config.DisableGPUMetrics {
 		ns := os.Getenv("POD_NAMESPACE")
 		if ns == "" {
-			ns = "devzero-zxporter"
+			ns = "devzero-system"
 		}
 		c.nodemonClient = NewNodemonClient(c.k8sClient, ns, c.logger)
 		c.logger.Info("Initialized nodemon client (auto-discovery)", "namespace", ns)

--- a/internal/controller/collectionpolicy_controller.go
+++ b/internal/controller/collectionpolicy_controller.go
@@ -193,7 +193,7 @@ type PolicyConfig struct {
 // +kubebuilder:rbac:groups="",resources=configmaps,verbs=get;list;watch;update
 
 // Secret access for cluster token persistence when useSecretForToken is enabled
-// +kubebuilder:rbac:groups="",resources=secrets,resourceNames=devzero-zxporter-token,verbs=get;update;patch
+// +kubebuilder:rbac:groups="",resources=secrets,resourceNames=token,verbs=get;update;patch
 // +kubebuilder:rbac:groups="",resources=secrets,verbs=create
 
 // Metrics access

--- a/internal/controller/custom.go
+++ b/internal/controller/custom.go
@@ -495,7 +495,7 @@ func (c *EnvBasedController) persistClusterTokenToConfigMap(
 			namespace = strings.TrimSpace(string(data))
 		} else {
 			// Fall back to default if all else fails
-			namespace = "devzero-zxporter"
+			namespace = "devzero-system"
 			c.Log.Info("Could not determine namespace, using default", "namespace", namespace)
 		}
 	}
@@ -548,7 +548,7 @@ func (c *EnvBasedController) persistClusterTokenToSecret(ctx context.Context, to
 			namespace = strings.TrimSpace(string(data))
 		} else {
 			// Fall back to default if all else fails
-			namespace = "devzero-zxporter"
+			namespace = "devzero-system"
 			c.Log.Info("Could not determine namespace, using default", "namespace", namespace)
 		}
 	}
@@ -646,7 +646,7 @@ func (c *EnvBasedController) readClusterTokenFromSecret(ctx context.Context) str
 			namespace = strings.TrimSpace(string(data))
 		} else {
 			// Fall back to default if all else fails
-			namespace = "devzero-zxporter"
+			namespace = "devzero-system"
 		}
 	}
 
@@ -717,7 +717,7 @@ func (c *EnvBasedController) readClusterTokenFromConfigMap(ctx context.Context) 
 			namespace = strings.TrimSpace(string(data))
 		} else {
 			// Fall back to default if all else fails
-			namespace = "devzero-zxporter"
+			namespace = "devzero-system"
 		}
 	}
 

--- a/internal/controller/custom.go
+++ b/internal/controller/custom.go
@@ -47,6 +47,8 @@ import (
 	"github.com/devzero-inc/zxporter/internal/version"
 )
 
+const defaultNamespace = "devzero-system"
+
 // EnvBasedController is a controller that uses environment variables instead of CRDs
 type EnvBasedController struct {
 	client.Client
@@ -495,7 +497,7 @@ func (c *EnvBasedController) persistClusterTokenToConfigMap(
 			namespace = strings.TrimSpace(string(data))
 		} else {
 			// Fall back to default if all else fails
-			namespace = "devzero-system"
+			namespace = defaultNamespace
 			c.Log.Info("Could not determine namespace, using default", "namespace", namespace)
 		}
 	}
@@ -548,7 +550,7 @@ func (c *EnvBasedController) persistClusterTokenToSecret(ctx context.Context, to
 			namespace = strings.TrimSpace(string(data))
 		} else {
 			// Fall back to default if all else fails
-			namespace = "devzero-system"
+			namespace = defaultNamespace
 			c.Log.Info("Could not determine namespace, using default", "namespace", namespace)
 		}
 	}
@@ -646,7 +648,7 @@ func (c *EnvBasedController) readClusterTokenFromSecret(ctx context.Context) str
 			namespace = strings.TrimSpace(string(data))
 		} else {
 			// Fall back to default if all else fails
-			namespace = "devzero-system"
+			namespace = defaultNamespace
 		}
 	}
 
@@ -717,7 +719,7 @@ func (c *EnvBasedController) readClusterTokenFromConfigMap(ctx context.Context) 
 			namespace = strings.TrimSpace(string(data))
 		} else {
 			// Fall back to default if all else fails
-			namespace = "devzero-system"
+			namespace = defaultNamespace
 		}
 	}
 

--- a/internal/controller/custom.go
+++ b/internal/controller/custom.go
@@ -398,12 +398,16 @@ func (c *EnvBasedController) initializeTelemetryComponents(ctx context.Context) 
 			}
 			c.Log.Info("Successfully obtained cluster token", "clusterId", clusterId)
 			envSpec.Policies.ClusterToken = token
+		}
+	}
 
-			// Persist the token to ConfigMap or Secret based on configuration
-			// If it fails, continue anyway - the token is in memory
-			if err := c.persistClusterToken(ctx, token); err != nil {
-				c.Log.Error(err, "Failed to persist cluster token")
-			}
+	// Persist the resolved token to the runtime Secret so other operators (dakr, trezr, etc.)
+	// can read it via secretKeyRef. This covers both direct-token installs (where the token
+	// arrives via env var from devzero-zxporter-credentials and was never written to the
+	// runtime Secret) and PAT-exchange installs. Idempotent — safe on every startup.
+	if envSpec.Policies.ClusterToken != "" && c.shouldUseSecretStorage() {
+		if err := c.persistClusterToken(ctx, envSpec.Policies.ClusterToken); err != nil {
+			c.Log.Error(err, "Failed to persist cluster token to runtime Secret")
 		}
 	}
 

--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -5,10 +5,6 @@ import (
 	"runtime"
 )
 
-const (
-	versionNamespace     = "devzero-system"
-	versionConfigMapName = "zxporter-version"
-)
 
 type Info struct {
 	Major        string `json:"major"`

--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -6,7 +6,7 @@ import (
 )
 
 const (
-	versionNamespace     = "devzero-zxporter"
+	versionNamespace     = "devzero-system"
 	versionConfigMapName = "zxporter-version"
 )
 

--- a/policy.yaml
+++ b/policy.yaml
@@ -2,7 +2,7 @@ apiVersion: devzero.io/v1
 kind: CollectionPolicy
 metadata:
   name: default-policy
-  namespace: devzero-zxporter
+  namespace: devzero-system
 spec:
   targetSelector:
     namespaces: [] # Empty means all namespaces

--- a/test/testserver/kubernetes.yaml
+++ b/test/testserver/kubernetes.yaml
@@ -2,7 +2,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: testserver
-  namespace: devzero-zxporter
+  namespace: devzero-system
   labels:
     app: testserver
 spec:
@@ -31,7 +31,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: testserver
-  namespace: devzero-zxporter
+  namespace: devzero-system
 spec:
   selector:
     app: testserver


### PR DESCRIPTION
## Summary

Migrates all namespace references from the legacy `devzero-zxporter` namespace to `devzero-system`, consolidating the zxporter stack with the rest of the DevZero operator suite.

### Changes

- **Helm chart** (`helm-chart/zxporter/values.yaml`): `prometheusUrl` DNS reference updated to `devzero-system`; `useSecretForToken` now defaults to `true`
- **Kustomize config** (`config/default/kustomization.yaml`, `config/zxporter-netmon.yaml`): Namespace updated to `devzero-system`; regenerated all `dist/` manifests accordingly
- **Go source fallback defaults**: Updated in `internal/version/version.go`, `internal/controller/custom.go`, `internal/collector/container_resource_collector.go`, `internal/collector/node_collector.go` — these are last-resort defaults used only when `POD_NAMESPACE` env var and the service account namespace file are both unavailable (e.g. local development)
- **Dev/test manifests**: `collection.yaml`, `env_configmap.yaml`, `policy.yaml`, `test/testserver/kubernetes.yaml` updated
- **Docs**: `README.md` and `docs/nodemon.md` install command examples updated

### Backward compatibility

Existing clusters that already have zxporter running in `devzero-zxporter` are unaffected — zxporter reads its own namespace at runtime from `POD_NAMESPACE` or the service account file. The Go fallback defaults only apply in environments where neither is available.

## Testing plan

- [ ] Fresh helm install with default values deploys into `devzero-system`
- [ ] `helm install zxporter ./helm-chart/zxporter --namespace devzero-system --create-namespace` succeeds and all pods come up
- [ ] Prometheus URL resolves correctly at `prometheus-dz-prometheus-server.devzero-system.svc.cluster.local`
- [ ] `kubectl apply -f dist/install.yaml` deploys all resources into `devzero-system`
- [ ] Existing install in `devzero-zxporter` continues to function without changes (namespace is read from pod runtime, not the fallback default)

----
## Summary by Gitar

- **Secret naming:**
  - Renamed the runtime secret from `devzero-zxporter-token` to `token` in `manager.yaml`, `role.yaml`, and `env_secret.yaml` to prevent Kustomize name-prefix collisions.
  - Updated `collectionpolicy_controller.go` RBAC annotations and `Makefile` bundle patching logic to reflect the renamed secret resource.


<sub>This will update automatically on new commits.</sub>