### PR TITLE
ci: stabilize jvm-metrics-kind workflow (namespace runner + robust validations)

### DIFF
--- a/.github/workflows/jvm-metrics-kind-test.yml
+++ b/.github/workflows/jvm-metrics-kind-test.yml
@@ -8,7 +8,9 @@ on:
 
 jobs:
   jvm-metrics-kind:
-    runs-on: ubuntu-xl
+    # NOTE: ubuntu-xl is not a standard GitHub-hosted runner label; when it's not available,
+    # GitHub fails the workflow immediately with no jobs created.
+    runs-on: ubuntu-24.04
     steps:
       - name: Checkout code
         uses: actions/checkout@v4

--- a/.github/workflows/jvm-metrics-kind-test.yml
+++ b/.github/workflows/jvm-metrics-kind-test.yml
@@ -67,6 +67,7 @@ jobs:
           kubectl -n jvm-spike rollout status deploy/java21-jdk-options --timeout=300s
           kubectl -n jvm-spike rollout status deploy/java21-precedence-env --timeout=300s
           kubectl -n jvm-spike rollout status deploy/java21-precedence-cmdline --timeout=300s
+          kubectl -n jvm-spike rollout status deploy/java21-per-flag-sources --timeout=300s
           kubectl -n jvm-spike rollout status deploy/not-java --timeout=300s
 
       - name: Validate nodemon JVM metrics output
@@ -184,6 +185,19 @@ jobs:
           if (heap.get('max_bytes') or 0) <= 0:
               raise SystemExit(f'java21-precedence-cmdline expected heap.max_bytes > 0; got heap={heap}')
           assert_close('java21-precedence-cmdline heap.max_bytes vs xmx_bytes', heap.get('max_bytes'), flags.get('xmx_bytes'))
+
+          # Per-flag sourcing: Xmx from JAVA_TOOL_OPTIONS; Xms from JDK_JAVA_OPTIONS
+          mpf = req_prefix('java21-per-flag-sources')
+          flags = mpf.get('flags_extracted', {})
+          if flags.get('xmx_bytes') != 117440512 or flags.get('xms_bytes') != 29360128:
+              raise SystemExit(f'java21-per-flag-sources expected xmx=112m xms=28m got flags={flags}')
+          src = mpf.get('flag_sources', {})
+          if str(src.get('xmx_bytes', '')) != 'JAVA_TOOL_OPTIONS' or str(src.get('xms_bytes', '')) != 'JDK_JAVA_OPTIONS':
+              raise SystemExit(f'java21-per-flag-sources expected xmx source JAVA_TOOL_OPTIONS and xms source JDK_JAVA_OPTIONS; got {src}')
+          heap = mpf.get('heap', {})
+          if (heap.get('max_bytes') or 0) <= 0:
+              raise SystemExit(f'java21-per-flag-sources expected heap.max_bytes > 0; got heap={heap}')
+          assert_close('java21-per-flag-sources heap.max_bytes vs xmx_bytes', heap.get('max_bytes'), flags.get('xmx_bytes'))
 
           print('OK')
           PY

--- a/.github/workflows/jvm-metrics-kind-test.yml
+++ b/.github/workflows/jvm-metrics-kind-test.yml
@@ -102,22 +102,32 @@ jobs:
           flags = m8.get('flags_extracted', {})
           if flags.get('xmx_bytes') != 201326592:
               raise SystemExit(f'java8-xmx-only expected xmx_bytes=201326592 got {flags.get("xmx_bytes")}')
+          src = m8.get('flag_sources', {})
+          if str(src.get('xmx_bytes', '')) != 'cmdline':
+              raise SystemExit(f'java8-xmx-only expected xmx source cmdline; got {src}')
 
