### PR TITLE
ci: switch build/push runners from Namespace to ubuntu-latest

### DIFF
--- a/.github/workflows/push-zxporter-image.yml
+++ b/.github/workflows/push-zxporter-image.yml
@@ -20,7 +20,7 @@ permissions:
 jobs:
   package-and-push:
     name: Package & Push Docker image
-    runs-on: namespace-profile-dz-generic
+    runs-on: ubuntu-latest
     outputs:
       is_release: ${{ steps.version.outputs.is_release }}
 
@@ -219,7 +219,7 @@ jobs:
 
   update-helm-values-image-tag-pr:
     name: Update Helm values image.tag and create PR
-    runs-on: namespace-profile-dz-generic
+    runs-on: ubuntu-latest
     needs: [package-and-push] # only do this if all previous steps pass
     if: ${{ needs.package-and-push.outputs.is_release == 'true' }}
     steps:

--- a/.github/workflows/push-zxporter-netmon-image.yml
+++ b/.github/workflows/push-zxporter-netmon-image.yml
@@ -20,7 +20,7 @@ permissions:
 jobs:
   package-and-push:
     name: Package & Push Docker image
-    runs-on: namespace-profile-dz-generic
+    runs-on: ubuntu-latest
     outputs:
       is_release: ${{ steps.version.outputs.is_release }}
 
@@ -220,7 +220,7 @@ jobs:
 
   update-helm-values-image-tag-pr:
     name: Update Helm values image.tag and create PR
-    runs-on: namespace-profile-dz-generic
+    runs-on: ubuntu-latest
     needs: [package-and-push] # only do this if all previous steps pass
     if: ${{ needs.package-and-push.outputs.is_release == 'true' }}
     steps:

--- a/.github/workflows/push-zxporter-nodemon-image.yml
+++ b/.github/workflows/push-zxporter-nodemon-image.yml
@@ -20,7 +20,7 @@ permissions:
 jobs:
   package-and-push:
     name: Package & Push Docker image
-    runs-on: namespace-profile-dz-generic
+    runs-on: ubuntu-latest
     outputs:
       is_release: ${{ steps.version.outputs.is_release }}
 
@@ -189,7 +189,7 @@ jobs:
 
   update-helm-values-image-tag-pr:
     name: Update Helm values image.tag and create PR
-    runs-on: namespace-profile-dz-generic
+    runs-on: ubuntu-latest
     needs: [package-and-push] # only do this if all previous steps pass
     if: ${{ needs.package-and-push.outputs.is_release == 'true' }}
     steps:


### PR DESCRIPTION
## Summary
- Switches `runs-on` from `namespace-profile-dz-generic` to `ubuntu-latest` on all three image push workflows
- Buildx already uses `docker/setup-buildx-action@v3` (from #443)

**Why:** Namespace remote builder causes intermittent `DeadlineExceeded` failures on multi-arch builds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)