### PR TITLE
Guarantee node/container metrics coverage with kubelet fallback

### DIFF
--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -34,6 +34,7 @@ rules:
   - ""
   resources:
   - nodes/metrics
+  - nodes/proxy
   - nodes/status
   - pods/status
   verbs:

--- a/dist/backend-install.yaml
+++ b/dist/backend-install.yaml
@@ -181,6 +181,7 @@ rules:
       - ""
     resources:
       - nodes/metrics
+      - nodes/proxy
       - nodes/status
       - pods/status
     verbs:
@@ -936,6 +937,9 @@ spec:
         app.kubernetes.io/name: zxporter-nodemon
         app.kubernetes.io/instance: zxporter-nodemon
     spec:
+      # nodemon is the sole source of node/container metrics, so it must run on every node and
+      # survive scheduling pressure on all providers (not just EKS).
+      priorityClassName: system-node-critical
       serviceAccountName: zxporter-nodemon
       volumes:
         - name: "pod-gpu-resources"
@@ -999,6 +1003,9 @@ spec:
           imagePullPolicy: IfNotPresent
           command: ["/bin/bash", "-c"]
           args:
+            # nodemon now schedules on every node (incl. non-GPU), so the DCGM sidecar must idle
+            # gracefully instead of crashlooping where there is no GPU. Use the resilient retry loop
+            # for all providers, including GCP.
             - hostname $NODE_NAME; for ((;;)) { r=$(dcgm-exporter -f /etc/dcgm-exporter/counters.csv); echo "dcgm-exporter could not run"; sleep 60 ; }
           ports:
             - name: "metrics"

--- a/dist/install.yaml
+++ b/dist/install.yaml
@@ -181,6 +181,7 @@ rules:
   - ""
   resources:
   - nodes/metrics
+  - nodes/proxy
   - nodes/status
   - pods/status
   verbs:
@@ -936,6 +937,9 @@ spec:
         app.kubernetes.io/name: zxporter-nodemon
         app.kubernetes.io/instance: zxporter-nodemon
     spec:
+      # nodemon is the sole source of node/container metrics, so it must run on every node and
+      # survive scheduling pressure on all providers (not just EKS).
+      priorityClassName: system-node-critical
       serviceAccountName: zxporter-nodemon
       volumes:
         - name: "pod-gpu-resources"
@@ -999,6 +1003,9 @@ spec:
           imagePullPolicy: IfNotPresent
           command: [ "/bin/bash", "-c" ]
           args:
+          # nodemon now schedules on every node (incl. non-GPU), so the DCGM sidecar must idle
+          # gracefully instead of crashlooping where there is no GPU. Use the resilient retry loop
+          # for all providers, including GCP.
             - hostname $NODE_NAME; for ((;;)) { r=$(dcgm-exporter -f /etc/dcgm-exporter/counters.csv); echo "dcgm-exporter could not run"; sleep 60 ; }
           ports:
             - name: "metrics"

--- a/dist/installer_updater.yaml
+++ b/dist/installer_updater.yaml
@@ -181,6 +181,7 @@ rules:
       - ""
     resources:
       - nodes/metrics
+      - nodes/proxy
       - nodes/status
       - pods/status
     verbs:
@@ -873,6 +874,9 @@ spec:
         app.kubernetes.io/name: zxporter-nodemon
         app.kubernetes.io/instance: zxporter-nodemon
     spec:
+      # nodemon is the sole source of node/container metrics, so it must run on every node and
+      # survive scheduling pressure on all providers (not just EKS).
+      priorityClassName: system-node-critical
       serviceAccountName: zxporter-nodemon
       volumes:
         - name: "pod-gpu-resources"
@@ -936,6 +940,9 @@ spec:
           imagePullPolicy: IfNotPresent
           command: ["/bin/bash", "-c"]
           args:
+            # nodemon now schedules on every node (incl. non-GPU), so the DCGM sidecar must idle
+            # gracefully instead of crashlooping where there is no GPU. Use the resilient retry loop
+            # for all providers, including GCP.
             - hostname $NODE_NAME; for ((;;)) { r=$(dcgm-exporter -f /etc/dcgm-exporter/counters.csv); echo "dcgm-exporter could not run"; sleep 60 ; }
           ports:
             - name: "metrics"

--- a/dist/nodemon.yaml
+++ b/dist/nodemon.yaml
@@ -174,6 +174,9 @@ spec:
         app.kubernetes.io/name: zxporter-nodemon
         app.kubernetes.io/instance: zxporter-nodemon
     spec:
+      # nodemon is the sole source of node/container metrics, so it must run on every node and
+      # survive scheduling pressure on all providers (not just EKS).
+      priorityClassName: system-node-critical
       serviceAccountName: zxporter-nodemon
       volumes:
         - name: "pod-gpu-resources"
@@ -237,6 +240,9 @@ spec:
           imagePullPolicy: IfNotPresent
           command: [ "/bin/bash", "-c" ]
           args:
+          # nodemon now schedules on every node (incl. non-GPU), so the DCGM sidecar must idle
+          # gracefully instead of crashlooping where there is no GPU. Use the resilient retry loop
+          # for all providers, including GCP.
             - hostname $NODE_NAME; for ((;;)) { r=$(dcgm-exporter -f /etc/dcgm-exporter/counters.csv); echo "dcgm-exporter could not run"; sleep 60 ; }
           ports:
             - name: "metrics"

--- a/dist/zxporter.yaml
+++ b/dist/zxporter.yaml
@@ -172,6 +172,7 @@ rules:
   - ""
   resources:
   - nodes/metrics
+  - nodes/proxy
   - nodes/status
   - pods/status
   verbs:

