### PR TITLE
Add periodic checks for Prometheus + add telemetry

### DIFF
--- a/internal/controller/collectionpolicy_controller.go
+++ b/internal/controller/collectionpolicy_controller.go
@@ -4038,11 +4038,7 @@ func (r *CollectionPolicyReconciler) waitForPrometheusAvailability(
 		Transport: tr,
 	}
 
-	// Endpoint to verify prometheus is ready
-	healthEndpoint := fmt.Sprintf("%s/-/ready", prometheusURL)
-	if !strings.HasPrefix(prometheusURL, "http") {
-		healthEndpoint = fmt.Sprintf("http://%s/-/ready", prometheusURL)
-	}
+	healthEndpoint := prometheusHealthEndpoint(prometheusURL)
 
 	for i := 0; i < maxRetries; i++ {
 		select {
@@ -4209,16 +4205,23 @@ func (r *CollectionPolicyReconciler) startPeriodicPrometheusHealthCheck(url stri
 		return
 	}
 
-	endpoint := url + "/-/ready"
-	if !strings.HasPrefix(url, "http") {
-		endpoint = "http://" + url + "/-/ready"
-	}
+	endpoint := prometheusHealthEndpoint(url)
 	ctx, cancel := context.WithCancel(context.Background())
 	done := make(chan struct{})
 	r.prometheusProbeCancel = cancel
 	r.prometheusProbeDone = done
 
 	go r.runPrometheusProbe(ctx, done, url, endpoint)
+}
+
+// prometheusHealthEndpoint returns the full /-/ready URL, defaulting to http://
+// when the caller passed a bare host:port. Shared by waitForPrometheusAvailability
+// and the periodic probe so both build the same endpoint from the same input.
+func prometheusHealthEndpoint(url string) string {
+	if !strings.HasPrefix(url, "http") {
+		return "http://" + url + "/-/ready"
+	}
+	return url + "/-/ready"
 }
 
 // probeStillAliveLocked returns true if the existing probe goroutine is still
@@ -4246,7 +4249,11 @@ func (r *CollectionPolicyReconciler) runPrometheusProbe(ctx context.Context, don
 		}
 	}()
 
-	client := &http.Client{Timeout: 5 * time.Second}
+	// Clone DefaultTransport so the probe inherits proxy/TLS settings (matches
+	// waitForPrometheusAvailability). Re-using DefaultTransport directly would
+	// share the connection pool with every other consumer in the binary.
+	tr := http.DefaultTransport.(*http.Transport).Clone()
+	client := &http.Client{Timeout: 5 * time.Second, Transport: tr}
 	ticker := time.NewTicker(60 * time.Second)
 	defer ticker.Stop()
 
