### PR TITLE
ci: switch build/push jobs from Namespace to ubuntu-latest runners

### DIFF
--- a/.github/workflows/push-zxporter-image.yml
+++ b/.github/workflows/push-zxporter-image.yml
@@ -20,7 +20,7 @@ permissions:
 jobs:
   package-and-push:
     name: Package & Push Docker image
-    runs-on: namespace-profile-dz-generic
+    runs-on: ubuntu-latest
     outputs:
       is_release: ${{ steps.version.outputs.is_release }}
 
@@ -70,7 +70,7 @@ jobs:
           password: ${{ secrets.DOCKERHUB_ZXPORTER_BALANCE_TOKEN }}
 
       - name: Set up Docker Buildx
-        uses: namespacelabs/nscloud-setup-buildx-action@v0
+        uses: docker/setup-buildx-action@v3
 
       - name: Set build metadata
         run: |
@@ -219,7 +219,7 @@ jobs:
 
   update-helm-values-image-tag-pr:
     name: Update Helm values image.tag and create PR
-    runs-on: namespace-profile-dz-generic
+    runs-on: ubuntu-latest
     needs: [package-and-push] # only do this if all previous steps pass
     if: ${{ needs.package-and-push.outputs.is_release == 'true' }}
     steps:

--- a/.github/workflows/push-zxporter-image.yml
+++ b/.github/workflows/push-zxporter-image.yml
@@ -20,7 +20,7 @@ permissions:
 jobs:
   package-and-push:
     name: Package & Push Docker image
-    runs-on: ubuntu-latest
+    runs-on: namespace-profile-dz-generic
     outputs:
       is_release: ${{ steps.version.outputs.is_release }}
 
@@ -219,7 +219,7 @@ jobs:
 
   update-helm-values-image-tag-pr:
     name: Update Helm values image.tag and create PR
-    runs-on: ubuntu-latest
+    runs-on: namespace-profile-dz-generic
     needs: [package-and-push] # only do this if all previous steps pass
     if: ${{ needs.package-and-push.outputs.is_release == 'true' }}
     steps:

--- a/.github/workflows/push-zxporter-netmon-image.yml
+++ b/.github/workflows/push-zxporter-netmon-image.yml
@@ -20,7 +20,7 @@ permissions:
 jobs:
   package-and-push:
     name: Package & Push Docker image
-    runs-on: ubuntu-latest
+    runs-on: namespace-profile-dz-generic
     outputs:
       is_release: ${{ steps.version.outputs.is_release }}
 
@@ -220,7 +220,7 @@ jobs:
 
   update-helm-values-image-tag-pr:
     name: Update Helm values image.tag and create PR
-    runs-on: ubuntu-latest
+    runs-on: namespace-profile-dz-generic
     needs: [package-and-push] # only do this if all previous steps pass
     if: ${{ needs.package-and-push.outputs.is_release == 'true' }}
     steps:

--- a/.github/workflows/push-zxporter-netmon-image.yml
+++ b/.github/workflows/push-zxporter-netmon-image.yml
@@ -20,7 +20,7 @@ permissions:
 jobs:
   package-and-push:
     name: Package & Push Docker image
-    runs-on: namespace-profile-dz-generic
+    runs-on: ubuntu-latest
     outputs:
       is_release: ${{ steps.version.outputs.is_release }}
 
@@ -70,7 +70,7 @@ jobs:
           password: ${{ secrets.DOCKERHUB_ZXPORTER_BALANCE_TOKEN }}
 
       - name: Set up Docker Buildx
-        uses: namespacelabs/nscloud-setup-buildx-action@v0
+        uses: docker/setup-buildx-action@v3
 
       - name: Set build metadata
         run: |
@@ -220,7 +220,7 @@ jobs:
 
   update-helm-values-image-tag-pr:
     name: Update Helm values image.tag and create PR
-    runs-on: namespace-profile-dz-generic
+    runs-on: ubuntu-latest
     needs: [package-and-push] # only do this if all previous steps pass
     if: ${{ needs.package-and-push.outputs.is_release == 'true' }}
     steps:

--- a/.github/workflows/push-zxporter-nodemon-image.yml
+++ b/.github/workflows/push-zxporter-nodemon-image.yml
@@ -20,7 +20,7 @@ permissions:
 jobs:
   package-and-push:
     name: Package & Push Docker image
-    runs-on: ubuntu-latest
+    runs-on: namespace-profile-dz-generic
     outputs:
       is_release: ${{ steps.version.outputs.is_release }}
 
@@ -189,7 +189,7 @@ jobs:
 
   update-helm-values-image-tag-pr:
     name: Update Helm values image.tag and create PR
-    runs-on: ubuntu-latest
+    runs-on: namespace-profile-dz-generic
     needs: [package-and-push] # only do this if all previous steps pass
     if: ${{ needs.package-and-push.outputs.is_release == 'true' }}
     steps:

--- a/.github/workflows/push-zxporter-nodemon-image.yml
+++ b/.github/workflows/push-zxporter-nodemon-image.yml
@@ -20,7 +20,7 @@ permissions:
 jobs:
   package-and-push:
     name: Package & Push Docker image
-    runs-on: namespace-profile-dz-generic
+    runs-on: ubuntu-latest
     outputs:
       is_release: ${{ steps.version.outputs.is_release }}
 
@@ -70,7 +70,7 @@ jobs:
           password: ${{ secrets.DOCKERHUB_ZXPORTER_BALANCE_TOKEN }}
 
       - name: Set up Docker Buildx
-        uses: namespacelabs/nscloud-setup-buildx-action@v0
+        uses: docker/setup-buildx-action@v3
 
       - name: Set build metadata
         run: |
@@ -189,7 +189,7 @@ jobs:
 
   update-helm-values-image-tag-pr:
     name: Update Helm values image.tag and create PR
-    runs-on: namespace-profile-dz-generic
+    runs-on: ubuntu-latest
     needs: [package-and-push] # only do this if all previous steps pass
     if: ${{ needs.package-and-push.outputs.is_release == 'true' }}
     steps:


### PR DESCRIPTION
## Summary
- Replaces `namespacelabs/nscloud-setup-buildx-action@v0` with `docker/setup-buildx-action@v3` across all three image push workflows (`push-zxporter-image`, `push-zxporter-nodemon-image`, `push-zxporter-netmon-image`)
- Namespace runners are unchanged

**Why:** The Namespace remote builder was dropping gRPC connections mid-build (`DeadlineExceeded: context deadline exceeded`) causing intermittent failures on multi-arch builds.

## Test plan
- [ ] Trigger one of the workflows via `workflow_dispatch` to verify the build completes

🤖 Generated with [Claude Code](https://claude.com/claude-code)