### PR TITLE
ci: checkout before paths-filter in gate jobs

### DIFF
--- a/.github/workflows/k8s-compatibility-test.yml
+++ b/.github/workflows/k8s-compatibility-test.yml
@@ -25,6 +25,13 @@ jobs:
     outputs:
       run: ${{ steps.filter.outputs.run }}
     steps:
+      # paths-filter uses the GitHub API on pull_request events, but on push
+      # events it shells out to git and needs the repo checked out first.
+      # This workflow has no push trigger today, but keep the checkout so the
+      # gate stays correct if one is ever added (mirrors run-tests.yml).
+      - name: Checkout code
+        uses: actions/checkout@v4
+
       - name: Filter changed paths
         uses: dorny/paths-filter@v3
         id: filter

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -20,6 +20,12 @@ jobs:
     outputs:
       run: ${{ steps.filter.outputs.run }}
     steps:
+      # paths-filter uses the GitHub API on pull_request events, but on push
+      # events it shells out to git and needs the repo checked out first.
+      # Without this, pushes to main fail with "fatal: not a git repository".
+      - name: Checkout code
+        uses: actions/checkout@v4
+
       - name: Filter changed paths
         uses: dorny/paths-filter@v3
         id: filter


### PR DESCRIPTION
## Problem

The `Run Tests` workflow failed on the push of #402 to `main`:

```
[command]/usr/bin/git branch --show-current
fatal: not a git repository (or any of the parent directories): .git
##[error]The process '/usr/bin/git' failed with exit code 128
```

The `changes` gate job runs `dorny/paths-filter@v3` with no checkout. paths-filter uses the GitHub API on `pull_request` events (so it passed on PRs) but shells out to local `git` on `push` events — with no repo checked out it exits 128. Every push to `main` would fail until fixed.

## Fix

Add `actions/checkout@v4` before the filter step in both gate jobs:

- `run-tests.yml` — the one that actually failed (has a `push: [main]` trigger).
- `k8s-compatibility-test.yml` — same gate pattern, no push trigger today so only latently broken; hardened for consistency so it can't break if a push trigger is ever added.

Workflow-level `contents: read` already covers checkout; PR behavior is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)