--- a/helm-chart/zxporter-nodemon/templates/daemonset.yaml
+++ b/helm-chart/zxporter-nodemon/templates/daemonset.yaml
@@ -32,9 +32,10 @@ spec:
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-      {{- if eq (required ".Values.provider is required (gcp|eks|azure)" .Values.provider) "eks" }}
+      {{- $provider := required ".Values.provider is required (gcp|eks|azure)" .Values.provider }}
+      # nodemon is the sole source of node/container metrics, so it must run on every node and
+      # survive scheduling pressure on all providers (not just EKS).
       priorityClassName: system-node-critical
-      {{- end }}
       serviceAccountName: {{ include "zxporter-nodemon.serviceAccountName" . }}
       {{- if .Values.dcgmExporter.enabled }}
       volumes:
@@ -54,16 +55,9 @@ spec:
       nodeSelector:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-      {{- if .Values.nodemon.affinity }}
       {{- with .Values.nodemon.affinity }}
       affinity:
         {{- toYaml . | nindent 8 }}
-      {{- end }}
-      {{- else if (eq .Values.provider "gcp")}}
-      {{- with .Values.gcp.affinity }}
-      affinity:
-        {{- toYaml . | nindent 8 }}
-      {{- end }}
       {{- end }}
       {{- with .Values.nodemon.tolerations }}
       tolerations:
@@ -128,18 +122,13 @@ spec:
           imagePullPolicy: {{ .Values.dcgmExporter.image.pullPolicy }}
           command: [ "/bin/bash", "-c" ]
           args:
-          {{- if eq .Values.provider "gcp"}}
-            {{- if .Values.dcgmExporter.useExternalHostEngine }}
-            - hostname $NODE_NAME; dcgm-exporter --remote-hostengine-info ${NODE_IP} -f /etc/dcgm-exporter/counters.csv
-            {{- else }}
-            - hostname $NODE_NAME; dcgm-exporter -f /etc/dcgm-exporter/counters.csv
-            {{- end }}
-          {{- else }}
-            {{- if .Values.dcgmExporter.useExternalHostEngine }}
+          # nodemon now schedules on every node (incl. non-GPU), so the DCGM sidecar must idle
+          # gracefully instead of crashlooping where there is no GPU. Use the resilient retry loop
+          # for all providers, including GCP.
+          {{- if .Values.dcgmExporter.useExternalHostEngine }}
             - hostname $NODE_NAME; for ((;;)) { r=$(dcgm-exporter --remote-hostengine-info ${NODE_IP} -f /etc/dcgm-exporter/counters.csv); echo "dcgm-exporter could not run"; sleep 60 ; }
-            {{- else }}
+          {{- else }}
             - hostname $NODE_NAME; for ((;;)) { r=$(dcgm-exporter -f /etc/dcgm-exporter/counters.csv); echo "dcgm-exporter could not run"; sleep 60 ; }
-            {{- end }}
           {{- end }}
           ports:
             - name: "metrics"

--- a/helm-chart/zxporter-nodemon/values.yaml
+++ b/helm-chart/zxporter-nodemon/values.yaml
@@ -12,9 +12,10 @@ image:
   tag: "v0.0.83"
 
 nodemon:
-  # the affinity field is the preferred way of adding affinity annotations
-  # for gcp provider the gcp.affinity will be used if this isn't defined but in the future custom affinity annotations
-  # should be defined in the nodemon.affinity field
+  # nodemon.affinity -- optional pod affinity/anti-affinity. Leave empty so nodemon schedules on
+  # EVERY node (it is the sole source of node/container metrics). Only set this if you intentionally
+  # want to restrict where nodemon runs. NOTE: this is no longer GPU-gated on GCP — DCGM/GPU metrics
+  # are handled by the dcgm-exporter sidecar, which idles gracefully on non-GPU nodes.
   affinity:
   config: { }
   # config:
@@ -54,15 +55,6 @@ dcgmExporter:
     pullPolicy: IfNotPresent
     tag: 3.3.7-3.5.0-ubuntu22.04
   useExternalHostEngine: false
-
-gcp:
-  affinity:
-    nodeAffinity:
-      requiredDuringSchedulingIgnoredDuringExecution:
-        nodeSelectorTerms:
-          - matchExpressions:
-              - key: cloud.google.com/gke-accelerator
-                operator: Exists
 
 migrate:
   image:

--- a/helm-chart/zxporter/templates/zxporter-rbac.yaml
+++ b/helm-chart/zxporter/templates/zxporter-rbac.yaml
@@ -276,6 +276,7 @@ rules:
   - ""
   resources:
   - nodes/metrics
+  - nodes/proxy
   - nodes/status
   - pods/status
   verbs:

