### PR TITLE
fix(nodemon): correct G1 heap-max double-count in JVM metrics

### DIFF
--- a/internal/nodemon/jvm_collector.go
+++ b/internal/nodemon/jvm_collector.go
@@ -313,6 +313,55 @@ func sumSpaceCounters(counters map[string]any, metric string) int64 {
 	return total
 }
 
+// heapMaxBytes derives the JVM's maximum heap size from hsperfdata counters.
+//
+// Modern JVMs expose the aggregate sun.gc.heap.maxCapacity counter, which is
+// authoritative. When it is absent we fall back to the per-generation
+// maxCapacity counters, but how they combine depends on the collector:
+//
+//   - Generational collectors (Serial, Parallel) physically partition the heap
+//     into a young and an old generation, so the heap max is gen0 + gen1.
+//   - Region-based collectors (G1, ZGC, Shenandoah) manage one shared region
+//     pool; each generation's maxCapacity reports ~the whole heap (any region
+//     can belong to either generation), so summing double-counts. The heap max
+//     is then a single generation's maxCapacity, i.e. the larger of the two.
+//
+// Summing under G1 was the original bug: it reported ~2x the real max heap,
+// exceeding the container memory limit.
+func heapMaxBytes(counters map[string]any) int64 {
+	if maxCap, ok := hsInt(counters, "sun.gc.heap.maxCapacity"); ok {
+		return maxCap
+	}
+	gen0, _ := hsInt(counters, "sun.gc.generation.0.maxCapacity")
+	gen1, _ := hsInt(counters, "sun.gc.generation.1.maxCapacity")
+	if isRegionBasedCollector(counters) {
+		if gen0 > gen1 {
+			return gen0
+		}
+		return gen1
+	}
+	return gen0 + gen1
+}
+
+// isRegionBasedCollector reports whether the JVM uses a collector that manages
+// the heap as a single shared region pool (G1, ZGC, Shenandoah) rather than as
+// physically separate young/old generations (Serial, Parallel). It inspects the
+// sun.gc.collector.<n>.name counters published by the JVM.
+func isRegionBasedCollector(counters map[string]any) bool {
+	for i := 0; i < 8; i++ {
+		name, ok := hsStr(counters, fmt.Sprintf("sun.gc.collector.%d.name", i))
+		if !ok || name == "" {
+			break
+		}
+		if strings.Contains(name, "G1") ||
+			strings.Contains(name, "ZGC") ||
+			strings.Contains(name, "Shenandoah") {
+			return true
+		}
+	}
+	return false
+}
+
 // stripContainerIDScheme strips the URL scheme (e.g., "containerd://") from a container ID.
 func stripContainerIDScheme(raw string) string {
 	if i := strings.LastIndex(raw, "://"); i >= 0 {
@@ -354,13 +403,7 @@ func buildJVMMetric(counters map[string]any, proc JavaProcess, info containerInf
 		m.HeapUsedBytes = sumSpaceCounters(counters, "used")
 	}
 
-	if maxCap, ok := hsInt(counters, "sun.gc.heap.maxCapacity"); ok {
-		m.HeapMaxSizeBytes = maxCap
-	} else {
-		gen0, _ := hsInt(counters, "sun.gc.generation.0.maxCapacity")
-		gen1, _ := hsInt(counters, "sun.gc.generation.1.maxCapacity")
-		m.HeapMaxSizeBytes = gen0 + gen1
-	}
+	m.HeapMaxSizeBytes = heapMaxBytes(counters)
 
 	// Convert GC time ticks to seconds using the JVM's high-resolution timer frequency.
 	freq, _ := hsInt(counters, "sun.os.hrt.frequency")

--- a/internal/nodemon/jvm_collector_test.go
+++ b/internal/nodemon/jvm_collector_test.go
@@ -136,6 +136,92 @@ func TestCheckHostPIDVisibility_InvalidProcRoot(t *testing.T) {
 	c.checkHostPIDVisibility()
 }
 
+func TestHeapMaxBytes(t *testing.T) {
+	const mib = int64(1) << 20
+
+	tests := []struct {
+		name     string
+		counters map[string]any
+		want     int64
+	}{
+		{
+			name:     "aggregate counter is authoritative",
+			counters: map[string]any{"sun.gc.heap.maxCapacity": 512 * mib},
+			want:     512 * mib,
+		},
+		{
+			name: "serial GC sums physically-partitioned generations",
+			counters: map[string]any{
+				"sun.gc.collector.0.name":         "copy",
+				"sun.gc.collector.1.name":         "MarkSweepCompact",
+				"sun.gc.generation.0.maxCapacity": 128 * mib, // young
+				"sun.gc.generation.1.maxCapacity": 384 * mib, // old
+			},
+			want: 512 * mib,
+		},
+		{
+			name: "G1 equal generations are not double-counted",
+			counters: map[string]any{
+				"sun.gc.collector.0.name": "G1 incremental collections",
+				"sun.gc.collector.1.name": "G1 stop-the-world full collections",
+				// G1 reports ~the whole heap as each generation's max.
+				"sun.gc.generation.0.maxCapacity": 538 * mib,
+				"sun.gc.generation.1.maxCapacity": 538 * mib,
+			},
+			want: 538 * mib, // NOT 1076 MiB (the original bug)
+		},
+		{
+			name: "G1 unequal generations take the larger (old == whole heap)",
+			counters: map[string]any{
+				"sun.gc.collector.0.name":         "G1 incremental collections",
+				"sun.gc.generation.0.maxCapacity": 300 * mib, // young capped below heap
+				"sun.gc.generation.1.maxCapacity": 538 * mib, // old == whole heap
+			},
+			want: 538 * mib,
+		},
+		{
+			name: "Shenandoah is region-based",
+			counters: map[string]any{
+				"sun.gc.collector.0.name":         "Shenandoah Pauses",
+				"sun.gc.generation.0.maxCapacity": 256 * mib,
+				"sun.gc.generation.1.maxCapacity": 256 * mib,
+			},
+			want: 256 * mib,
+		},
+		{
+			name:     "no counters present yields zero",
+			counters: map[string]any{},
+			want:     0,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, heapMaxBytes(tt.counters))
+		})
+	}
+}
+
+func TestBuildJVMMetric_G1HeapMaxNotDoubled(t *testing.T) {
+	const mib = int64(1) << 20
+	counters := map[string]any{
+		"sun.gc.collector.0.name":         "G1 incremental collections",
+		"sun.gc.generation.0.maxCapacity": 538 * mib,
+		"sun.gc.generation.1.maxCapacity": 538 * mib,
+		// per-space used/capacity sum without overlap (these stay correct).
+		"sun.gc.generation.0.space.0.used":     20 * mib,
+		"sun.gc.generation.0.space.0.capacity": 64 * mib,
+		"sun.gc.generation.1.space.0.used":     6 * mib,
+		"sun.gc.generation.1.space.0.capacity": 64 * mib,
+	}
+
+	m := buildJVMMetric(counters, JavaProcess{ContainerID: "containerd://abc"}, containerInfo{}, "node-1")
+
+	assert.Equal(t, 538*mib, m.HeapMaxSizeBytes, "G1 heap max must not be the sum of both generations")
+	assert.Equal(t, 26*mib, m.HeapUsedBytes, "heap used sums per-space counters (no overlap)")
+	assert.Equal(t, 128*mib, m.HeapSizeBytes, "committed capacity sums per-space counters")
+}
+
 func TestUpdateContainerMap_OverwritesOnUpdate(t *testing.T) {
 	cid := "abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789"
 	c := &JVMCollector{


### PR DESCRIPTION
## Why

Every Java workload using the **G1 garbage collector** has been persisting a max-heap value roughly **2× the real configured maximum** — and larger than the container's own memory limit, which is physically impossible. That makes JVM heap panels and heap-utilization percentages misleading for the most common modern collector (G1 is the default in JDK 9+).

Found while validating JVM heap metrics on preprod (`jvm-jmx` namespace). Five `app` containers run `-XX:+UseG1GC -XX:MaxRAMPercentage=70` (no explicit `-Xmx`, limits 768Mi / 896Mi):

| container | mem limit | expected max heap (70%) | persisted `jvm_heap_max_bytes` | ratio |
|---|---|---|---|---|
| G1 app containers | 768Mi | ~538Mi | **1076Mi** | **2.00×** |
| G1 app containers | 896Mi | ~627Mi | **1256Mi** | **2.00×** |
| `-Xmx128m` Serial-GC sidecar | 256Mi | 128Mi | **128Mi** ✓ | 1.00× |

The exact-2× on every G1 container, with the Serial-GC sidecar correct, isolates the cause precisely.

## Root cause

In `buildJVMMetric`, when the aggregate `sun.gc.heap.maxCapacity` counter is absent (the case for G1/ZGC/Shenandoah), the max heap fell back to:

```go
gen0 + gen1   // sun.gc.generation.{0,1}.maxCapacity
```

That sum is right for **generational** collectors (Serial, Parallel) whose young/old generations are physically partitioned. Under **region-based** collectors (G1, ZGC, Shenandoah) the generations share one region pool and each generation's `maxCapacity` reports ~the whole heap, so the sum double-counts.

## Fix

Detect region-based collectors via the `sun.gc.collector.<n>.name` counters; for those, take a single generation's `maxCapacity` (the larger of the two — old gen ≈ whole heap) instead of summing. Generational collectors keep summing.

`heap_used` and committed capacity are **unchanged** — they sum per-*space* counters (eden/survivor/old), which don't overlap, so they were already correct.

## Tests

- `TestHeapMaxBytes` — aggregate-authoritative, Serial sums, G1 equal gens (not doubled), G1 unequal gens (takes larger), Shenandoah, empty.
- `TestBuildJVMMetric_G1HeapMaxNotDoubled` — end-to-end regression: G1 counters → max heap not doubled, while used/committed stay correct.

## Blast radius

Display/stored metric only. Does not affect the dakr respect-floor recommendation logic (it derives effective heap from extracted flags, never from `jvm_heap_max_bytes`).