-          # java11: env JAVA_TOOL_OPTIONS provides xmx/xms/maxram; sources should mention JAVA_TOOL_OPTIONS
+          # java11: env JAVA_TOOL_OPTIONS provides xmx/xms/maxram; sources should be JAVA_TOOL_OPTIONS
           m11 = req_prefix('java11-tool-options')
           flags = m11.get('flags_extracted', {})
           if flags.get('xmx_bytes') != 167772160 or flags.get('xms_bytes') != 50331648 or flags.get('max_ram_percentage') != 65:
               raise SystemExit(f'java11-tool-options flags mismatch: {flags}')
           src = m11.get('flag_sources', {})
-          xmx_src = str(src.get('xmx_bytes', ''))
-          if 'TOOL_OPTIONS' not in xmx_src:
-              raise SystemExit(f'java11-tool-options expected xmx source to mention JAVA_TOOL_OPTIONS; got {src}')
+          if str(src.get('xmx_bytes', '')) != 'JAVA_TOOL_OPTIONS' or str(src.get('xms_bytes', '')) != 'JAVA_TOOL_OPTIONS':
+              raise SystemExit(f'java11-tool-options expected xmx/xms sources JAVA_TOOL_OPTIONS; got {src}')
 
           # java17: maxram only should be 40
           m17 = req_prefix('java17-maxram-only')
           flags = m17.get('flags_extracted', {})
           if flags.get('max_ram_percentage') != 40:
               raise SystemExit(f'java17-maxram-only expected max_ram_percentage=40 got {flags.get("max_ram_percentage")}')
+
+          # Spot-check that hsperfdata-derived heap metrics exist (non-zero) for the JVM pods
+          for name, m in [('java8-xmx-only', m8), ('java11-tool-options', m11), ('java17-maxram-only', m17)]:
+              heap = m.get('heap', {})
+              if (heap.get('max_bytes') or 0) <= 0:
+                  raise SystemExit(f'{name} expected heap.max_bytes > 0; got heap={heap}')
+              if (heap.get('used_bytes') or 0) < 0:
+                  raise SystemExit(f'{name} expected heap.used_bytes >= 0; got heap={heap}')
 
           print('OK')
           PY

--- a/.github/workflows/jvm-metrics-kind-test.yml
+++ b/.github/workflows/jvm-metrics-kind-test.yml
@@ -64,6 +64,7 @@ jobs:
           kubectl -n jvm-spike rollout status deploy/java8-xmx-only --timeout=300s
           kubectl -n jvm-spike rollout status deploy/java11-tool-options --timeout=300s
           kubectl -n jvm-spike rollout status deploy/java17-maxram-only --timeout=300s
+          kubectl -n jvm-spike rollout status deploy/java21-jdk-options --timeout=300s
           kubectl -n jvm-spike rollout status deploy/not-java --timeout=300s
 
       - name: Validate nodemon JVM metrics output
@@ -121,13 +122,40 @@ jobs:
           if flags.get('max_ram_percentage') != 40:
               raise SystemExit(f'java17-maxram-only expected max_ram_percentage=40 got {flags.get("max_ram_percentage")}')
 
-          # Spot-check that hsperfdata-derived heap metrics exist (non-zero) for the JVM pods
+          def assert_close(name, got, expected, rel=0.10, abs_bytes=16*1024*1024):
+              if got is None or expected is None:
+                  raise SystemExit(f'{name} missing values for close-check (got={got} expected={expected})')
+              lo = expected - max(abs_bytes, int(expected * rel))
+              hi = expected + max(abs_bytes, int(expected * rel))
+              if not (lo <= got <= hi):
+                  raise SystemExit(f'{name} expected ~{expected} (±max({abs_bytes}, {int(expected*rel)})) got {got}; range=[{lo},{hi}]')
+
+          # Spot-check that hsperfdata-derived heap metrics exist (non-zero) for JVM pods.
+          # And when Xmx is known, ensure heap.max_bytes is roughly consistent (buffered to avoid flakiness).
           for name, m in [('java8-xmx-only', m8), ('java11-tool-options', m11), ('java17-maxram-only', m17)]:
               heap = m.get('heap', {})
               if (heap.get('max_bytes') or 0) <= 0:
                   raise SystemExit(f'{name} expected heap.max_bytes > 0; got heap={heap}')
               if (heap.get('used_bytes') or 0) < 0:
                   raise SystemExit(f'{name} expected heap.used_bytes >= 0; got heap={heap}')
