### PR TITLE
ci: skip irrelevant workflows for docs- and helm-chart-only PRs

### DIFF
--- a/.github/workflows/build-installer-check.yml
+++ b/.github/workflows/build-installer-check.yml
@@ -2,6 +2,11 @@ name: Build Installer Check
 
 on:
   pull_request:
+    paths-ignore:
+      - '**.md'
+      - 'docs/**'
+      - 'LICENSE'
+      - 'helm-chart/**'
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -4,7 +4,17 @@ on:
   push:
     branches:
       - main
+    paths-ignore:
+      - '**.md'
+      - 'docs/**'
+      - 'LICENSE'
+      - 'helm-chart/**'
   pull_request:
+    paths-ignore:
+      - '**.md'
+      - 'docs/**'
+      - 'LICENSE'
+      - 'helm-chart/**'
   merge_group:
   workflow_dispatch:
 

--- a/.github/workflows/jvm-metrics-kind-test.yml
+++ b/.github/workflows/jvm-metrics-kind-test.yml
@@ -5,6 +5,12 @@ permissions:
 
 on:
   pull_request:
+    # Nodemon helm chart templates are exercised here, so do not ignore
+    # helm-chart/** — only skip documentation-only changes.
+    paths-ignore:
+      - '**.md'
+      - 'docs/**'
+      - 'LICENSE'
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/k8s-compatibility-test.yml
+++ b/.github/workflows/k8s-compatibility-test.yml
@@ -4,9 +4,42 @@ on:
   workflow_dispatch:
   pull_request:
 
+permissions:
+  contents: read
+  pull-requests: read
+
 jobs:
+  # The "Test on K8s ... (manifest)" jobs are required status checks, so we
+  # cannot use trigger-level paths-ignore (a non-running required check blocks
+  # merges forever). Instead we gate the build job on a changes filter; the test
+  # matrix `needs: build`, so it is skipped automatically when build is skipped,
+  # and skipped required checks are treated as satisfied.
+  #
+  # helm-chart/** is intentionally NOT ignored: helm-mode deploys render the
+  # chart templates, so chart changes must still be tested. Image-tag bumps in
+  # values.yaml are overwritten at test time, but path filters cannot tell those
+  # apart from template changes, so we keep running on any helm-chart change.
+  changes:
+    name: Detect relevant changes
+    runs-on: ubuntu-latest
+    outputs:
+      run: ${{ steps.filter.outputs.run }}
+    steps:
+      - name: Filter changed paths
+        uses: dorny/paths-filter@v3
+        id: filter
+        with:
+          filters: |
+            run:
+              - '**'
+              - '!**/*.md'
+              - '!docs/**'
+              - '!LICENSE'
+
   build:
     name: Build Docker Image
+    needs: changes
+    if: ${{ github.event_name == 'workflow_dispatch' || needs.changes.outputs.run == 'true' }}
     runs-on: ubuntu-latest
     outputs:
       image: ${{ steps.set-image.outputs.image }}

--- a/.github/workflows/metrics-server-lifecycle-test.yml
+++ b/.github/workflows/metrics-server-lifecycle-test.yml
@@ -5,6 +5,11 @@ name: Metrics Server Lifecycle Test
 on:
   workflow_dispatch:
   pull_request:
+    paths-ignore:
+      - '**.md'
+      - 'docs/**'
+      - 'LICENSE'
+      - 'helm-chart/**'
 
 jobs:
   build:

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -1,6 +1,7 @@
 name: Run Tests
 permissions:
   contents: read
+  pull-requests: read
 
 on:
   pull_request:
@@ -9,10 +10,34 @@ on:
   workflow_dispatch:
 
 jobs:
+  # "Run make test" is a required status check, so we cannot use trigger-level
+  # paths-ignore (a non-running required check blocks merges forever). Instead we
+  # gate the job on a changes filter: when only docs/helm-chart change the job is
+  # skipped, and a skipped required check is treated as satisfied.
+  changes:
+    name: Detect relevant changes
+    runs-on: ubuntu-latest
+    outputs:
+      run: ${{ steps.filter.outputs.run }}
+    steps:
+      - name: Filter changed paths
+        uses: dorny/paths-filter@v3
+        id: filter
+        with:
+          filters: |
+            run:
+              - '**'
+              - '!**/*.md'
+              - '!docs/**'
+              - '!LICENSE'
+              - '!helm-chart/**'
+
   test:
     name: Run make test
+    needs: changes
+    if: ${{ github.event_name == 'workflow_dispatch' || needs.changes.outputs.run == 'true' }}
     runs-on: ubuntu-latest
-    
+
     steps:
       - name: Checkout code
         uses: actions/checkout@v4


### PR DESCRIPTION
## Problem

Routine PRs that only touch docs (e.g. #400, `CHANGELOG.md`) or bump image tags in `helm-chart/*/values.yaml` (e.g. #401) trigger the **entire** CI suite — Go tests, lint, build-installer, jvm-metrics, metrics-server-lifecycle, and the 9-version × 2-method k8s-compatibility matrix — none of which can be affected by those changes.

## Approach

The helm chart is generated **from** the kustomize config (`build-chart` → `build-installer` → `helmify`), so `config/` is the source of truth and `helm-chart/` is downstream. Workflows split into two groups:

**Never read `helm-chart/`** (Go source / kustomize `config/` only) → ignore docs **and** `helm-chart/**`:
- `golangci-lint`, `run-tests` (`make test`), `build-installer-check`, `metrics-server-lifecycle-test` (`make deploy` = kustomize)

**Render chart templates live** (`helm install ./helm-chart/...`) → ignore docs only, keep running on `helm-chart/**`:
- `k8s-compatibility-test` (helm mode), `jvm-metrics-kind-test`

## Required-check handling

The `main` ruleset requires `Run make test` and `Test on K8s vX (manifest)`. Trigger-level `paths-ignore` on a required workflow would **deadlock merges** (a non-running required check never reports). So required workflows use a `dorny/paths-filter` **`changes` gate** + job-level `if:` — a *skipped* job still reports its context, satisfying the requirement. `workflow_dispatch` always runs. Non-required workflows use simple trigger-level `paths-ignore`.

## Effect
- **Docs-only PR** → all 6 skip (required checks report skipped → mergeable).
- **helm values bump** → 4 Go/kustomize workflows skip; `k8s-compat` + `jvm-metrics` still run (template safety).

## Verification
- All 6 files pass `yaml.safe_load`.
- `actionlint` clean on the additions (remaining warnings are pre-existing: `SC2086` info, unknown custom runner labels).

## Out of scope
- `Analyze (go)` / CodeQL is GitHub **default setup** (no workflow file in repo); its path behavior is controlled in repo Settings, not YAML.

🤖 Generated with [Claude Code](https://claude.com/claude-code)