--- a/internal/collector/container_resource_collector.go
+++ b/internal/collector/container_resource_collector.go
@@ -304,7 +304,7 @@ func (c *ContainerResourceCollector) collectAllContainerResources(ctx context.Co
 	// Pre-fetch container metrics from nodemon for network/IO/throttle (one call per cycle)
 	c.nodemonContainerMetricsCache = nil
 	if c.nodemonClient != nil {
-		allContainerMetrics, err := c.nodemonClient.FetchAllContainerMetrics(ctx)
+		allContainerMetrics, _, err := c.nodemonClient.FetchAllContainerMetrics(ctx)
 		if err != nil {
 			c.logger.Error(err, "Failed to fetch container metrics from nodemon")
 		} else {
@@ -658,14 +658,15 @@ func (c *ContainerResourceCollector) processContainerMetrics(
 // of collectAllContainerResources to work unchanged — CPU/memory come from nodemon's
 // stats/summary data (usageNanoCores, workingSetBytes) instead of the metrics-server API.
 func (c *ContainerResourceCollector) buildPodMetricsFromNodemon(ctx context.Context) (*metricsv1beta1.PodMetricsList, error) {
-	allMetrics, err := c.nodemonClient.FetchAllContainerMetrics(ctx)
+	allMetrics, failedNodes, err := c.nodemonClient.FetchAllContainerMetrics(ctx)
 	if err != nil {
 		return nil, fmt.Errorf("failed to fetch container metrics from nodemon: %w", err)
 	}
 
-	// Kubelet fallback: for any node that has pods but no nodemon pod, scrape the
-	// kubelet Summary API directly so those containers still get CPU/memory metrics.
-	allMetrics = append(allMetrics, c.fallbackContainerMetrics(ctx)...)
+	// Kubelet fallback: for any node that has pods but no nodemon pod — OR where
+	// the nodemon pod is Running but failed to serve metrics — scrape the kubelet
+	// Summary API directly so those containers still get CPU/memory metrics.
+	allMetrics = append(allMetrics, c.fallbackContainerMetrics(ctx, failedNodes)...)
 
 	// Group by pod
 	podMap := make(map[string]*metricsv1beta1.PodMetrics)
@@ -708,10 +709,14 @@ func (c *ContainerResourceCollector) buildPodMetricsFromNodemon(ctx context.Cont
 	return result, nil
 }
 
-// fallbackContainerMetrics scrapes the kubelet Summary API for any node that has
-// pods but no running nodemon pod, returning per-container CPU/memory metrics so
-// those nodes are not metrics blind spots. Errors are logged per-node and skipped.
-func (c *ContainerResourceCollector) fallbackContainerMetrics(ctx context.Context) []UnifiedContainerMetric {
+// fallbackContainerMetrics scrapes the kubelet Summary API for any node that
+// needs it, returning per-container CPU/memory metrics so those nodes are not
+// metrics blind spots. A node needs fallback if:
+//   - it has no running nodemon pod at all (not in CoveredNodes), OR
+//   - it has a Running nodemon pod that failed to serve metrics (in nodemonFailedNodes)
+//
+// Errors are logged per-node and skipped.
+func (c *ContainerResourceCollector) fallbackContainerMetrics(ctx context.Context, nodemonFailedNodes map[string]struct{}) []UnifiedContainerMetric {
 	if c.podInformer == nil {
 		return nil
 	}
@@ -722,7 +727,13 @@ func (c *ContainerResourceCollector) fallbackContainerMetrics(ctx context.Contex
 		return nil
 	}
 
-	// Collect distinct node names that host pods but lack a nodemon pod.
+	// Remove nodes where nodemon was "covered" (Running) but actually failed to serve.
+	// These need the kubelet fallback just like nodes with no nodemon pod.
+	for node := range nodemonFailedNodes {
+		delete(covered, node)
+	}
+
+	// Collect distinct node names that host pods but lack working nodemon coverage.
 	uncovered := make(map[string]struct{})
 	for _, obj := range c.podInformer.GetIndexer().List() {
 		pod, ok := obj.(*corev1.Pod)

--- a/internal/collector/container_resource_collector.go
+++ b/internal/collector/container_resource_collector.go
@@ -80,6 +80,7 @@ type ContainerResourceCollector struct {
 	k8sClient       kubernetes.Interface
 	metricsClient   *metricsv1.Clientset
 	nodemonClient   *NodemonClient
+	kubeletClient   *KubeletSummaryClient
 	informerFactory informers.SharedInformerFactory
 	podInformer     cache.SharedIndexInformer
 	batchChan       chan CollectedResource   // Channel for individual resources -> input to batcher
@@ -155,11 +156,13 @@ func NewContainerResourceCollector(
 		ns = defaultNamespace
 	}
 	nodemonClient := NewNodemonClient(k8sClient, ns, logger)
+	kubeletClient := NewKubeletSummaryClient(k8sClient, logger)
 
 	return &ContainerResourceCollector{
 		k8sClient:        k8sClient,
 		metricsClient:    metricsClient,
 		nodemonClient:    nodemonClient,
+		kubeletClient:    kubeletClient,
 		batchChan:        batchChan,
 		resourceChan:     resourceChan,
 		batcher:          batcher,
@@ -660,6 +663,10 @@ func (c *ContainerResourceCollector) buildPodMetricsFromNodemon(ctx context.Cont
 		return nil, fmt.Errorf("failed to fetch container metrics from nodemon: %w", err)
 	}
 
+	// Kubelet fallback: for any node that has pods but no nodemon pod, scrape the
+	// kubelet Summary API directly so those containers still get CPU/memory metrics.
+	allMetrics = append(allMetrics, c.fallbackContainerMetrics(ctx)...)
+
 	// Group by pod
 	podMap := make(map[string]*metricsv1beta1.PodMetrics)
 	for _, m := range allMetrics {
@@ -699,6 +706,51 @@ func (c *ContainerResourceCollector) buildPodMetricsFromNodemon(ctx context.Cont
 
 	c.logger.V(1).Info("Built pod metrics from nodemon", "pods", len(result.Items), "containers", len(allMetrics))
 	return result, nil
+}
+
+// fallbackContainerMetrics scrapes the kubelet Summary API for any node that has
+// pods but no running nodemon pod, returning per-container CPU/memory metrics so
+// those nodes are not metrics blind spots. Errors are logged per-node and skipped.
+func (c *ContainerResourceCollector) fallbackContainerMetrics(ctx context.Context) []UnifiedContainerMetric {
+	if c.podInformer == nil {
+		return nil
+	}
+
+	covered, err := c.nodemonClient.CoveredNodes(ctx)
+	if err != nil {
+		c.logger.V(1).Info("Could not determine nodemon coverage, skipping kubelet fallback", "error", err)
+		return nil
+	}
+
+	// Collect distinct node names that host pods but lack a nodemon pod.
+	uncovered := make(map[string]struct{})
+	for _, obj := range c.podInformer.GetIndexer().List() {
+		pod, ok := obj.(*corev1.Pod)
+		if !ok || pod.Spec.NodeName == "" {
+			continue
+		}
+		if !covered[pod.Spec.NodeName] {
+			uncovered[pod.Spec.NodeName] = struct{}{}
+		}
+	}
+	if len(uncovered) == 0 {
+		return nil
+	}
+
+	var fallback []UnifiedContainerMetric
+	for node := range uncovered {
+		metrics, err := c.kubeletClient.FetchContainerMetricsByNode(ctx, node)
+		if err != nil {
+			c.logger.V(1).Info("Kubelet container-metrics fallback failed", "node", node, "error", err)
+			continue
+		}
+		fallback = append(fallback, metrics...)
+	}
+	if len(fallback) > 0 {
+		c.logger.V(1).Info("Kubelet fallback supplied container metrics",
+			"nodesWithoutNodemon", len(uncovered), "containers", len(fallback))
+	}
+	return fallback
 }
 
 // indexContainerMetricsByPod builds a lookup map keyed by "namespace/podName" from a

--- a/internal/collector/kubelet_summary_client.go
+++ b/internal/collector/kubelet_summary_client.go
@@ -1,0 +1,184 @@
+package collector
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"time"
+
+	"github.com/go-logr/logr"
+	"k8s.io/client-go/kubernetes"
+)
+
+// KubeletSummaryClient fetches per-node resource usage directly from the kubelet
+// Summary API (/stats/summary) via the API-server node proxy subresource.
+//
+// It exists as a fallback for nodes that have NO zxporter-nodemon pod running
+// (e.g. the DaemonSet pod failed to schedule, or is not yet ready). Because the
+// kubelet runs on every node by construction, this gives a hard coverage
+// guarantee that a DaemonSet alone cannot.
+//
+// The Summary API exposes the same kubelet stats nodemon itself is built on
+// (usageNanoCores / workingSetBytes), so results are returned in the existing
+// UnifiedNodeMetric / UnifiedContainerMetric shapes and reuse all downstream
+// conversion. Only CPU + memory are available here — network/disk rates,
+// CPU-throttle, GPU and JVM metrics remain nodemon-only and stay zero for
+// fallback nodes (a deliberate degraded mode, on par with what metrics-server
+// would have provided).
+type KubeletSummaryClient struct {
+	k8sClient kubernetes.Interface
+	log       logr.Logger
+}
+
+// NewKubeletSummaryClient creates a client that reads kubelet /stats/summary
+// through the API-server node proxy. It requires the `nodes/proxy` (get) RBAC
+// verb on the zxporter ClusterRole.
+func NewKubeletSummaryClient(k8sClient kubernetes.Interface, log logr.Logger) *KubeletSummaryClient {
+	return &KubeletSummaryClient{
+		k8sClient: k8sClient,
+		log:       log.WithName("kubelet-summary-client"),
+	}
+}
+
+// kubeletSummary is a minimal subset of k8s.io/kubelet/pkg/apis/stats/v1alpha1.Summary.
+// Defined locally to avoid adding the k8s.io/kubelet dependency.
+type kubeletSummary struct {
+	Node kubeletNodeStats  `json:"node"`
+	Pods []kubeletPodStats `json:"pods"`
+}
+
+type kubeletNodeStats struct {
+	NodeName string              `json:"nodeName"`
+	CPU      *kubeletCPUStats    `json:"cpu"`
+	Memory   *kubeletMemoryStats `json:"memory"`
+}
+
+type kubeletPodStats struct {
+	PodRef     kubeletPodReference     `json:"podRef"`
+	Containers []kubeletContainerStats `json:"containers"`
+}
+
+type kubeletPodReference struct {
+	Name      string `json:"name"`
+	Namespace string `json:"namespace"`
+}
+
+type kubeletContainerStats struct {
+	Name   string              `json:"name"`
+	CPU    *kubeletCPUStats    `json:"cpu"`
+	Memory *kubeletMemoryStats `json:"memory"`
+}
+
+type kubeletCPUStats struct {
+	Time           time.Time `json:"time"`
+	UsageNanoCores *uint64   `json:"usageNanoCores"`
+}
+
+type kubeletMemoryStats struct {
+	WorkingSetBytes *uint64 `json:"workingSetBytes"`
+	UsageBytes      *uint64 `json:"usageBytes"`
+	RSSBytes        *uint64 `json:"rssBytes"`
+}
+
+// fetchSummary retrieves and parses the kubelet Summary API for a single node
+// via GET /api/v1/nodes/<node>/proxy/stats/summary.
+func (c *KubeletSummaryClient) fetchSummary(ctx context.Context, nodeName string) (*kubeletSummary, error) {
+	raw, err := c.k8sClient.CoreV1().RESTClient().
+		Get().
+		Resource("nodes").
+		Name(nodeName).
+		SubResource("proxy").
+		Suffix("stats", "summary").
+		DoRaw(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("fetching kubelet summary for node %s: %w", nodeName, err)
+	}
+
+	return parseKubeletSummary(raw, nodeName)
+}
+
+// parseKubeletSummary unmarshals raw kubelet Summary API JSON. Split out from the
+// HTTP call so it can be unit-tested with fixtures.
+func parseKubeletSummary(raw []byte, nodeName string) (*kubeletSummary, error) {
+	var summary kubeletSummary
+	if err := json.Unmarshal(raw, &summary); err != nil {
+		return nil, fmt.Errorf("decoding kubelet summary for node %s: %w", nodeName, err)
+	}
+	return &summary, nil
+}
+
+// FetchNodeMetricsByNode returns node-level CPU/memory usage for the given node
+// from the kubelet Summary API. Returns a metric with zeroed fields where the
+// kubelet did not report a value.
+func (c *KubeletSummaryClient) FetchNodeMetricsByNode(
+	ctx context.Context,
+	nodeName string,
+) (*UnifiedNodeMetric, error) {
+	summary, err := c.fetchSummary(ctx, nodeName)
+	if err != nil {
+		return nil, err
+	}
+	return nodeMetricFromSummary(nodeName, summary), nil
+}
+
+// nodeMetricFromSummary converts node-level kubelet stats into a UnifiedNodeMetric.
+func nodeMetricFromSummary(nodeName string, summary *kubeletSummary) *UnifiedNodeMetric {
+	m := &UnifiedNodeMetric{NodeName: nodeName}
+	if cpu := summary.Node.CPU; cpu != nil {
+		m.Timestamp = cpu.Time
+		if cpu.UsageNanoCores != nil {
+			m.CPUUsageNanoCores = *cpu.UsageNanoCores
+		}
+	}
+	if mem := summary.Node.Memory; mem != nil && mem.WorkingSetBytes != nil {
+		m.MemoryWorkingSet = *mem.WorkingSetBytes
+	}
+	return m
+}
+
+// FetchContainerMetricsByNode returns per-container CPU/memory usage for all pods
+// on the given node from the kubelet Summary API.
+func (c *KubeletSummaryClient) FetchContainerMetricsByNode(
+	ctx context.Context,
+	nodeName string,
+) ([]UnifiedContainerMetric, error) {
+	summary, err := c.fetchSummary(ctx, nodeName)
+	if err != nil {
+		return nil, err
+	}
+	return containerMetricsFromSummary(nodeName, summary), nil
+}
+
+// containerMetricsFromSummary converts per-container kubelet stats into UnifiedContainerMetric.
+func containerMetricsFromSummary(nodeName string, summary *kubeletSummary) []UnifiedContainerMetric {
+	var out []UnifiedContainerMetric
+	for _, pod := range summary.Pods {
+		for _, ctr := range pod.Containers {
+			m := UnifiedContainerMetric{
+				NodeName:  nodeName,
+				Namespace: pod.PodRef.Namespace,
+				Pod:       pod.PodRef.Name,
+				Container: ctr.Name,
+			}
+			if cpu := ctr.CPU; cpu != nil {
+				m.Timestamp = cpu.Time
+				if cpu.UsageNanoCores != nil {
+					m.CPUUsageNanoCores = *cpu.UsageNanoCores
+				}
+			}
+			if mem := ctr.Memory; mem != nil {
+				if mem.WorkingSetBytes != nil {
+					m.MemoryWorkingSet = *mem.WorkingSetBytes
+				}
+				if mem.UsageBytes != nil {
+					m.MemoryUsageBytes = *mem.UsageBytes
+				}
+				if mem.RSSBytes != nil {
+					m.MemoryRSSBytes = *mem.RSSBytes
+				}
+			}
+			out = append(out, m)
+		}
+	}
+	return out
+}

--- a/internal/collector/kubelet_summary_client_test.go
+++ b/internal/collector/kubelet_summary_client_test.go
@@ -1,0 +1,105 @@
+package collector
+
+import (
+	"testing"
+)
+
+const sampleSummaryJSON = `{
+  "node": {
+    "nodeName": "node-a",
+    "cpu": {"time": "2026-06-17T10:00:00Z", "usageNanoCores": 1500000000},
+    "memory": {"workingSetBytes": 2147483648}
+  },
+  "pods": [
+    {
+      "podRef": {"name": "web-0", "namespace": "default"},
+      "containers": [
+        {
+          "name": "app",
+          "cpu": {"time": "2026-06-17T10:00:00Z", "usageNanoCores": 250000000},
+          "memory": {"workingSetBytes": 104857600, "usageBytes": 120000000, "rssBytes": 90000000}
+        },
+        {
+          "name": "sidecar",
+          "cpu": {"usageNanoCores": 50000000},
+          "memory": {"workingSetBytes": 10485760}
+        }
+      ]
+    }
+  ]
+}`
+
+func TestParseKubeletSummary_NodeMetric(t *testing.T) {
+	summary, err := parseKubeletSummary([]byte(sampleSummaryJSON), "node-a")
+	if err != nil {
+		t.Fatalf("parse failed: %v", err)
+	}
+
+	nm := nodeMetricFromSummary("node-a", summary)
+	if nm.NodeName != "node-a" {
+		t.Errorf("node name = %q, want node-a", nm.NodeName)
+	}
+	if nm.CPUUsageNanoCores != 1500000000 {
+		t.Errorf("cpu = %d, want 1500000000", nm.CPUUsageNanoCores)
+	}
+	if nm.MemoryWorkingSet != 2147483648 {
+		t.Errorf("mem = %d, want 2147483648", nm.MemoryWorkingSet)
+	}
+	if nm.Timestamp.IsZero() {
+		t.Error("expected non-zero timestamp from cpu.time")
+	}
+}
+
+func TestParseKubeletSummary_ContainerMetrics(t *testing.T) {
+	summary, err := parseKubeletSummary([]byte(sampleSummaryJSON), "node-a")
+	if err != nil {
+		t.Fatalf("parse failed: %v", err)
+	}
+
+	cms := containerMetricsFromSummary("node-a", summary)
+	if len(cms) != 2 {
+		t.Fatalf("got %d container metrics, want 2", len(cms))
+	}
+
+	app := cms[0]
+	if app.Namespace != "default" || app.Pod != "web-0" || app.Container != "app" {
+		t.Errorf("unexpected identity: %+v", app)
+	}
+	if app.NodeName != "node-a" {
+		t.Errorf("node name = %q, want node-a", app.NodeName)
+	}
+	if app.CPUUsageNanoCores != 250000000 {
+		t.Errorf("app cpu = %d, want 250000000", app.CPUUsageNanoCores)
+	}
+	if app.MemoryWorkingSet != 104857600 || app.MemoryUsageBytes != 120000000 || app.MemoryRSSBytes != 90000000 {
+		t.Errorf("app memory mismatch: ws=%d usage=%d rss=%d", app.MemoryWorkingSet, app.MemoryUsageBytes, app.MemoryRSSBytes)
+	}
+
+	// sidecar has no memory usage/rss reported — those stay zero, no panic on nil.
+	side := cms[1]
+	if side.Container != "sidecar" || side.CPUUsageNanoCores != 50000000 || side.MemoryWorkingSet != 10485760 {
+		t.Errorf("sidecar mismatch: %+v", side)
+	}
+	if side.MemoryUsageBytes != 0 || side.MemoryRSSBytes != 0 {
+		t.Errorf("sidecar expected zero usage/rss, got usage=%d rss=%d", side.MemoryUsageBytes, side.MemoryRSSBytes)
+	}
+}
+
+func TestParseKubeletSummary_MissingAndEmpty(t *testing.T) {
+	// Node with no cpu/memory blocks and no pods must not panic and yield zeroed metrics.
+	summary, err := parseKubeletSummary([]byte(`{"node":{"nodeName":"n"},"pods":[]}`), "n")
+	if err != nil {
+		t.Fatalf("parse failed: %v", err)
+	}
+	nm := nodeMetricFromSummary("n", summary)
+	if nm.CPUUsageNanoCores != 0 || nm.MemoryWorkingSet != 0 {
+		t.Errorf("expected zeroed node metric, got %+v", nm)
+	}
+	if got := containerMetricsFromSummary("n", summary); len(got) != 0 {
+		t.Errorf("expected no container metrics, got %d", len(got))
+	}
+
+	if _, err := parseKubeletSummary([]byte("not json"), "n"); err == nil {
+		t.Error("expected error on invalid JSON")
+	}
+}

--- a/internal/collector/node_collector.go
+++ b/internal/collector/node_collector.go
@@ -39,6 +39,7 @@ type NodeCollector struct {
 	k8sClient       kubernetes.Interface
 	metricsClient   *metricsv1.Clientset
 	nodemonClient   *NodemonClient
+	kubeletClient   *KubeletSummaryClient
 	informerFactory informers.SharedInformerFactory
 	nodeInformer    cache.SharedIndexInformer
 	batchChan       chan CollectedResource   // Channel for individual resources -> input to batcher
@@ -98,11 +99,13 @@ func NewNodeCollector(
 		ns = defaultNamespace
 	}
 	nodemonClient := NewNodemonClient(k8sClient, ns, logger)
+	kubeletClient := NewKubeletSummaryClient(k8sClient, logger)
 
 	return &NodeCollector{
 		k8sClient:       k8sClient,
 		metricsClient:   metricsClient,
 		nodemonClient:   nodemonClient,
+		kubeletClient:   kubeletClient,
 		batchChan:       batchChan,
 		resourceChan:    resourceChan,
 		batcher:         batcher,
@@ -457,6 +460,11 @@ func (c *NodeCollector) collectAllNodeResources(ctx context.Context) {
 	// node-level data which includes system processes, not just container aggregation)
 	nodeMetricsList := &metricsapisv1beta1.NodeMetricsList{}
 
+	// Coverage accounting: nodemon is the primary source; nodes without a nodemon
+	// pod fall back to the kubelet Summary API. Nodes where both fail are true gaps.
+	var nodemonCovered, kubeletFallback int
+	var uncoveredNodes []string
+
 	nodes := c.nodeInformer.GetIndexer().List()
 	for _, obj := range nodes {
 		node, ok := obj.(*corev1.Node)
@@ -470,29 +478,70 @@ func (c *NodeCollector) collectAllNodeResources(ctx context.Context) {
 		// Fetch node-level metrics from nodemon (includes system process CPU/memory)
 		nodeMetric, err := c.nodemonClient.FetchNodeMetricsByNode(ctx, node.Name)
 		if err != nil {
-			c.logger.V(1).Info("Failed to fetch node metrics from nodemon, skipping CPU/memory", "node", node.Name, "error", err)
-		} else if nodeMetric != nil {
+			c.logger.V(1).Info("Failed to fetch node metrics from nodemon", "node", node.Name, "error", err)
+			nodeMetric = nil
+		}
+		if nodeMetric == nil {
+			// No nodemon pod on this node — fall back to the kubelet Summary API.
+			if km, kerr := c.kubeletClient.FetchNodeMetricsByNode(ctx, node.Name); kerr != nil {
+				c.logger.V(1).Info("Kubelet node-metrics fallback failed", "node", node.Name, "error", kerr)
+				uncoveredNodes = append(uncoveredNodes, node.Name)
+			} else if km != nil {
+				nodeMetric = km
+				kubeletFallback++
+			}
+		} else {
+			nodemonCovered++
+		}
+		if nodeMetric != nil {
 			cpuMillis := int64(nodeMetric.CPUUsageNanoCores / 1_000_000)
 			nm.Usage[corev1.ResourceCPU] = *resource.NewMilliQuantity(cpuMillis, resource.DecimalSI)
 			nm.Usage[corev1.ResourceMemory] = *resource.NewQuantity(int64(nodeMetric.MemoryWorkingSet), resource.BinarySI)
 		}
 		nodeMetricsList.Items = append(nodeMetricsList.Items, nm)
 	}
-	c.logger.V(1).Info("Built node metrics from nodemon container data", "nodes", len(nodeMetricsList.Items))
+	c.logger.V(1).Info("Built node metrics",
+		"nodes", len(nodeMetricsList.Items),
+		"nodemonCovered", nodemonCovered,
+		"kubeletFallback", kubeletFallback,
+		"uncovered", len(uncoveredNodes))
 
 	if c.telemetryLogger != nil {
 		c.telemetryLogger.Report(
 			gen.LogLevel_LOG_LEVEL_INFO,
 			"NodeCollector",
-			"Successfully fetched node metrics from metrics server",
+			"Fetched node metrics",
 			nil,
 			map[string]string{
 				"node_count":       fmt.Sprintf("%d", len(nodeMetricsList.Items)),
+				"nodemon_covered":  fmt.Sprintf("%d", nodemonCovered),
+				"kubelet_fallback": fmt.Sprintf("%d", kubeletFallback),
 				"excluded_nodes":   fmt.Sprintf("%v", c.excludedNodes),
-				"event_type":       "metrics_server_query_success",
+				"event_type":       "node_metrics_query_success",
 				"zxporter_version": version.Get().String(),
 			},
 		)
+	}
+
+	// Surface coverage gaps: nodes where neither nodemon nor the kubelet fallback
+	// produced metrics. This converts previously-silent blind spots into a signal.
+	if len(uncoveredNodes) > 0 {
+		c.logger.Info("Nodes without any metrics coverage (no nodemon pod and kubelet fallback failed)",
+			"count", len(uncoveredNodes), "nodes", uncoveredNodes)
+		if c.telemetryLogger != nil {
+			c.telemetryLogger.Report(
+				gen.LogLevel_LOG_LEVEL_WARN,
+				"NodeCollector",
+				"Nodes without metrics coverage",
+				nil,
+				map[string]string{
+					"uncovered_count":  fmt.Sprintf("%d", len(uncoveredNodes)),
+					"uncovered_nodes":  fmt.Sprintf("%v", uncoveredNodes),
+					"event_type":       "node_metrics_coverage_gap",
+					"zxporter_version": version.Get().String(),
+				},
+			)
+		}
 	}
 
 	// Process each node's metrics

--- a/internal/collector/nodemon_client.go
+++ b/internal/collector/nodemon_client.go
@@ -246,6 +246,21 @@ func (c *NodemonClient) refreshCache(ctx context.Context) (map[string]string, er
 	return nodeToIP, nil
 }
 
+// CoveredNodes returns the set of node names that currently have a running
+// nodemon pod. Used to determine which nodes need the kubelet Summary-API
+// fallback for metrics coverage.
+func (c *NodemonClient) CoveredNodes(ctx context.Context) (map[string]bool, error) {
+	nodeToIP, err := c.refreshCache(ctx)
+	if err != nil {
+		return nil, err
+	}
+	covered := make(map[string]bool, len(nodeToIP))
+	for node := range nodeToIP {
+		covered[node] = true
+	}
+	return covered, nil
+}
+
 // HasExporters returns true if any nodemon pods were discovered.
 func (c *NodemonClient) HasExporters(ctx context.Context) bool {
 	m, err := c.refreshCache(ctx)

--- a/internal/collector/nodemon_client.go
+++ b/internal/collector/nodemon_client.go
@@ -380,16 +380,22 @@ func (c *NodemonClient) fetchContainerMetrics(
 
 // FetchAllContainerMetrics fetches container metrics from all discovered nodemon pods,
 // merging the results into a single slice.
-func (c *NodemonClient) FetchAllContainerMetrics(ctx context.Context) ([]UnifiedContainerMetric, error) {
+// FetchAllContainerMetrics fetches container metrics from all running nodemon pods.
+// It returns the collected metrics and a set of node names where the nodemon pod was
+// Running but the HTTP fetch failed (e.g. readiness probe failing, internal crash).
+// These "failed nodes" should be fed into the kubelet fallback so they don't become
+// metrics blind spots.
+func (c *NodemonClient) FetchAllContainerMetrics(ctx context.Context) ([]UnifiedContainerMetric, map[string]struct{}, error) {
 	nodeToIP, err := c.refreshCache(ctx)
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 	if len(nodeToIP) == 0 {
-		return nil, nil
+		return nil, nil, nil
 	}
 
 	var allMetrics []UnifiedContainerMetric
+	failedNodes := make(map[string]struct{})
 	for nodeName, podIP := range nodeToIP {
 		baseURL := fmt.Sprintf("http://%s:%d", podIP, c.port)
 		metrics, fetchErr := c.fetchContainerMetrics(ctx, baseURL)
@@ -400,12 +406,13 @@ func (c *NodemonClient) FetchAllContainerMetrics(ctx context.Context) ([]Unified
 				"node", nodeName,
 				"podIP", podIP,
 			)
+			failedNodes[nodeName] = struct{}{}
 			continue
 		}
 		allMetrics = append(allMetrics, metrics...)
 	}
 
-	return allMetrics, nil
+	return allMetrics, failedNodes, nil
 }
 
 // fetchNodeMetrics fetches from a single nodemon pod's /node/metrics endpoint.

--- a/internal/controller/collectionpolicy_controller.go
+++ b/internal/controller/collectionpolicy_controller.go
@@ -166,12 +166,18 @@ type PolicyConfig struct {
 // +kubebuilder:rbac:groups=devzero.io,resources=collectionpolicies/finalizers,verbs=update
 
 // ========================================
-// BOOTSTRAP PERMISSIONS (entrypoint.sh)
+// BOOTSTRAP PERMISSIONS (currently UNUSED)
 // ========================================
-// These permissions are required for automatic metrics-server installation
-// via kubectl apply in entrypoint.sh when metrics-server is not detected
+// NOTE: These write permissions were originally added for an "automatic metrics-server
+// installation via kubectl apply in entrypoint.sh" path that DOES NOT EXIST — entrypoint.sh
+// only execs the app, and metrics-server is no longer used (node/container metrics come from the
+// nodemon DaemonSet, with a kubelet /stats/summary fallback). No controller code creates
+// serviceaccounts/clusterroles/clusterrolebindings/rolebindings/apiservices, and deployments/
+// services/serviceaccounts are only ever read by collectors. These create/update/patch grants are
+// dead and are candidates for least-privilege removal (tracked as a follow-up; left intact here to
+// keep this change focused and avoid an unreviewed RBAC reduction).
 
-// ServiceAccount creation for metrics-server
+// ServiceAccount creation (unused)
 // +kubebuilder:rbac:groups="",resources=serviceaccounts,verbs=get;list;watch;create;update;patch
 
 // RBAC setup for metrics-server (ClusterRoles, ClusterRoleBindings, RoleBindings)
@@ -198,6 +204,8 @@ type PolicyConfig struct {
 
 // Metrics access
 // +kubebuilder:rbac:groups="",resources=nodes/metrics,verbs=get
+// nodes/proxy: kubelet Summary API fallback (/stats/summary) for nodes without a nodemon pod
+// +kubebuilder:rbac:groups="",resources=nodes/proxy,verbs=get
 
 // Core Kubernetes resources (READ-ONLY monitoring and collection)
 // +kubebuilder:rbac:groups="",resources=pods,verbs=get;list;watch
@@ -213,7 +221,7 @@ type PolicyConfig struct {
 // +kubebuilder:rbac:groups="",resources=persistentvolumes,verbs=get;list;watch
 // +kubebuilder:rbac:groups="",resources=endpoints,verbs=get;list;watch
 
-// Apps API Group resources (READ-ONLY monitoring - note: deployments also needs write for metrics-server bootstrap)
+// Apps API Group resources (READ-ONLY monitoring; deployments write lives in the unused bootstrap block above)
 // +kubebuilder:rbac:groups=apps,resources=statefulsets,verbs=get;list;watch
 // +kubebuilder:rbac:groups=apps,resources=daemonsets,verbs=get;list;watch
 // +kubebuilder:rbac:groups=apps,resources=replicasets,verbs=get;list;watch


### PR DESCRIPTION
## What?

zxporter recently moved all node/container CPU/memory/network metrics to the **nodemon DaemonSet** and stopped installing or querying metrics-server (the `metricsv1` client is still built but never queried). That made nodemon the *sole* metrics source — so any node without a running nodemon pod became a silent metrics blind spot.

This PR guarantees coverage in three layers:

1. **Scheduling (Helm):** nodemon now lands on every node. Removed the GCP-only `nodeAffinity` on `cloud.google.com/gke-accelerator` (which restricted nodemon to GPU nodes), set `priorityClassName: system-node-critical` for all providers (was EKS-only), and made the `dcgm-exporter` sidecar use the resilient retry loop on GCP so it idles instead of crashlooping on non-GPU nodes.
2. **Kubelet fallback (Go):** new `KubeletSummaryClient` reads `/api/v1/nodes/{node}/proxy/stats/summary` for any node that has no nodemon pod, returning CPU/memory in the existing metric shapes. Wired into the node and container collectors; adds `nodes/proxy` RBAC.
3. **Observability (Go):** the node collector now tracks nodemon-covered / kubelet-fallback / uncovered counts and emits a `WARN` telemetry report listing nodes where both sources failed.

Also corrects stale comments claiming an "automatic metrics-server installation via entrypoint.sh" that doesn't exist.

## Why?

With metrics-server gone, a DaemonSet is the only thing producing per-node metrics — and a DaemonSet can never *guarantee* a pod on every node (taints, scheduling pressure, startup races, or restrictive affinity all leave gaps). On GCP specifically, nodemon was only scheduled on GPU nodes, so every non-GPU node silently reported no CPU/memory. The kubelet runs on every node by construction, so it's the only way to get a hard coverage guarantee — which is exactly how metrics-server and cAdvisor achieve full coverage.

## How?

- **Scheduling over affinity:** rather than maintain GPU-gating on the nodemon pod, nodemon-core now runs everywhere and GPU concerns stay isolated to the `dcgm-exporter` sidecar (which already had a retry loop on non-GCP; GCP now matches). This decouples "collect node metrics everywhere" from "collect GPU metrics where GPUs exist."
- **API-server proxy, not direct kubelet:** the fallback goes through the `nodes/proxy` subresource using the existing in-cluster client, so it needs no extra network reachability to port 10250 and no new config. Notably, the chart already granted `nodes/proxy`+`nodes/stats` in a sibling role, confirming this is an established access pattern.
- **Reuse existing conversion:** the kubelet Summary API exposes the same `usageNanoCores`/`workingSetBytes` fields nodemon is built on, so results flow through the existing `UnifiedNodeMetric`/`UnifiedContainerMetric` → `PodMetricsList` path unchanged. Minimal local structs avoid pulling in the `k8s.io/kubelet` dependency.
- **Deliberate degraded mode:** the fallback supplies CPU + memory only (parity with what metrics-server provided). Network rates, CPU-throttle, GPU and JVM metrics remain nodemon-only and stay zero for fallback nodes.

I intentionally left the now-dead metrics-server bootstrap *write* RBAC (serviceaccounts/clusterroles/deployments-write/apiservices) in place rather than stripping it here — that's a security-sensitive ClusterRole reduction that deserves its own review. It's flagged inline as a least-privilege follow-up.

## Testing?

- New table tests for the kubelet Summary parser/converters (`kubelet_summary_client_test.go`): valid summary, missing/empty node + pods, invalid JSON, and nil-safe memory fields.
- `go build ./...` and `go vet ./internal/...` clean; full `internal/collector` suite passes.
- `helm template`/`helm lint` verified for `provider=gcp|eks|azure`: nodemon-core renders with no GPU affinity, `system-node-critical` on all three, the resilient DCGM loop everywhere, and `nodes/proxy` present in the rendered manager-role. `provider` is still required when unset.

Not yet exercised end-to-end on a live cluster with a deliberately-uncovered node — recommend a kind run that taints a node (so nodemon can't land) and asserts that node still reports CPU/memory via the fallback and emits the coverage WARN.

## Anything Else?

The fallback is degraded by design (no network-rate/GPU/throttle/JVM on uncovered nodes). Full parity would require either teaching nodemon to schedule with stronger guarantees or extending the fallback — worth a follow-up if uncovered nodes turn out to be common. The dead metrics-server bootstrap RBAC removal is also a good least-privilege follow-up.