+
+              flags = m.get('flags_extracted', {})
+              xmx = flags.get('xmx_bytes')
+              if xmx:
+                  assert_close(f'{name} heap.max_bytes vs xmx_bytes', heap.get('max_bytes'), xmx)
+
+          # java21: verify JDK_JAVA_OPTIONS parsing + source attribution
+          m21 = req_prefix('java21-jdk-options')
+          flags = m21.get('flags_extracted', {})
+          if flags.get('xmx_bytes') != 134217728 or flags.get('xms_bytes') != 33554432:
+              raise SystemExit(f'java21-jdk-options flags mismatch: {flags}')
+          src = m21.get('flag_sources', {})
+          if str(src.get('xmx_bytes', '')) != 'JDK_JAVA_OPTIONS' or str(src.get('xms_bytes', '')) != 'JDK_JAVA_OPTIONS':
+              raise SystemExit(f'java21-jdk-options expected xmx/xms sources JDK_JAVA_OPTIONS; got {src}')
+          heap = m21.get('heap', {})
+          if (heap.get('max_bytes') or 0) <= 0:
+              raise SystemExit(f'java21-jdk-options expected heap.max_bytes > 0; got heap={heap}')
+          assert_close('java21-jdk-options heap.max_bytes vs xmx_bytes', heap.get('max_bytes'), flags.get('xmx_bytes'))
 
           print('OK')
           PY

--- a/.github/workflows/jvm-metrics-kind-test.yml
+++ b/.github/workflows/jvm-metrics-kind-test.yml
@@ -65,6 +65,8 @@ jobs:
           kubectl -n jvm-spike rollout status deploy/java11-tool-options --timeout=300s
           kubectl -n jvm-spike rollout status deploy/java17-maxram-only --timeout=300s
           kubectl -n jvm-spike rollout status deploy/java21-jdk-options --timeout=300s
+          kubectl -n jvm-spike rollout status deploy/java21-precedence-env --timeout=300s
+          kubectl -n jvm-spike rollout status deploy/java21-precedence-cmdline --timeout=300s
           kubectl -n jvm-spike rollout status deploy/not-java --timeout=300s
 
       - name: Validate nodemon JVM metrics output
@@ -156,6 +158,32 @@ jobs:
           if (heap.get('max_bytes') or 0) <= 0:
               raise SystemExit(f'java21-jdk-options expected heap.max_bytes > 0; got heap={heap}')
           assert_close('java21-jdk-options heap.max_bytes vs xmx_bytes', heap.get('max_bytes'), flags.get('xmx_bytes'))
+
+          # Precedence: JAVA_TOOL_OPTIONS > JDK_JAVA_OPTIONS > JAVA_OPTS
+          menv = req_prefix('java21-precedence-env')
+          flags = menv.get('flags_extracted', {})
+          if flags.get('xmx_bytes') != 100663296 or flags.get('xms_bytes') != 25165824:
+              raise SystemExit(f'java21-precedence-env expected xmx=96m xms=24m got flags={flags}')
+          src = menv.get('flag_sources', {})
+          if str(src.get('xmx_bytes', '')) != 'JAVA_TOOL_OPTIONS' or str(src.get('xms_bytes', '')) != 'JAVA_TOOL_OPTIONS':
+              raise SystemExit(f'java21-precedence-env expected sources JAVA_TOOL_OPTIONS; got {src}')
+          heap = menv.get('heap', {})
+          if (heap.get('max_bytes') or 0) <= 0:
+              raise SystemExit(f'java21-precedence-env expected heap.max_bytes > 0; got heap={heap}')
+          assert_close('java21-precedence-env heap.max_bytes vs xmx_bytes', heap.get('max_bytes'), flags.get('xmx_bytes'))
+
+          # Precedence: cmdline beats env
+          mcmd = req_prefix('java21-precedence-cmdline')
+          flags = mcmd.get('flags_extracted', {})
+          if flags.get('xmx_bytes') != 83886080 or flags.get('xms_bytes') != 16777216:
+              raise SystemExit(f'java21-precedence-cmdline expected xmx=80m xms=16m got flags={flags}')
+          src = mcmd.get('flag_sources', {})
+          if str(src.get('xmx_bytes', '')) != 'cmdline' or str(src.get('xms_bytes', '')) != 'cmdline':
+              raise SystemExit(f'java21-precedence-cmdline expected sources cmdline; got {src}')
+          heap = mcmd.get('heap', {})
+          if (heap.get('max_bytes') or 0) <= 0:
+              raise SystemExit(f'java21-precedence-cmdline expected heap.max_bytes > 0; got heap={heap}')
+          assert_close('java21-precedence-cmdline heap.max_bytes vs xmx_bytes', heap.get('max_bytes'), flags.get('xmx_bytes'))
 
           print('OK')
           PY

