### PR TITLE
ci: revert to Namespace runners + trim K8s test matrix

### DIFF
--- a/.github/workflows/k8s-compatibility-test.yml
+++ b/.github/workflows/k8s-compatibility-test.yml
@@ -116,6 +116,7 @@ jobs:
           - v1.33.7
           - v1.34.3
           - v1.35.1
+          - v1.36.1
         deployment-method:
           - helm
           - manifest
@@ -146,7 +147,7 @@ jobs:
       - name: Create k8s Kind Cluster
         uses: helm/kind-action@v1
         with:
-          version: v0.31.0
+          version: v0.32.0
           node_image: kindest/node:${{ matrix.k8s-version }}
           cluster_name: kind-${{ matrix.k8s-version }}
           wait: 120s

--- a/.github/workflows/k8s-compatibility-test.yml
+++ b/.github/workflows/k8s-compatibility-test.yml
@@ -111,10 +111,6 @@ jobs:
         # Test against K8s versions from the last ~2 years
         # See https://kubernetes.io/releases/ for release/EOL dates
         k8s-version:
-          - v1.27.16
-          - v1.28.15
-          - v1.29.14
-          - v1.30.13
           - v1.31.14
           - v1.32.11
           - v1.33.7

--- a/.github/workflows/push-zxporter-image.yml
+++ b/.github/workflows/push-zxporter-image.yml
@@ -20,7 +20,7 @@ permissions:
 jobs:
   package-and-push:
     name: Package & Push Docker image
-    runs-on: ubuntu-latest
+    runs-on: namespace-profile-dz-generic
     outputs:
       is_release: ${{ steps.version.outputs.is_release }}
 
@@ -70,7 +70,7 @@ jobs:
           password: ${{ secrets.DOCKERHUB_ZXPORTER_BALANCE_TOKEN }}
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: namespacelabs/nscloud-setup-buildx-action@v0
 
       - name: Set build metadata
         run: |
@@ -219,7 +219,7 @@ jobs:
 
   update-helm-values-image-tag-pr:
     name: Update Helm values image.tag and create PR
-    runs-on: ubuntu-latest
+    runs-on: namespace-profile-dz-generic
     needs: [package-and-push] # only do this if all previous steps pass
     if: ${{ needs.package-and-push.outputs.is_release == 'true' }}
     steps:

--- a/.github/workflows/push-zxporter-netmon-image.yml
+++ b/.github/workflows/push-zxporter-netmon-image.yml
@@ -20,7 +20,7 @@ permissions:
 jobs:
   package-and-push:
     name: Package & Push Docker image
-    runs-on: ubuntu-latest
+    runs-on: namespace-profile-dz-generic
     outputs:
       is_release: ${{ steps.version.outputs.is_release }}
 
@@ -70,7 +70,7 @@ jobs:
           password: ${{ secrets.DOCKERHUB_ZXPORTER_BALANCE_TOKEN }}
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: namespacelabs/nscloud-setup-buildx-action@v0
 
       - name: Set build metadata
         run: |
@@ -220,7 +220,7 @@ jobs:
 
   update-helm-values-image-tag-pr:
     name: Update Helm values image.tag and create PR
-    runs-on: ubuntu-latest
+    runs-on: namespace-profile-dz-generic
     needs: [package-and-push] # only do this if all previous steps pass
     if: ${{ needs.package-and-push.outputs.is_release == 'true' }}
     steps:

--- a/.github/workflows/push-zxporter-nodemon-image.yml
+++ b/.github/workflows/push-zxporter-nodemon-image.yml
@@ -20,7 +20,7 @@ permissions:
 jobs:
   package-and-push:
     name: Package & Push Docker image
-    runs-on: ubuntu-latest
+    runs-on: namespace-profile-dz-generic
     outputs:
       is_release: ${{ steps.version.outputs.is_release }}
 
@@ -70,7 +70,7 @@ jobs:
           password: ${{ secrets.DOCKERHUB_ZXPORTER_BALANCE_TOKEN }}
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: namespacelabs/nscloud-setup-buildx-action@v0
 
       - name: Set build metadata
         run: |
@@ -189,7 +189,7 @@ jobs:
 
   update-helm-values-image-tag-pr:
     name: Update Helm values image.tag and create PR
-    runs-on: ubuntu-latest
+    runs-on: namespace-profile-dz-generic
     needs: [package-and-push] # only do this if all previous steps pass
     if: ${{ needs.package-and-push.outputs.is_release == 'true' }}
     steps:


### PR DESCRIPTION
## Summary
- **Reverts #443 and #444** — restores `namespace-profile-dz-generic` runners and `namespacelabs/nscloud-setup-buildx-action@v0` across all three image push workflows (`push-zxporter-image`, `push-zxporter-nodemon-image`, `push-zxporter-netmon-image`)
- **Trims the K8s compatibility test matrix** — drops v1.27, v1.28, v1.29, v1.30
- **Adds K8s v1.36.1** and bumps kind to v0.32.0 (required for 1.36's v1beta4 kubeadm config)

Matrix is now: v1.31.14, v1.32.11, v1.33.7, v1.34.3, v1.35.1, v1.36.1

🤖 Generated with [Claude Code](https://claude.com/claude-code)