### PR TITLE
fix: add envFrom to raw netmon manifest and reduce eBPF log noise

### DIFF
--- a/config/zxporter-netmon.yaml
+++ b/config/zxporter-netmon.yaml
@@ -39,6 +39,13 @@ spec:
             - name: http
               containerPort: 8081
               protocol: TCP
+          envFrom:
+            - configMapRef:
+                name: devzero-zxporter-env-config
+                optional: true
+            - secretRef:
+                name: devzero-zxporter-token
+                optional: true
           env:
             - name: NODE_NAME
               valueFrom:

--- a/internal/networkmonitor/ebpf/tracer_linux.go
+++ b/internal/networkmonitor/ebpf/tracer_linux.go
@@ -184,7 +184,7 @@ func (t *Tracer) Run(ctx context.Context) error {
 		// Parse the full raw packet captured from eBPF
 		event, err := parseEvent(record.RawSample)
 		if err != nil {
-			t.log.Error(err, "parsing event")
+			t.log.V(1).Info("skipping non-DNS event", "err", err)
 			continue
 		}
 


### PR DESCRIPTION
## Problem

Two independent issues in zxporter-netmon:

1. **Missing credentials in raw manifest**: `config/zxporter-netmon.yaml` had no `envFrom` block, so pods deployed from the raw manifest (rather than the helm chart) never received `DAKR_URL` or `CLUSTER_TOKEN`. The helm chart already had `envFrom`; the raw manifest was left behind.

2. **eBPF log spam**: The eBPF DNS tracer logged every non-DNS packet at `Error` level. In `netfilter` mode all network packets hit the eBPF hook, producing continuous error logs for traffic that is expected and harmless.

## Changes

### `config/zxporter-netmon.yaml`
Add `envFrom` block to the DaemonSet container spec (both references optional to avoid pod startup failures when the ConfigMap/Secret are absent):
```yaml
envFrom:
  - configMapRef:
      name: devzero-zxporter-env-config
      optional: true
  - secretRef:
      name: devzero-zxporter-token
      optional: true
```

### `internal/networkmonitor/ebpf/tracer_linux.go`
Downgrade the parse-error log from `Error` to `V(1).Info` (debug level, consistent with other debug logging in the same file). Non-DNS packets hitting the hook are expected and not actionable.

## Test plan
- [ ] Apply `config/zxporter-netmon.yaml` to a cluster, verify pod starts and `kubectl exec -- env | grep -E 'DAKR_URL|CLUSTER_TOKEN'` returns values
- [ ] With eBPF collector mode, confirm `kubectl logs ds/zxporter-netmon | grep "parsing event"` returns nothing