--- a/.github/workflows/jvm-metrics-kind-test.yml
+++ b/.github/workflows/jvm-metrics-kind-test.yml
@@ -1,6 +1,7 @@
+name: jvm-metrics-kind
+
 permissions:
   contents: read
-name: JVM Metrics (nodemon) Kind Test
 
 on:
   pull_request:
@@ -70,48 +71,55 @@ jobs:
           POD_IP=$(kubectl -n devzero-system get pod -l app.kubernetes.io/name=zxporter-nodemon -o jsonpath='{.items[0].status.podIP}')
           echo "nodemon podIP=$POD_IP"
 
-          # Assertions (python; no jq dependency). Fetch JSON inside the python container.
-          kubectl -n devzero-system run py-assert --image=python:3.12-slim -i --rm --restart=Never --command -- \
-            sh -lc "python - <<'PY'
-import json,sys,urllib.request
-pod_ip = '${POD_IP}'
-url = f'http://{pod_ip}:6061/container/jvm-metrics?namespace=jvm-spike'
-with urllib.request.urlopen(url, timeout=30) as r:
-    data = json.loads(r.read().decode('utf-8'))
+          # Assertions (python; no jq dependency).
+          # Avoid `kubectl run -i --rm` + heredoc (flaky/non-interactive on Actions).
+          kubectl -n devzero-system run py-assert --image=python:3.12-slim --restart=Never --command -- sleep 3600
+          kubectl -n devzero-system wait --for=condition=Ready --timeout=120s pod/py-assert
 
-by_pod={m.get('pod'):m for m in data}
+          kubectl -n devzero-system exec py-assert -- python - <<'PY'
+          import json
+          import urllib.request
 
-def req_prefix(prefix):
-    for k,v in by_pod.items():
-        if k and k.startswith(prefix):
-            return v
-    raise SystemExit(f'missing pod prefix={prefix}; got pods={list(by_pod.keys())}')
+          pod_ip = '${POD_IP}'
+          url = f'http://{pod_ip}:6061/container/jvm-metrics?namespace=jvm-spike'
+          with urllib.request.urlopen(url, timeout=30) as r:
+              data = json.loads(r.read().decode('utf-8'))
 
-# Ensure not-java absent
-if any((m.get('pod','') or '').startswith('not-java') for m in data):
-    raise SystemExit('not-java unexpectedly present in JVM metrics')
+          by_pod = {m.get('pod'): m for m in data}
 
-# java8: cmdline -Xmx192m => 201326592
-m8=req_prefix('java8-xmx-only')
-flags=m8.get('flags_extracted',{})
-if flags.get('xmx_bytes')!=201326592:
-    raise SystemExit(f'java8-xmx-only expected xmx_bytes=201326592 got {flags.get("xmx_bytes")}')
+          def req_prefix(prefix):
+              for k, v in by_pod.items():
+                  if k and k.startswith(prefix):
+                      return v
+              raise SystemExit(f'missing pod prefix={prefix}; got pods={list(by_pod.keys())}')
 
