### PR TITLE
Recognize dzkarp node operator by Helm instance label

### DIFF
--- a/internal/collector/karpenter_collector.go
+++ b/internal/collector/karpenter_collector.go
@@ -18,6 +18,16 @@ import (
 	"k8s.io/client-go/tools/cache"
 )
 
+// karpenterControllerLabelSelector selects the Karpenter controller
+// deployment. DevZero's dzkarp charts set app.kubernetes.io/name to the chart
+// name (e.g. "dzkarp-aws-karpenter"), not "karpenter", so selecting on the
+// name label misses every DevZero-managed install. The Helm release is
+// consistently "karpenter" across providers (and for upstream Karpenter), so
+// the instance label is the stable selector. Note: this collector matches any
+// Karpenter controller (upstream or DevZero-managed); it does not filter by
+// image like the health monitor's discoverDeployment does.
+const karpenterControllerLabelSelector = "app.kubernetes.io/instance=karpenter"
+
 // KarpenterResource defines a Karpenter resource to be watched
 type KarpenterResource struct {
 	GroupVersion schema.GroupVersion
@@ -86,7 +96,7 @@ func (c *KarpenterCollector) Start(ctx context.Context) error {
 		Version:  "v1",
 		Resource: "deployments",
 	}
-	labelSelector := "app.kubernetes.io/name=karpenter"
+	labelSelector := karpenterControllerLabelSelector
 
 	deployments, err := c.dynamicClient.Resource(gvr).List(ctx, metav1.ListOptions{
 		LabelSelector: labelSelector,
@@ -833,7 +843,7 @@ func (c *KarpenterCollector) IsAvailable(ctx context.Context) bool {
 		Resource: "deployments",
 	}
 
-	labelSelector := "app.kubernetes.io/name=karpenter"
+	labelSelector := karpenterControllerLabelSelector
 
 	deployments, err := c.dynamicClient.Resource(gvr).List(ctx, metav1.ListOptions{
 		LabelSelector: labelSelector,

--- a/internal/health/node_operator_monitor.go
+++ b/internal/health/node_operator_monitor.go
@@ -14,7 +14,15 @@ import (
 )
 
 const (
-	karpenterLabelName  = "app.kubernetes.io/name=karpenter"
+	// karpenterLabelName selects the Karpenter controller deployment/service.
+	// DevZero's dzkarp charts (dzkarp-aws-karpenter, dzkarp-azure-karpenter,
+	// dzkarp-gcp-karpenter, ...) set app.kubernetes.io/name to the chart name —
+	// e.g. "dzkarp-aws-karpenter" — NOT "karpenter", so selecting on the name
+	// label misses every DevZero-managed install. The Helm release is
+	// consistently "karpenter" across providers (and for upstream Karpenter),
+	// so app.kubernetes.io/instance is the stable selector; isDevZeroImage()
+	// then confirms the deployment is DevZero-managed.
+	karpenterLabelName  = "app.kubernetes.io/instance=karpenter"
 	defaultHealthPort   = "8081"
 	defaultProbeTimeout = 5 * time.Second
 )

--- a/internal/health/node_operator_monitor_test.go
+++ b/internal/health/node_operator_monitor_test.go
@@ -99,8 +99,9 @@ func TestNodeOperatorMonitor_DiscoverDeployment(t *testing.T) {
 				Name:      "karpenter",
 				Namespace: "kube-system",
 				Labels: map[string]string{
-					"app.kubernetes.io/name":    "karpenter",
-					"app.kubernetes.io/version": "1.7.8",
+					"app.kubernetes.io/name":     "karpenter",
+					"app.kubernetes.io/instance": "karpenter",
+					"app.kubernetes.io/version":  "1.7.8",
 				},
 			},
 			Spec: appsv1.DeploymentSpec{
@@ -137,13 +138,64 @@ func TestNodeOperatorMonitor_DiscoverDeployment(t *testing.T) {
 		assert.Equal(t, "kube-system", found.Namespace)
 	})
 
+	// Regression: dzKarp Helm charts name the deployment "<release>-<chart>"
+	// (e.g. "karpenter-dzkarp-aws-karpenter") and set
+	// app.kubernetes.io/name to the chart name, NOT "karpenter". The old
+	// name=karpenter selector missed these entirely, so the node operator
+	// showed as "not installed". Discovery must key on the instance label.
+	t.Run("finds dzKarp deployment whose name label is the chart name", func(t *testing.T) {
+		dep := &appsv1.Deployment{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "karpenter-dzkarp-aws-karpenter",
+				Namespace: "devzero-system",
+				Labels: map[string]string{
+					"app.kubernetes.io/name":     "dzkarp-aws-karpenter",
+					"app.kubernetes.io/instance": "karpenter",
+					"app.kubernetes.io/version":  "1.7.16",
+				},
+			},
+			Spec: appsv1.DeploymentSpec{
+				Replicas: int32Ptr(1),
+				Selector: &metav1.LabelSelector{
+					MatchLabels: map[string]string{
+						"app.kubernetes.io/instance": "karpenter",
+					},
+				},
+				Template: corev1.PodTemplateSpec{
+					Spec: corev1.PodSpec{
+						Containers: []corev1.Container{
+							{
+								Name:  "controller",
+								Image: "docker.io/devzeroinc/dzkarp-aws-controller:1.7.16",
+							},
+						},
+					},
+				},
+			},
+			Status: appsv1.DeploymentStatus{
+				Replicas:          1,
+				ReadyReplicas:     1,
+				AvailableReplicas: 1,
+			},
+		}
+		clientset := fake.NewSimpleClientset(dep)
+		mon := NewNodeOperatorMonitor(logr.Discard(), clientset, &http.Client{})
+
+		found, err := mon.discoverDeployment(context.Background())
+		require.NoError(t, err)
+		require.NotNil(t, found)
+		assert.Equal(t, "karpenter-dzkarp-aws-karpenter", found.Name)
+		assert.Equal(t, "devzero-system", found.Namespace)
+	})
+
 	t.Run("ignores upstream karpenter without devzero image", func(t *testing.T) {
 		dep := &appsv1.Deployment{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      "karpenter",
 				Namespace: "karpenter",
 				Labels: map[string]string{
-					"app.kubernetes.io/name": "karpenter",
+					"app.kubernetes.io/name":     "karpenter",
+					"app.kubernetes.io/instance": "karpenter",
 				},
 			},
 			Spec: appsv1.DeploymentSpec{
@@ -266,7 +318,8 @@ func TestNodeOperatorMonitor_DiscoverServiceEndpoint(t *testing.T) {
 				Name:      "karpenter",
 				Namespace: "kube-system",
 				Labels: map[string]string{
-					"app.kubernetes.io/name": "karpenter",
+					"app.kubernetes.io/name":     "karpenter",
+					"app.kubernetes.io/instance": "karpenter",
 				},
 			},
 			Spec: corev1.ServiceSpec{
@@ -289,7 +342,8 @@ func TestNodeOperatorMonitor_DiscoverServiceEndpoint(t *testing.T) {
 				Name:      "karpenter",
 				Namespace: "kube-system",
 				Labels: map[string]string{
-					"app.kubernetes.io/name": "karpenter",
+					"app.kubernetes.io/name":     "karpenter",
+					"app.kubernetes.io/instance": "karpenter",
 				},
 			},
 			Spec: corev1.ServiceSpec{
@@ -348,8 +402,9 @@ func TestNodeOperatorMonitor_BuildReport(t *testing.T) {
 				Name:      "karpenter",
 				Namespace: "kube-system",
 				Labels: map[string]string{
-					"app.kubernetes.io/name":    "karpenter",
-					"app.kubernetes.io/version": "1.7.8",
+					"app.kubernetes.io/name":     "karpenter",
+					"app.kubernetes.io/instance": "karpenter",
+					"app.kubernetes.io/version":  "1.7.8",
 				},
 				CreationTimestamp: metav1.Now(),
 			},
@@ -379,7 +434,8 @@ func TestNodeOperatorMonitor_BuildReport(t *testing.T) {
 				Name:      "karpenter",
 				Namespace: "kube-system",
 				Labels: map[string]string{
-					"app.kubernetes.io/name": "karpenter",
+					"app.kubernetes.io/name":     "karpenter",
+					"app.kubernetes.io/instance": "karpenter",
 				},
 			},
 			Spec: corev1.ServiceSpec{
@@ -435,8 +491,9 @@ func TestNodeOperatorMonitor_BuildReport(t *testing.T) {
 				Name:      "karpenter",
 				Namespace: "kube-system",
 				Labels: map[string]string{
-					"app.kubernetes.io/name":    "karpenter",
-					"app.kubernetes.io/version": "1.7.8",
+					"app.kubernetes.io/name":     "karpenter",
+					"app.kubernetes.io/instance": "karpenter",
+					"app.kubernetes.io/version":  "1.7.8",
 				},
 				CreationTimestamp: metav1.Now(),
 			},


### PR DESCRIPTION
## What?

Fixes Karpenter node-operator detection so DevZero-managed Karpenter (`dzkarp`) installs are recognized. zxporter now locates the Karpenter controller deployment/service by `app.kubernetes.io/instance=karpenter` instead of `app.kubernetes.io/name=karpenter`, across all three discovery sites (`NodeOperatorMonitor.discoverDeployment`/`discoverServiceEndpoint`, and `KarpenterCollector.Start`/`IsAvailable`).

## Why?

On clusters running `dzkarp`, the dashboard showed the **Node Operator as "not installed"** even though `karpenter-dzkarp-aws-karpenter` was healthy (`1/1 Running`). The dzkarp Helm charts label the deployment `app.kubernetes.io/name=dzkarp-aws-karpenter` (the chart name) with the release under `app.kubernetes.io/instance=karpenter`. The old `name=karpenter` selector matched **nothing** on these clusters, so:

- the `NODE` operator heartbeat was never sent ("No DevZero-managed Karpenter deployment found, skipping…"), and
- the Karpenter controller Deployment was never collected/ingested.

The control plane then had no heartbeat and no managed-deployment record for the node operator, so it reported it as uninstalled. This restores accurate node-operator status (and version reporting) for every dzkarp cluster.

## How?

The Helm `instance` label is the release name, which is consistently `karpenter` across the AWS/Azure/GCP/OCI dzkarp charts **and** for upstream Karpenter — so it's a stable selector where the chart-specific `name` label is not. The existing `isDevZeroImage()` and `controller` container-name/image checks remain as the authoritative discriminators, so broadening the pre-filter doesn't loosen what we treat as DevZero-managed. The selector is now a shared const in the collector to keep the two call sites in sync.

Considered keying on the `name` label with a set-based selector enumerating each provider's chart name (`dzkarp-aws-karpenter`, etc.), but that's fragile — a new or renamed provider chart would silently regress. The `instance` label avoids hardcoding chart names.

## Testing?

`go build`, `go vet`, and `go test ./internal/health/ ./internal/collector/` all pass. Added a regression test in `node_operator_monitor_test.go` covering a dzkarp deployment whose `name` label is the chart name (`dzkarp-aws-karpenter`) with `instance=karpenter` — it fails under the old selector and passes under the new one. Existing fixtures were updated to carry the `instance` label that real Karpenter/dzkarp deployments always set. golangci-lint reports only pre-existing findings in unrelated files; none in the changed files.

Verified the selector mismatch against a live dzkarp cluster: `kubectl get deploy -A -l app.kubernetes.io/name=karpenter` returns nothing, while `-l app.kubernetes.io/instance=karpenter` matches `karpenter-dzkarp-aws-karpenter`.

## Anything Else?

This is a zxporter (Read Operator) change, so existing clusters pick it up only after a zxporter release and Read Operator upgrade. The control-plane read path (`GetClusterOperatorHealth` / `GetKarpenterInfo`) needs no change — once the heartbeat and Deployment flow, it reports the node operator and its version correctly.