@@ -4257,7 +4264,16 @@ func (r *CollectionPolicyReconciler) runPrometheusProbe(ctx context.Context, don
 		case <-ticker.C:
 			status, msg := health.HealthStatusHealthy, "Prometheus available"
 			meta := map[string]string{"url": url}
-			resp, err := client.Get(endpoint)
+			// Build the request from ctx so a URL change or shutdown cancels
+			// any in-flight call immediately rather than waiting for the timeout.
+			req, err := http.NewRequestWithContext(ctx, http.MethodGet, endpoint, nil)
+			if err != nil {
+				status, msg = health.HealthStatusDegraded, "Prometheus probe request build failed"
+				meta["error"] = err.Error()
+				r.updateHealthStatus(status, msg, meta)
+				continue
+			}
+			resp, err := client.Do(req)
 			switch {
 			case err != nil:
 				status, msg = health.HealthStatusDegraded, "Prometheus probe failed"

--- a/internal/controller/collectionpolicy_controller.go
+++ b/internal/controller/collectionpolicy_controller.go
@@ -95,6 +95,7 @@ type CollectionPolicyReconciler struct {
 	prometheusProbeMu     sync.Mutex
 	prometheusProbeURL    string
 	prometheusProbeCancel context.CancelFunc
+	prometheusProbeDone   chan struct{} // closed by the goroutine on exit; nil until first start
 }
 
 // pendingCollector represents a collector that was unavailable at registration time
@@ -1067,7 +1068,7 @@ func (r *CollectionPolicyReconciler) restartCollectors(
 		)
 
 		prometheusAvailable := r.waitForPrometheusAvailability(ctx, newConfig.PrometheusURL)
-		r.startPeriodicPrometheusHealthCheck(ctx, newConfig.PrometheusURL)
+		r.startPeriodicPrometheusHealthCheck(newConfig.PrometheusURL)
 		if !prometheusAvailable {
 			logger.Info(
 				"Prometheus is not available after waiting, will continue with restart but metrics may be limited",
@@ -1899,7 +1900,7 @@ func (r *CollectionPolicyReconciler) initializeCollectors(
 
 		// Start (or refresh) the periodic probe so health recovers from transient
 		// outages rather than being frozen on the one-shot startup result.
-		r.startPeriodicPrometheusHealthCheck(ctx, config.PrometheusURL)
+		r.startPeriodicPrometheusHealthCheck(config.PrometheusURL)
 	} else {
 		r.TelemetryLogger.Report(
 			gen.LogLevel_LOG_LEVEL_WARN,
@@ -1912,7 +1913,7 @@ func (r *CollectionPolicyReconciler) initializeCollectors(
 			},
 		)
 		// No URL — make sure any prior probe is stopped.
-		r.startPeriodicPrometheusHealthCheck(ctx, "")
+		r.startPeriodicPrometheusHealthCheck("")
 	}
 
 	// Setup collection manager and basic services
@@ -4182,11 +4183,20 @@ func (r *CollectionPolicyReconciler) updateHealthStatus(
 // pings Prometheus every minute and updates ComponentPrometheus health. Without
 // this, the one-shot startup check leaves the status frozen until something
 // else happens to refresh it. Pass "" to stop the probe.
-func (r *CollectionPolicyReconciler) startPeriodicPrometheusHealthCheck(parentCtx context.Context, url string) {
+//
+// The goroutine is parented on context.Background() rather than the caller's
+// reconcile context: controller-runtime cancels the reconcile ctx as soon as
+// Reconcile returns, which would kill the probe immediately. The stored cancel
+// func is the only intended way to stop it (matches the OOM reconciler pattern).
+//
+// Idempotency: if a probe for the same URL is already running we no-op. We
+// detect a dead goroutine (panic, lost cancel, etc.) via the done channel —
+// if it's already closed we treat the probe as gone and start a fresh one.
+func (r *CollectionPolicyReconciler) startPeriodicPrometheusHealthCheck(url string) {
 	r.prometheusProbeMu.Lock()
 	defer r.prometheusProbeMu.Unlock()
 
-	if r.prometheusProbeURL == url && r.prometheusProbeCancel != nil {
+	if r.prometheusProbeURL == url && r.probeStillAliveLocked() {
 		return
 	}
 	if r.prometheusProbeCancel != nil {
@@ -4194,6 +4204,7 @@ func (r *CollectionPolicyReconciler) startPeriodicPrometheusHealthCheck(parentCt
 	}
 	r.prometheusProbeURL = url
 	r.prometheusProbeCancel = nil
+	r.prometheusProbeDone = nil
 	if url == "" {
 		return
 	}
@@ -4202,34 +4213,63 @@ func (r *CollectionPolicyReconciler) startPeriodicPrometheusHealthCheck(parentCt
 	if !strings.HasPrefix(url, "http") {
 		endpoint = "http://" + url + "/-/ready"
 	}
-	ctx, cancel := context.WithCancel(parentCtx)
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan struct{})
 	r.prometheusProbeCancel = cancel
+	r.prometheusProbeDone = done
 
-	go func() {
-		client := &http.Client{Timeout: 5 * time.Second}
-		ticker := time.NewTicker(60 * time.Second)
-		defer ticker.Stop()
-		for {
-			select {
-			case <-ctx.Done():
-				return
-			case <-ticker.C:
-				status, msg := health.HealthStatusHealthy, "Prometheus available"
-				meta := map[string]string{"url": url}
-				resp, err := client.Get(endpoint)
-				switch {
-				case err != nil:
-					status, msg = health.HealthStatusDegraded, "Prometheus probe failed"
-					meta["error"] = err.Error()
-				case resp.StatusCode != http.StatusOK:
-					status, msg = health.HealthStatusDegraded, "Prometheus probe returned non-OK status"
-					meta["status_code"] = fmt.Sprintf("%d", resp.StatusCode)
-				}
-				if resp != nil {
-					_ = resp.Body.Close()
-				}
-				r.updateHealthStatus(status, msg, meta)
-			}
+	go r.runPrometheusProbe(ctx, done, url, endpoint)
+}
+
+// probeStillAliveLocked returns true if the existing probe goroutine is still
+// running. Caller must hold prometheusProbeMu.
+func (r *CollectionPolicyReconciler) probeStillAliveLocked() bool {
+	if r.prometheusProbeCancel == nil || r.prometheusProbeDone == nil {
+		return false
+	}
+	select {
+	case <-r.prometheusProbeDone:
+		return false
+	default:
+		return true
+	}
+}
+
+// runPrometheusProbe is the probe goroutine body. Defers a recover so a panic
+// in the HTTP client does not silently leave the probe dead with no cleanup,
+// and always closes done so probeStillAliveLocked can detect exit.
+func (r *CollectionPolicyReconciler) runPrometheusProbe(ctx context.Context, done chan struct{}, url, endpoint string) {
+	defer close(done)
+	defer func() {
+		if rec := recover(); rec != nil {
+			r.Log.Error(fmt.Errorf("%v", rec), "Prometheus probe goroutine panicked", "url", url)
 		}
 	}()
+
+	client := &http.Client{Timeout: 5 * time.Second}
+	ticker := time.NewTicker(60 * time.Second)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			status, msg := health.HealthStatusHealthy, "Prometheus available"
+			meta := map[string]string{"url": url}
+			resp, err := client.Get(endpoint)
+			switch {
+			case err != nil:
+				status, msg = health.HealthStatusDegraded, "Prometheus probe failed"
+				meta["error"] = err.Error()
+			case resp.StatusCode != http.StatusOK:
+				status, msg = health.HealthStatusDegraded, "Prometheus probe returned non-OK status"
+				meta["status_code"] = fmt.Sprintf("%d", resp.StatusCode)
+			}
+			if resp != nil {
+				_ = resp.Body.Close()
+			}
+			r.updateHealthStatus(status, msg, meta)
+		}
+	}
 }

--- a/internal/controller/collectionpolicy_controller.go
+++ b/internal/controller/collectionpolicy_controller.go
@@ -87,6 +87,14 @@ type CollectionPolicyReconciler struct {
 	// OOM reconciler for periodic sweep of missed OOM events
 	oomReconciler       *collector.OOMReconciler
 	oomReconcilerCancel context.CancelFunc
+
+	// Periodic Prometheus availability probe. Without this the prometheus
+	// component health is set once at startup (via waitForPrometheusAvailability)
+	// and never re-evaluated, so a transient outage at boot leaves the operator
+	// permanently reporting prometheus as unhealthy even after recovery.
+	prometheusProbeMu     sync.Mutex
+	prometheusProbeURL    string
+	prometheusProbeCancel context.CancelFunc
 }
 
 // pendingCollector represents a collector that was unavailable at registration time
@@ -1059,6 +1067,7 @@ func (r *CollectionPolicyReconciler) restartCollectors(
 		)
 
 		prometheusAvailable := r.waitForPrometheusAvailability(ctx, newConfig.PrometheusURL)
+		r.startPeriodicPrometheusHealthCheck(ctx, newConfig.PrometheusURL)
 		if !prometheusAvailable {
 			logger.Info(
 				"Prometheus is not available after waiting, will continue with restart but metrics may be limited",
@@ -1887,6 +1896,10 @@ func (r *CollectionPolicyReconciler) initializeCollectors(
 			)
 			logger.Info("Prometheus is available, continuing with full metrics collection")
 		}
+
+		// Start (or refresh) the periodic probe so health recovers from transient
+		// outages rather than being frozen on the one-shot startup result.
+		r.startPeriodicPrometheusHealthCheck(ctx, config.PrometheusURL)
 	} else {
 		r.TelemetryLogger.Report(
 			gen.LogLevel_LOG_LEVEL_WARN,
@@ -1898,6 +1911,8 @@ func (r *CollectionPolicyReconciler) initializeCollectors(
 				"zxporter_version": version.Get().String(),
 			},
 		)
+		// No URL — make sure any prior probe is stopped.
+		r.startPeriodicPrometheusHealthCheck(ctx, "")
 	}
 
 	// Setup collection manager and basic services
@@ -4161,4 +4176,60 @@ func (r *CollectionPolicyReconciler) updateHealthStatus(
 	if r.HealthManager != nil {
 		r.HealthManager.UpdateStatus(health.ComponentPrometheus, status, message, metadata)
 	}
+}
+
+// startPeriodicPrometheusHealthCheck launches (or restarts) a goroutine that
+// pings Prometheus every minute and updates ComponentPrometheus health. Without
+// this, the one-shot startup check leaves the status frozen until something
+// else happens to refresh it. Pass "" to stop the probe.
+func (r *CollectionPolicyReconciler) startPeriodicPrometheusHealthCheck(parentCtx context.Context, url string) {
+	r.prometheusProbeMu.Lock()
+	defer r.prometheusProbeMu.Unlock()
+
+	if r.prometheusProbeURL == url && r.prometheusProbeCancel != nil {
+		return
+	}
+	if r.prometheusProbeCancel != nil {
+		r.prometheusProbeCancel()
+	}
+	r.prometheusProbeURL = url
+	r.prometheusProbeCancel = nil
+	if url == "" {
+		return
+	}
+
+	endpoint := url + "/-/ready"
+	if !strings.HasPrefix(url, "http") {
+		endpoint = "http://" + url + "/-/ready"
+	}
+	ctx, cancel := context.WithCancel(parentCtx)
+	r.prometheusProbeCancel = cancel
+
+	go func() {
+		client := &http.Client{Timeout: 5 * time.Second}
+		ticker := time.NewTicker(60 * time.Second)
+		defer ticker.Stop()
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case <-ticker.C:
+				status, msg := health.HealthStatusHealthy, "Prometheus available"
+				meta := map[string]string{"url": url}
+				resp, err := client.Get(endpoint)
+				switch {
+				case err != nil:
+					status, msg = health.HealthStatusDegraded, "Prometheus probe failed"
+					meta["error"] = err.Error()
+				case resp.StatusCode != http.StatusOK:
+					status, msg = health.HealthStatusDegraded, "Prometheus probe returned non-OK status"
+					meta["status_code"] = fmt.Sprintf("%d", resp.StatusCode)
+				}
+				if resp != nil {
+					_ = resp.Body.Close()
+				}
+				r.updateHealthStatus(status, msg, meta)
+			}
+		}
+	}()
 }

--- a/internal/controller/custom.go
+++ b/internal/controller/custom.go
@@ -460,6 +460,12 @@ func (c *EnvBasedController) initializeTelemetryComponents(ctx context.Context) 
 // newHealthTransitionObserver returns a TransitionObserver that emits a telemetry
 // log on every component status change so we can trace flips in Datadog rather
 // than only seeing the latest snapshot via the heartbeat.
+//
+// The dispatch is offloaded to a goroutine so observer execution never blocks
+// the caller of UpdateStatus. tl.Report is currently non-blocking (it queues
+// with a select-default drop), but we should not couple the observer contract
+// to that internal detail — a future telemetry implementation that does I/O
+// would otherwise stall every health transition.
 func newHealthTransitionObserver(tl telemetry_logger.Logger) health.TransitionObserver {
 	return func(component string, oldStatus, newStatus health.HealthStatus, message string, metadata map[string]string) {
 		level := gen.LogLevel_LOG_LEVEL_INFO
@@ -479,7 +485,7 @@ func newHealthTransitionObserver(tl telemetry_logger.Logger) health.TransitionOb
 		fields["new_status"] = newStatus.String()
 		fields["zxporter_version"] = version.Get().String()
 
-		tl.Report(level, "HealthManager_StatusTransition", message, nil, fields)
+		go tl.Report(level, "HealthManager_StatusTransition", message, nil, fields)
 	}
 }
 

--- a/internal/controller/custom.go
+++ b/internal/controller/custom.go
@@ -447,8 +447,40 @@ func (c *EnvBasedController) initializeTelemetryComponents(ctx context.Context) 
 	c.Reconciler.Sender = sender
 	c.Reconciler.TelemetryLogger = telemetryLogger
 
+	if c.Reconciler.HealthManager != nil {
+		c.Reconciler.HealthManager.SetTransitionObserver(
+			newHealthTransitionObserver(telemetryLogger),
+		)
+	}
+
 	c.Log.Info("Successfully initialized telemetry components")
 	return nil
+}
+
+// newHealthTransitionObserver returns a TransitionObserver that emits a telemetry
+// log on every component status change so we can trace flips in Datadog rather
+// than only seeing the latest snapshot via the heartbeat.
+func newHealthTransitionObserver(tl telemetry_logger.Logger) health.TransitionObserver {
+	return func(component string, oldStatus, newStatus health.HealthStatus, message string, metadata map[string]string) {
+		level := gen.LogLevel_LOG_LEVEL_INFO
+		switch newStatus {
+		case health.HealthStatusDegraded:
+			level = gen.LogLevel_LOG_LEVEL_WARN
+		case health.HealthStatusUnhealthy:
+			level = gen.LogLevel_LOG_LEVEL_ERROR
+		}
+
+		fields := make(map[string]string, len(metadata)+4)
+		for k, v := range metadata {
+			fields[k] = v
+		}
+		fields["component"] = component
+		fields["old_status"] = oldStatus.String()
+		fields["new_status"] = newStatus.String()
+		fields["zxporter_version"] = version.Get().String()
+
+		tl.Report(level, "HealthManager_StatusTransition", message, nil, fields)
+	}
 }
 
 // doReconcile performs a single reconciliation

--- a/internal/health/manager.go
+++ b/internal/health/manager.go
@@ -24,12 +24,20 @@ type ComponentStatus struct {
 	Metadata map[string]string
 }
 
+// TransitionObserver is invoked whenever a component's status changes via UpdateStatus.
+// It is called outside the HealthManager lock so observers may safely call back into
+// the manager (e.g. to read other component statuses) without deadlocking. The observer
+// is invoked synchronously, but the typical implementation should hand off to a queue
+// so the UpdateStatus call site stays fast.
+type TransitionObserver func(component string, oldStatus, newStatus HealthStatus, message string, metadata map[string]string)
+
 type HealthManager struct {
 	mu                  sync.RWMutex
 	components          map[string]*ComponentStatus
 	livenessGraceUntil  time.Time // LivenessCheck always passes before this deadline
 	readinessGraceUntil time.Time // ReadinessCheck always passes before this deadline
 	standby             bool      // standby=true when not leader; readiness passes unconditionally
+	transitionObserver  TransitionObserver
 }
 
 // NewHealthManager creates a new HealthManager
@@ -59,16 +67,34 @@ func (hm *HealthManager) Deregister(name string) {
 	delete(hm.components, name)
 }
 
-// UpdateStatus updates the health status, message, and metadata for a component
+// SetTransitionObserver registers (or clears, if nil) a callback invoked on every
+// component status transition. Only one observer is held at a time. The observer
+// runs outside the lock so it may safely re-enter the HealthManager.
+func (hm *HealthManager) SetTransitionObserver(obs TransitionObserver) {
+	hm.mu.Lock()
+	defer hm.mu.Unlock()
+	hm.transitionObserver = obs
+}
+
+// UpdateStatus updates the health status, message, and metadata for a component.
+// If the new status differs from the previous one, the registered TransitionObserver
+// (if any) is invoked outside the lock with old and new status.
 func (hm *HealthManager) UpdateStatus(
 	name string,
 	status HealthStatus,
 	message string,
 	metadata map[string]string,
 ) {
+	var (
+		transitioned bool
+		observer     TransitionObserver
+		oldStatus    HealthStatus
+		metaCopy     map[string]string
+	)
+
 	hm.mu.Lock()
-	defer hm.mu.Unlock()
 	if comp, exists := hm.components[name]; exists {
+		oldStatus = comp.Status
 		comp.Status = status
 		comp.Message = message
 		if metadata != nil {
@@ -78,6 +104,21 @@ func (hm *HealthManager) UpdateStatus(
 			}
 			comp.Metadata = m
 		}
+		if oldStatus != status {
+			transitioned = true
+			observer = hm.transitionObserver
+			if observer != nil {
+				metaCopy = make(map[string]string, len(comp.Metadata))
+				for k, v := range comp.Metadata {
+					metaCopy[k] = v
+				}
+			}
+		}
+	}
+	hm.mu.Unlock()
+
+	if transitioned && observer != nil {
+		observer(name, oldStatus, status, message, metaCopy)
 	}
 }
 

--- a/internal/health/manager_test.go
+++ b/internal/health/manager_test.go
@@ -7,7 +7,52 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
+
+// observedTransition records a single TransitionObserver invocation.
+type observedTransition struct {
+	component string
+	oldStatus HealthStatus
+	newStatus HealthStatus
+	message   string
+	metadata  map[string]string
+}
+
+// observerFixture wraps a HealthManager pre-wired with a transition observer
+// that records every call. Use snapshot() to read calls under the lock.
+type observerFixture struct {
+	hm    *HealthManager
+	mu    sync.Mutex
+	calls []observedTransition
+}
+
+// newObserverFixture builds a HealthManager with the given components registered
+// and a recording observer attached. t.Helper() is set so any failures inside
+// this constructor surface at the calling test line, not inside the helper.
+func newObserverFixture(t *testing.T, components ...string) *observerFixture {
+	t.Helper()
+	f := &observerFixture{hm: NewHealthManager()}
+	for _, c := range components {
+		f.hm.Register(c)
+	}
+	f.hm.SetTransitionObserver(func(component string, oldStatus, newStatus HealthStatus, message string, metadata map[string]string) {
+		f.mu.Lock()
+		defer f.mu.Unlock()
+		f.calls = append(f.calls, observedTransition{component, oldStatus, newStatus, message, metadata})
+	})
+	return f
+}
+
+// snapshot returns a copy of the recorded transitions taken under the lock so
+// the caller can assert on it without racing the observer.
+func (f *observerFixture) snapshot() []observedTransition {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	out := make([]observedTransition, len(f.calls))
+	copy(out, f.calls)
+	return out
+}
 
 const testCollectorManager = "collector_manager"
 
@@ -355,4 +400,108 @@ func TestReadinessCheck_StandbyClearedEnforcesNormalChecks(t *testing.T) {
 	hm.UpdateStatus(ComponentCollectorManager, HealthStatusHealthy, "ok", nil)
 	hm.UpdateStatus(ComponentDakrTransport, HealthStatusHealthy, "ok", nil)
 	assert.NoError(t, hm.ReadinessCheck()) // now passes
+}
+
+// TestTransitionObserver_FiresOnlyOnChange asserts the observer is called for
+// the initial Unspecified→Healthy flip and the subsequent Healthy→Degraded
+// flip, but NOT for an idempotent Healthy→Healthy update. This is the contract
+// the telemetry pipeline relies on — without it, every periodic probe success
+// would emit a duplicate log.
+func TestTransitionObserver_FiresOnlyOnChange(t *testing.T) {
+	f := newObserverFixture(t, ComponentPrometheus)
+
+	f.hm.UpdateStatus(ComponentPrometheus, HealthStatusHealthy, "available", map[string]string{"url": "http://prom"})
+	f.hm.UpdateStatus(ComponentPrometheus, HealthStatusHealthy, "still available", map[string]string{"url": "http://prom"})
+	f.hm.UpdateStatus(ComponentPrometheus, HealthStatusDegraded, "probe failed", map[string]string{"url": "http://prom", "error": "connection refused"})
+
+	calls := f.snapshot()
+	require.Len(t, calls, 2, "observer should only fire on actual transitions, not idempotent updates")
+
+	assert.Equal(t, ComponentPrometheus, calls[0].component)
+	assert.Equal(t, HealthStatusUnspecified, calls[0].oldStatus)
+	assert.Equal(t, HealthStatusHealthy, calls[0].newStatus)
+	assert.Equal(t, "available", calls[0].message)
+	assert.Equal(t, "http://prom", calls[0].metadata["url"])
+
+	assert.Equal(t, HealthStatusHealthy, calls[1].oldStatus)
+	assert.Equal(t, HealthStatusDegraded, calls[1].newStatus)
+	assert.Equal(t, "probe failed", calls[1].message)
+	assert.Equal(t, "connection refused", calls[1].metadata["error"])
+}
+
+// TestTransitionObserver_RunsOutsideLock verifies that the observer can call
+// back into HealthManager (e.g. to read sibling component status) without
+// deadlocking. UpdateStatus must release the write lock before invoking the
+// observer — otherwise this test would hang on hm.GetStatus.
+func TestTransitionObserver_RunsOutsideLock(t *testing.T) {
+	hm := NewHealthManager()
+	hm.Register(ComponentPrometheus)
+	hm.Register(ComponentCollectorManager)
+	hm.UpdateStatus(ComponentCollectorManager, HealthStatusHealthy, "ok", nil)
+
+	observed := make(chan ComponentStatus, 1)
+	hm.SetTransitionObserver(func(_ string, _, _ HealthStatus, _ string, _ map[string]string) {
+		// If UpdateStatus held the write lock here, this read would deadlock.
+		s, _ := hm.GetStatus(ComponentCollectorManager)
+		observed <- s
+	})
+
+	done := make(chan struct{})
+	go func() {
+		hm.UpdateStatus(ComponentPrometheus, HealthStatusHealthy, "available", nil)
+		close(done)
+	}()
+
+	select {
+	case <-done:
+		// Good — UpdateStatus returned without deadlocking.
+	case <-time.After(2 * time.Second):
+		t.Fatal("UpdateStatus deadlocked while invoking observer")
+	}
+
+	select {
+	case s := <-observed:
+		assert.Equal(t, HealthStatusHealthy, s.Status, "observer should have read sibling status")
+	case <-time.After(time.Second):
+		t.Fatal("observer was never invoked")
+	}
+}
+
+// TestTransitionObserver_NotInvokedForUnregisteredComponent ensures we don't
+// emit telemetry for components that were never registered (UpdateStatus is a
+// no-op in that case, so there's no transition to report).
+func TestTransitionObserver_NotInvokedForUnregisteredComponent(t *testing.T) {
+	// Intentionally pass no components — ComponentPrometheus stays unregistered.
+	f := newObserverFixture(t)
+
+	f.hm.UpdateStatus(ComponentPrometheus, HealthStatusHealthy, "available", nil)
+
+	assert.Empty(t, f.snapshot(), "observer should not fire for unregistered components")
+}
+
+// TestTransitionObserver_ReplaceAndClear verifies that SetTransitionObserver
+// replaces an existing observer and that passing nil clears it.
+func TestTransitionObserver_ReplaceAndClear(t *testing.T) {
+	// Don't use the fixture here — we deliberately swap observers mid-test.
+	hm := NewHealthManager()
+	hm.Register(ComponentPrometheus)
+
+	firstCalls := 0
+	secondCalls := 0
+	hm.SetTransitionObserver(func(string, HealthStatus, HealthStatus, string, map[string]string) {
+		firstCalls++
+	})
+	hm.UpdateStatus(ComponentPrometheus, HealthStatusHealthy, "ok", nil)
+	require.Equal(t, 1, firstCalls)
+
+	hm.SetTransitionObserver(func(string, HealthStatus, HealthStatus, string, map[string]string) {
+		secondCalls++
+	})
+	hm.UpdateStatus(ComponentPrometheus, HealthStatusDegraded, "uh", nil)
+	assert.Equal(t, 1, firstCalls, "first observer should not fire after replacement")
+	assert.Equal(t, 1, secondCalls)
+
+	hm.SetTransitionObserver(nil)
+	hm.UpdateStatus(ComponentPrometheus, HealthStatusUnhealthy, "down", nil)
+	assert.Equal(t, 1, secondCalls, "second observer should not fire after being cleared")
 }

--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -5,7 +5,6 @@ import (
 	"runtime"
 )
 
-
 type Info struct {
 	Major        string `json:"major"`
 	Minor        string `json:"minor"`


### PR DESCRIPTION
# fix(health): periodically re-probe Prometheus and emit transition telemetry

  ## 📚 Description of Changes

  After zxporter starts up, the Prometheus availability check runs once via `waitForPrometheusAvailability`. If Prometheus is unavailable during that startup window (e.g. zxporter started before Prometheus was
  ready), the retry budget exhausts and the `prometheus` component is permanently marked Unhealthy. Nothing re-evaluates that status afterwards, so customers see the operator reporting Prometheus as unhealthy
  long after Prometheus has fully recovered.

  This PR adds a continuous probe so health follows reality, and adds Datadog-visible telemetry on every component status flip so we can trace these incidents instead of only seeing the latest snapshot.

  - **What Changed:**
    - `internal/controller/collectionpolicy_controller.go`: added a periodic 60s probe of `<prometheus>/-/ready` that updates `health.ComponentPrometheus` to Healthy on success and Degraded on failure. Started
  from `initializeCollectors` and refreshed from `restartCollectors` so it follows config changes. Idempotent — passing the same URL twice is a no-op; passing a new URL cancels the prior probe.
    - `internal/health/manager.go`: added `TransitionObserver` callback on `HealthManager`, invoked from `UpdateStatus` whenever a component flips status. Called outside the lock so observers may safely re-enter
   the manager.
    - `internal/controller/custom.go`: registered an observer that emits a telemetry log (`HealthManager_StatusTransition`) on every flip, with old/new status, component, message, metadata, and zxporter version.
   Healthy is INFO, Degraded is WARN, Unhealthy is ERROR.
    - `internal/health/manager_test.go`: added four `TransitionObserver` tests covering fires-only-on-change, runs-outside-lock (deadlock guard), no-fire-for-unregistered, and replace/clear semantics. Uses a
  `newObserverFixture(t, components...)` helper marked with `t.Helper()` and `require` for prerequisite assertions so failures jump straight to the broken test line.

  - **Why This Change:**
    Customer-reported: cluster `01f798ba-44b0-4c0c-9cbf-9f14725ed17c` showed `prometheus: HEALTH_STATUS_DEGRADED — "Prometheus unavailable after retries"` while Prometheus itself was running healthily. Root
  cause: one-shot startup check + no re-evaluation. Without telemetry on transitions we also couldn't see *when* the operator's view of Prometheus diverged from reality.

  - **Affected Components:**
  - [ ] Compose
  - [x] K8s
  - [ ] Other (please specify)

  ## ❓ Motivation and Context

  The `prometheus` component health status was effectively frozen after the startup check. The only path back to Healthy was a successful `historical_metrics_collector.FetchPercentiles` call, which only happens
  when MPA actively queries percentiles — clusters without active MPA workloads stayed stuck on whatever the startup check produced. On top of that, we had no Datadog trail of when these flips happened, only the
   current snapshot returned via heartbeat.

  - **Context:**
    Internal Slack thread (https://devzeroworkspace.slack.com/archives/C086RLMC1FF/p1778093875826869) on cluster `01f798ba-44b0-4c0c-9cbf-9f14725ed17c` where `dakr_transport`, `mpa_server`, `collector_manager`,
  and `buffer_queue` were all Healthy but `prometheus` reported Degraded with `"Prometheus unavailable after retries"` while the Prometheus deployment was healthy. Suggestion from @ignas to add telemetry logs
  for the health checkers so we can audit divergence in Datadog.

  - **Relevant Tasks/Issues:**
    N/A — Slack thread.

  ## 🔍 Types of Changes

  - [x] **BUGFIX:** Non-breaking fix for an issue.
  - [ ] **NEW FEATURE:** Non-breaking addition of functionality.
  - [ ] **BREAKING CHANGE:** Fix or feature that causes existing functionality to not work as expected.
  - [x] **ENHANCEMENT:** Improvement to existing functionality.
  - [ ] **CHORE:** Changes that do not affect production (e.g., documentation, build tooling, CI).

  ## 🔬 QA / Verification Steps

  1. `make test` — all packages pass; `internal/health` coverage 89.6% → **92.4%** with the new TransitionObserver tests.
  2. `make lint` — no new lint errors in the touched files (`internal/health/manager.go`, `internal/health/manager_test.go`, `internal/controller/collectionpolicy_controller.go`,
  `internal/controller/custom.go`); pre-existing failures in unrelated files are unchanged.
  3. Deploy to a test cluster where Prometheus starts *after* zxporter (e.g. `kubectl scale deploy/prometheus-... --replicas=0`, restart zxporter, wait ~25 minutes for the startup retry budget to exhaust, then
  scale Prometheus back up). Confirm via `ReportHealth` heartbeat that the `prometheus` component returns to Healthy within ~60s of Prometheus becoming ready.
  4. In Datadog, filter logs by `service:dakr @procedure:"/api.v1.MetricsCollectorService/SendTelemetryLogs" @source:"HealthManager_StatusTransition"` and confirm transition entries appear with `old_status`,
  `new_status`, `component`, and `zxporter_version` fields.
  5. Toggle `prometheusUrl` in the CollectionPolicy config — confirm the probe restarts with the new URL (the prior probe's goroutine should exit cleanly when its context is cancelled).

  ## ✅ Global Checklist

  - [x] I have read and followed the [CONTRIBUTING guidelines](.github/CONTRIBUTING.md).
  - [x] My code follows the code style of this project.
  - [ ] I have updated the documentation as needed.
  - [x] I have added tests that cover my changes.
  - [x] All new and existing tests have passed locally.
  - [x] I have run this code in a local environment to verify functionality.
  - [x] I have considered the security implications of this change.