-# java11: env JAVA_TOOL_OPTIONS provides xmx/xms/maxram; sources should mention JAVA_TOOL_OPTIONS
-m11=req_prefix('java11-tool-options')
-flags=m11.get('flags_extracted',{})
-if flags.get('xmx_bytes')!=167772160 or flags.get('xms_bytes')!=50331648 or flags.get('max_ram_percentage')!=65:
-    raise SystemExit(f'java11-tool-options flags mismatch: {flags}')
-src=m11.get('flag_sources',{})
-xmx_src=str(src.get('xmx_bytes',''))
-if 'TOOL_OPTIONS' not in xmx_src:
-    raise SystemExit(f'java11-tool-options expected xmx source to mention JAVA_TOOL_OPTIONS; got {src}')
+          # Ensure not-java absent
+          if any((m.get('pod', '') or '').startswith('not-java') for m in data):
+              raise SystemExit('not-java unexpectedly present in JVM metrics')
 
-# java17: maxram only should be 40
-m17=req_prefix('java17-maxram-only')
-flags=m17.get('flags_extracted',{})
-if flags.get('max_ram_percentage')!=40:
-    raise SystemExit(f'java17-maxram-only expected max_ram_percentage=40 got {flags.get("max_ram_percentage")}')
+          # java8: cmdline -Xmx192m => 201326592
+          m8 = req_prefix('java8-xmx-only')
+          flags = m8.get('flags_extracted', {})
+          if flags.get('xmx_bytes') != 201326592:
+              raise SystemExit(f'java8-xmx-only expected xmx_bytes=201326592 got {flags.get("xmx_bytes")}')
 
-print('OK')
-PY"
+          # java11: env JAVA_TOOL_OPTIONS provides xmx/xms/maxram; sources should mention JAVA_TOOL_OPTIONS
+          m11 = req_prefix('java11-tool-options')
+          flags = m11.get('flags_extracted', {})
+          if flags.get('xmx_bytes') != 167772160 or flags.get('xms_bytes') != 50331648 or flags.get('max_ram_percentage') != 65:
+              raise SystemExit(f'java11-tool-options flags mismatch: {flags}')
+          src = m11.get('flag_sources', {})
+          xmx_src = str(src.get('xmx_bytes', ''))
+          if 'TOOL_OPTIONS' not in xmx_src:
+              raise SystemExit(f'java11-tool-options expected xmx source to mention JAVA_TOOL_OPTIONS; got {src}')
+
+          # java17: maxram only should be 40
+          m17 = req_prefix('java17-maxram-only')
+          flags = m17.get('flags_extracted', {})
+          if flags.get('max_ram_percentage') != 40:
+              raise SystemExit(f'java17-maxram-only expected max_ram_percentage=40 got {flags.get("max_ram_percentage")}')
+
+          print('OK')
+          PY
+
+          kubectl -n devzero-system delete pod/py-assert --ignore-not-found=true

--- a/.github/workflows/jvm-metrics-kind-test.yml
+++ b/.github/workflows/jvm-metrics-kind-test.yml
@@ -76,7 +76,7 @@ jobs:
           kubectl -n devzero-system run py-assert --image=python:3.12-slim --restart=Never --command -- sleep 3600
           kubectl -n devzero-system wait --for=condition=Ready --timeout=120s pod/py-assert
 
-          kubectl -n devzero-system exec py-assert -- python - <<'PY'
+          kubectl -n devzero-system exec py-assert -- python - <<PY
           import json
           import urllib.request
 

--- a/.github/workflows/jvm-metrics-kind-test.yml
+++ b/.github/workflows/jvm-metrics-kind-test.yml
@@ -9,9 +9,9 @@ on:
 
 jobs:
   jvm-metrics-kind:
-    # NOTE: ubuntu-xl is not a standard GitHub-hosted runner label; when it's not available,
-    # GitHub fails the workflow immediately with no jobs created.
-    runs-on: ubuntu-24.04
+    # Use our namespace runner profile (same pattern as image-push workflows).
+    # This avoids relying on GitHub-hosted runner labels.
+    runs-on: namespace-profile-dz-generic
     steps:
       - name: Checkout code
         uses: actions/checkout@v4

--- a/test/fixtures/jvm-apps.yaml
+++ b/test/fixtures/jvm-apps.yaml
@@ -20,7 +20,7 @@ spec:
     spec:
       containers:
         - name: app
-          image: eclipse-temurin:8-jre
+          image: eclipse-temurin:8-jdk
           command: ["sh","-lc"]
           args:
             - |
@@ -47,7 +47,7 @@ spec:
     spec:
       containers:
         - name: app
-          image: eclipse-temurin:11-jre
+          image: eclipse-temurin:11-jdk
           env:
             - name: JAVA_TOOL_OPTIONS
               value: "-Xms48m -Xmx160m -XX:MaxRAMPercentage=65 -Dfrom=tooloptions"
@@ -77,7 +77,7 @@ spec:
     spec:
       containers:
         - name: app
-          image: eclipse-temurin:17-jre
+          image: eclipse-temurin:17-jdk
           command: ["sh","-lc"]
           args:
             - |

--- a/test/fixtures/jvm-apps.yaml
+++ b/test/fixtures/jvm-apps.yaml
@@ -186,6 +186,39 @@ spec:
 apiVersion: apps/v1
 kind: Deployment
 metadata:
+  name: java21-per-flag-sources
+  namespace: jvm-spike
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: java21-per-flag-sources
+  template:
+    metadata:
+      labels:
+        app: java21-per-flag-sources
+    spec:
+      containers:
+        - name: app
+          image: eclipse-temurin:21-jdk
+          env:
+            # Per-flag sourcing test: Xmx from JAVA_TOOL_OPTIONS, Xms from JDK_JAVA_OPTIONS
+            - name: JAVA_TOOL_OPTIONS
+              value: "-Xmx112m -Dfrom=toolopts"
+            - name: JDK_JAVA_OPTIONS
+              value: "-Xms28m -Dfrom=jdkopts"
+          command: ["sh","-lc"]
+          args:
+            - |
+              cat >/tmp/DummyMain.java <<'EOF'
+              public class DummyMain { public static void main(String[] args) throws Exception { for(;;) Thread.sleep(60000); } }
+              EOF
+              javac /tmp/DummyMain.java
+              exec java -cp /tmp DummyMain
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
   name: not-java
   namespace: jvm-spike
 spec:

--- a/test/fixtures/jvm-apps.yaml
+++ b/test/fixtures/jvm-apps.yaml
@@ -90,6 +90,36 @@ spec:
 apiVersion: apps/v1
 kind: Deployment
 metadata:
+  name: java21-jdk-options
+  namespace: jvm-spike
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: java21-jdk-options
+  template:
+    metadata:
+      labels:
+        app: java21-jdk-options
+    spec:
+      containers:
+        - name: app
+          image: eclipse-temurin:21-jdk
+          env:
+            - name: JDK_JAVA_OPTIONS
+              value: "-Xms32m -Xmx128m -Dfrom=jdkopts"
+          command: ["sh","-lc"]
+          args:
+            - |
+              cat >/tmp/DummyMain.java <<'EOF'
+              public class DummyMain { public static void main(String[] args) throws Exception { for(;;) Thread.sleep(60000); } }
+              EOF
+              javac /tmp/DummyMain.java
+              exec java -cp /tmp DummyMain
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
   name: not-java
   namespace: jvm-spike
 spec:

--- a/test/fixtures/jvm-apps.yaml
+++ b/test/fixtures/jvm-apps.yaml
@@ -120,6 +120,72 @@ spec:
 apiVersion: apps/v1
 kind: Deployment
 metadata:
+  name: java21-precedence-env
+  namespace: jvm-spike
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: java21-precedence-env
+  template:
+    metadata:
+      labels:
+        app: java21-precedence-env
+    spec:
+      containers:
+        - name: app
+          image: eclipse-temurin:21-jdk
+          env:
+            # Precedence model: JAVA_TOOL_OPTIONS > JDK_JAVA_OPTIONS > JAVA_OPTS
+            - name: JAVA_TOOL_OPTIONS
+              value: "-Xms24m -Xmx96m -Dfrom=toolopts"
+            - name: JDK_JAVA_OPTIONS
+              value: "-Xms32m -Xmx128m -Dfrom=jdkopts"
+            - name: JAVA_OPTS
+              value: "-Xms40m -Xmx160m -Dfrom=javaopts"
+          command: ["sh","-lc"]
+          args:
+            - |
+              cat >/tmp/DummyMain.java <<'EOF'
+              public class DummyMain { public static void main(String[] args) throws Exception { for(;;) Thread.sleep(60000); } }
+              EOF
+              javac /tmp/DummyMain.java
+              exec java -cp /tmp DummyMain
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: java21-precedence-cmdline
+  namespace: jvm-spike
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: java21-precedence-cmdline
+  template:
+    metadata:
+      labels:
+        app: java21-precedence-cmdline
+    spec:
+      containers:
+        - name: app
+          image: eclipse-temurin:21-jdk
+          env:
+            - name: JAVA_TOOL_OPTIONS
+              value: "-Xms32m -Xmx128m -Dfrom=toolopts"
+          command: ["sh","-lc"]
+          args:
+            - |
+              cat >/tmp/DummyMain.java <<'EOF'
+              public class DummyMain { public static void main(String[] args) throws Exception { for(;;) Thread.sleep(60000); } }
+              EOF
+              javac /tmp/DummyMain.java
+              # cmdline should win over env
+              exec java -Xms16m -Xmx80m -cp /tmp DummyMain
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
   name: not-java
   namespace: jvm-spike
 spec:


### PR DESCRIPTION
Fixes and hardens the `jvm-metrics-kind` GitHub Actions workflow so it reliably schedules and validates our JVM metrics endpoint in CI.

## What changed
- **Runner**: switch from GitHub-hosted labels to our namespace runner profile:
  - `runs-on: namespace-profile-dz-generic`
- **Workflow UX**: set workflow name to `jvm-metrics-kind`.
- **Stable assertions execution**: replace flaky `kubectl run -i --rm` + inline heredoc-in-quoted-string with a stable pattern:
  - create a long-lived `py-assert` pod
  - `kubectl wait` for Ready
  - `kubectl exec ... python - <<PY` (unquoted heredoc so `${POD_IP}` expands)
  - cleanup pod
- **Fixtures**: make JVM workloads build reliably by using **Temurin JDK images** (not JRE) because the fixtures compile `DummyMain.java` with `javac`.

## What we validate (why this matters)
We test that nodemon’s `GET /container/jvm-metrics` output is correct and useful for JVM-aware recommendations:
- **Non-Java exclusion**: `not-java` must not appear.
- **Flag extraction correctness**:
  - cmdline `-Xmx` (java8)
  - env `JAVA_TOOL_OPTIONS` (java11)
  - env `JDK_JAVA_OPTIONS` (java21)
- **Precedence model** (critical for recs / source attribution):
  - `cmdline` beats env
  - `JAVA_TOOL_OPTIONS > JDK_JAVA_OPTIONS > JAVA_OPTS`
  - per-flag sourcing works (e.g. Xmx from `JAVA_TOOL_OPTIONS`, Xms from `JDK_JAVA_OPTIONS`)
- **Heap sanity + consistency**:
  - `heap.max_bytes > 0` and `heap.used_bytes >= 0`
  - when `xmx_bytes` is known, `heap.max_bytes` must be *roughly* consistent with Xmx (buffered: ±max(16MiB, 10%) to avoid flakiness)

## Notes
- Assertions are kept in **Python** (no `jq` dependency).
- This PR only changes CI workflow + fixtures; it does not modify runtime JVM metrics collection logic.
}