### PR TITLE
Give nodemon the custom PriorityClass so it schedules on packed nodes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -359,6 +359,7 @@ build-installer: manifests generate kustomize yq helm ## Generate a consolidated
 	@$(HELM) template zxporter-nodemon ./helm-chart/zxporter-nodemon \
 		--namespace $(DEVZERO_MONITORING_NAMESPACE) \
 		--set provider=other \
+		--set priorityClass.create=false \
 		--set image.repository=$(word 1,$(subst :, ,$(IMG_NODEMON))) \
 		--set image.tag=$(word 2,$(subst :, ,$(IMG_NODEMON))) \
 		> $(DIST_DIR)/nodemon.yaml
@@ -367,6 +368,7 @@ build-installer: manifests generate kustomize yq helm ## Generate a consolidated
 	@$(HELM) template zxporter-nodemon ./helm-chart/zxporter-nodemon \
 		--namespace $(DEVZERO_MONITORING_NAMESPACE) \
 		--set provider=other \
+		--set priorityClass.create=false \
 		--set dcgmExporter.runtimeClassName=nvidia \
 		--set image.repository=$(word 1,$(subst :, ,$(IMG_NODEMON))) \
 		--set image.tag=$(word 2,$(subst :, ,$(IMG_NODEMON))) \

--- a/config/zxporter-netmon.yaml
+++ b/config/zxporter-netmon.yaml
@@ -22,6 +22,12 @@ spec:
       labels:
         app: zxporter-netmon
     spec:
+      # Ensures the node agent can schedule on memory-packed nodes (it would
+      # otherwise lose the scheduling race and leave that node without
+      # telemetry). Custom class — NOT the reserved system-node-critical,
+      # which GKE blocks in non-kube-system namespaces (see #445). Kustomize's
+      # nameReference rewrites this to the prefixed PriorityClass name.
+      priorityClassName: devzero-zxporter-critical
       serviceAccountName: zxporter-netmon
       hostNetwork: true
       dnsPolicy: ClusterFirstWithHostNet

--- a/dist/backend-install-nvidia-runtime.yaml
+++ b/dist/backend-install-nvidia-runtime.yaml
@@ -933,6 +933,7 @@ spec:
         app.kubernetes.io/name: zxporter-nodemon
         app.kubernetes.io/instance: zxporter-nodemon
     spec:
+      priorityClassName: devzero-zxporter-devzero-zxporter-critical
       hostPID: true
       serviceAccountName: zxporter-nodemon
       affinity:
@@ -1025,6 +1026,7 @@ spec:
         app.kubernetes.io/name: zxporter-nodemon
         app.kubernetes.io/instance: zxporter-nodemon-gpu
     spec:
+      priorityClassName: devzero-zxporter-devzero-zxporter-critical
       hostPID: true
       runtimeClassName: "nvidia"
       serviceAccountName: zxporter-nodemon

--- a/dist/backend-install.yaml
+++ b/dist/backend-install.yaml
@@ -938,6 +938,7 @@ spec:
         app.kubernetes.io/name: zxporter-nodemon
         app.kubernetes.io/instance: zxporter-nodemon
     spec:
+      priorityClassName: devzero-zxporter-devzero-zxporter-critical
       hostPID: true
       serviceAccountName: zxporter-nodemon
       volumes:

--- a/dist/install-nvidia-runtime.yaml
+++ b/dist/install-nvidia-runtime.yaml
@@ -933,6 +933,7 @@ spec:
         app.kubernetes.io/name: zxporter-nodemon
         app.kubernetes.io/instance: zxporter-nodemon
     spec:
+      priorityClassName: devzero-zxporter-devzero-zxporter-critical
       hostPID: true
       serviceAccountName: zxporter-nodemon
       affinity:
@@ -1025,6 +1026,7 @@ spec:
         app.kubernetes.io/name: zxporter-nodemon
         app.kubernetes.io/instance: zxporter-nodemon-gpu
     spec:
+      priorityClassName: devzero-zxporter-devzero-zxporter-critical
       hostPID: true
       runtimeClassName: "nvidia"
       serviceAccountName: zxporter-nodemon

--- a/dist/install.yaml
+++ b/dist/install.yaml
@@ -938,6 +938,7 @@ spec:
         app.kubernetes.io/name: zxporter-nodemon
         app.kubernetes.io/instance: zxporter-nodemon
     spec:
+      priorityClassName: devzero-zxporter-devzero-zxporter-critical
       hostPID: true
       serviceAccountName: zxporter-nodemon
       volumes:

--- a/dist/installer_updater-nvidia-runtime.yaml
+++ b/dist/installer_updater-nvidia-runtime.yaml
@@ -870,6 +870,7 @@ spec:
         app.kubernetes.io/name: zxporter-nodemon
         app.kubernetes.io/instance: zxporter-nodemon
     spec:
+      priorityClassName: devzero-zxporter-devzero-zxporter-critical
       hostPID: true
       serviceAccountName: zxporter-nodemon
       affinity:
@@ -962,6 +963,7 @@ spec:
         app.kubernetes.io/name: zxporter-nodemon
         app.kubernetes.io/instance: zxporter-nodemon-gpu
     spec:
+      priorityClassName: devzero-zxporter-devzero-zxporter-critical
       hostPID: true
       runtimeClassName: "nvidia"
       serviceAccountName: zxporter-nodemon

--- a/dist/installer_updater.yaml
+++ b/dist/installer_updater.yaml
@@ -875,6 +875,7 @@ spec:
         app.kubernetes.io/name: zxporter-nodemon
         app.kubernetes.io/instance: zxporter-nodemon
     spec:
+      priorityClassName: devzero-zxporter-devzero-zxporter-critical
       hostPID: true
       serviceAccountName: zxporter-nodemon
       volumes:

--- a/dist/nodemon-nvidia-runtime.yaml
+++ b/dist/nodemon-nvidia-runtime.yaml
@@ -170,6 +170,7 @@ spec:
         app.kubernetes.io/name: zxporter-nodemon
         app.kubernetes.io/instance: zxporter-nodemon
     spec:
+      priorityClassName: devzero-zxporter-devzero-zxporter-critical
       hostPID: true
       serviceAccountName: zxporter-nodemon
       affinity:
@@ -262,6 +263,7 @@ spec:
         app.kubernetes.io/name: zxporter-nodemon
         app.kubernetes.io/instance: zxporter-nodemon-gpu
     spec:
+      priorityClassName: devzero-zxporter-devzero-zxporter-critical
       hostPID: true
       runtimeClassName: "nvidia"
       serviceAccountName: zxporter-nodemon

--- a/dist/nodemon.yaml
+++ b/dist/nodemon.yaml
@@ -175,6 +175,7 @@ spec:
         app.kubernetes.io/name: zxporter-nodemon
         app.kubernetes.io/instance: zxporter-nodemon
     spec:
+      priorityClassName: devzero-zxporter-devzero-zxporter-critical
       hostPID: true
       serviceAccountName: zxporter-nodemon
       volumes:

--- a/helm-chart/zxporter-nodemon/templates/daemonset.yaml
+++ b/helm-chart/zxporter-nodemon/templates/daemonset.yaml
@@ -66,6 +66,13 @@ spec:
         app.kubernetes.io/name: {{ include "zxporter-nodemon.name" $ }}
         app.kubernetes.io/instance: {{ $v.instance }}
     spec:
+      {{- if $.Values.priorityClass.enabled }}
+      {{- /* Lets the node agent schedule on memory-packed nodes instead of losing the
+             scheduling race and leaving that node without telemetry. Custom class — NOT the
+             reserved system-node-critical, which GKE blocks in non-kube-system namespaces (#445).
+             Must equal the PriorityClass name created by the parent chart's templates/priorityclass.yaml. */}}
+      priorityClassName: devzero-zxporter-devzero-zxporter-critical
+      {{- end }}
       {{- if $.Values.jvmMetrics.enabled }}
       hostPID: true
       {{- end }}

--- a/helm-chart/zxporter-nodemon/templates/daemonset.yaml
+++ b/helm-chart/zxporter-nodemon/templates/daemonset.yaml
@@ -66,11 +66,12 @@ spec:
         app.kubernetes.io/name: {{ include "zxporter-nodemon.name" $ }}
         app.kubernetes.io/instance: {{ $v.instance }}
     spec:
-      {{- if $.Values.priorityClass.enabled }}
+      {{- if $.Values.global.priorityClass.enabled }}
       {{- /* Lets the node agent schedule on memory-packed nodes instead of losing the
              scheduling race and leaving that node without telemetry. Custom class — NOT the
              reserved system-node-critical, which GKE blocks in non-kube-system namespaces (#445).
-             Must equal the PriorityClass name created by the parent chart's templates/priorityclass.yaml. */}}
+             Gated on the shared global so the reference and the PriorityClass object (created by
+             this subchart when standalone, or the parent chart when bundled) can't drift. */}}
       priorityClassName: devzero-zxporter-devzero-zxporter-critical
       {{- end }}
       {{- if $.Values.jvmMetrics.enabled }}

--- a/helm-chart/zxporter-nodemon/templates/priorityclass.yaml
+++ b/helm-chart/zxporter-nodemon/templates/priorityclass.yaml
@@ -1,0 +1,17 @@
+{{- if and .Values.priorityClass.enabled .Values.priorityClass.create }}
+apiVersion: scheduling.k8s.io/v1
+kind: PriorityClass
+metadata:
+  {{- /* Hardcoded (not release-derived) to match the same-named PriorityClass the parent
+         zxporter chart and the kustomize dist/ bundles create, so a standalone nodemon install
+         (CI, helm-release-nodemon) targets the SAME class the parent would. When installed via
+         the parent chart, the parent sets zxporter-nodemon.priorityClass.create=false so this
+         object isn't defined twice. */}}
+  name: devzero-zxporter-devzero-zxporter-critical
+  labels:
+    {{- include "zxporter-nodemon.labels" . | nindent 4 }}
+value: {{ .Values.priorityClass.value }}
+globalDefault: false
+description: {{ .Values.priorityClass.description | quote }}
+preemptionPolicy: {{ .Values.priorityClass.preemptionPolicy }}
+{{- end }}

--- a/helm-chart/zxporter-nodemon/templates/priorityclass.yaml
+++ b/helm-chart/zxporter-nodemon/templates/priorityclass.yaml
@@ -1,4 +1,4 @@
-{{- if and .Values.priorityClass.enabled .Values.priorityClass.create }}
+{{- if and .Values.global.priorityClass.enabled .Values.priorityClass.create }}
 apiVersion: scheduling.k8s.io/v1
 kind: PriorityClass
 metadata:
@@ -10,7 +10,7 @@ metadata:
   name: devzero-zxporter-devzero-zxporter-critical
   labels:
     {{- include "zxporter-nodemon.labels" . | nindent 4 }}
-value: {{ .Values.priorityClass.value }}
+value: {{ .Values.priorityClass.value | int64 }}
 globalDefault: false
 description: {{ .Values.priorityClass.description | quote }}
 preemptionPolicy: {{ .Values.priorityClass.preemptionPolicy }}

--- a/helm-chart/zxporter-nodemon/values.yaml
+++ b/helm-chart/zxporter-nodemon/values.yaml
@@ -58,6 +58,12 @@ nodemon:
 jvmMetrics:
   enabled: true
 
+# Assigns the node agent the parent chart's custom PriorityClass so it can
+# schedule on memory-packed nodes. Keep in sync with the parent's
+# priorityClass.enabled (the parent creates the PriorityClass object).
+priorityClass:
+  enabled: true
+
 dcgmExporter:
   enabled: true
   # RuntimeClass for the GPU DaemonSet only.

--- a/helm-chart/zxporter-nodemon/values.yaml
+++ b/helm-chart/zxporter-nodemon/values.yaml
@@ -58,14 +58,21 @@ nodemon:
 jvmMetrics:
   enabled: true
 
+# global.priorityClass.enabled is the single toggle for using the custom
+# PriorityClass. The parent zxporter chart supplies it (auto-propagated to this
+# subchart); this default applies when nodemon is installed standalone (CI,
+# helm-release-nodemon).
+global:
+  priorityClass:
+    enabled: true
+
 # Assigns the node agent a custom PriorityClass so it can schedule on
-# memory-packed nodes. When installed standalone (CI, helm-release-nodemon)
-# the subchart creates the PriorityClass itself (create: true). When installed
-# via the parent zxporter chart, the parent already owns the object and sets
-# create: false to avoid duplicate ownership. Values must match the parent's
-# so the class is identical whichever chart creates it.
+# memory-packed nodes. When installed standalone the subchart creates the
+# PriorityClass itself (create: true). When installed via the parent zxporter
+# chart, the parent already owns the object and overrides create to false to
+# avoid duplicate ownership. value/description/preemptionPolicy must match the
+# parent's so the class is identical whichever chart creates it.
 priorityClass:
-  enabled: true
   create: true
   value: 1000000000
   description: "This priority class is for critical zxporter infrastructure components."

--- a/helm-chart/zxporter-nodemon/values.yaml
+++ b/helm-chart/zxporter-nodemon/values.yaml
@@ -58,11 +58,18 @@ nodemon:
 jvmMetrics:
   enabled: true
 
-# Assigns the node agent the parent chart's custom PriorityClass so it can
-# schedule on memory-packed nodes. Keep in sync with the parent's
-# priorityClass.enabled (the parent creates the PriorityClass object).
+# Assigns the node agent a custom PriorityClass so it can schedule on
+# memory-packed nodes. When installed standalone (CI, helm-release-nodemon)
+# the subchart creates the PriorityClass itself (create: true). When installed
+# via the parent zxporter chart, the parent already owns the object and sets
+# create: false to avoid duplicate ownership. Values must match the parent's
+# so the class is identical whichever chart creates it.
 priorityClass:
   enabled: true
+  create: true
+  value: 1000000000
+  description: "This priority class is for critical zxporter infrastructure components."
+  preemptionPolicy: PreemptLowerPriority
 
 dcgmExporter:
   enabled: true

--- a/helm-chart/zxporter/templates/NOTES.txt
+++ b/helm-chart/zxporter/templates/NOTES.txt
@@ -62,7 +62,7 @@ To check DCGM exporter status:
 For detailed installation and configuration instructions, refer to:
   https://www.devzero.io/docs/k8s-automation/getting-started/step-by-step#nvidia-gpus-on-k8s
 
-{{- if .Values.priorityClass.enabled }}
+{{- if .Values.global.priorityClass.enabled }}
 
 High priority class has been configured for critical workload scheduling.
 

--- a/helm-chart/zxporter/templates/deployment.yaml
+++ b/helm-chart/zxporter/templates/deployment.yaml
@@ -21,7 +21,7 @@ spec:
         control-plane: controller-manager
         {{- include "zxporter.selectorLabels" . | nindent 8 }}
     spec:
-      {{- if .Values.priorityClass.enabled }}
+      {{- if .Values.global.priorityClass.enabled }}
       {{- /* Must equal the PriorityClass name in templates/priorityclass.yaml, which is hardcoded
              to the (double-prefixed) dist/ bundle name so helm + installer_updater stay in sync. */}}
       priorityClassName: devzero-zxporter-devzero-zxporter-critical

--- a/helm-chart/zxporter/templates/priorityclass.yaml
+++ b/helm-chart/zxporter/templates/priorityclass.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.priorityClass.enabled }}
+{{- if .Values.global.priorityClass.enabled }}
 apiVersion: scheduling.k8s.io/v1
 kind: PriorityClass
 metadata:
@@ -10,7 +10,7 @@ metadata:
   name: devzero-zxporter-devzero-zxporter-critical
   labels:
     {{- include "zxporter.labels" . | nindent 4 }}
-value: {{ .Values.priorityClass.value }}
+value: {{ .Values.priorityClass.value | int64 }}
 globalDefault: false
 description: {{ .Values.priorityClass.description | quote }}
 preemptionPolicy: {{ .Values.priorityClass.preemptionPolicy }}

--- a/helm-chart/zxporter/values.yaml
+++ b/helm-chart/zxporter/values.yaml
@@ -144,15 +144,22 @@ mpaServer:
   port: 50051
 
 # Priority Class for critical workloads
+# global.priorityClass.enabled is the single source of truth for whether the
+# custom PriorityClass is used at all. Being a global, it auto-propagates to the
+# nodemon subchart, so the object (created here) and the DaemonSet reference (in
+# the subchart) can never drift out of sync.
+global:
+  priorityClass:
+    enabled: true
+
 priorityClass:
-  enabled: true
   value: 1000000000
   description: "This priority class is for critical zxporter infrastructure components."
   preemptionPolicy: PreemptLowerPriority
 
-# Subchart overrides. The parent chart owns the PriorityClass object (above),
-# so the bundled nodemon subchart must NOT create it again (would be a duplicate
-# resource). The nodemon DaemonSet still references it via priorityClass.enabled.
+# Subchart overrides. The parent chart owns the PriorityClass object, so the
+# bundled nodemon subchart must NOT create it again (would be a duplicate
+# resource). The DaemonSet still references it, gated on the shared global.
 zxporter-nodemon:
   priorityClass:
     create: false

--- a/helm-chart/zxporter/values.yaml
+++ b/helm-chart/zxporter/values.yaml
@@ -149,3 +149,10 @@ priorityClass:
   value: 1000000000
   description: "This priority class is for critical zxporter infrastructure components."
   preemptionPolicy: PreemptLowerPriority
+
+# Subchart overrides. The parent chart owns the PriorityClass object (above),
+# so the bundled nodemon subchart must NOT create it again (would be a duplicate
+# resource). The nodemon DaemonSet still references it via priorityClass.enabled.
+zxporter-nodemon:
+  priorityClass:
+    create: false


### PR DESCRIPTION
## Why

On a memory-packed node, the node agent (`zxporter-nodemon`) had **no `priorityClassName`**, so its DaemonSet pod loses the scheduling race and stays `Pending` — that node then runs **with no telemetry at all**.

We hit this on a customer EKS cluster: their only running JVM workload sat on exactly such a node and was never JVM-detected, even though the **image and nodemon config were byte-for-byte identical** to a cluster where detection works. Root cause wasn't the collector — it was that nodemon never scheduled on the JVM's node (`Insufficient memory`, no priority to preempt).

## What this does

Assigns nodemon the **same custom PriorityClass the controller already uses** — `devzero-zxporter-devzero-zxporter-critical` (value `1e9`). Nodemon simply adopts a class that's already proven across GKE + EKS in production.

Why this succeeds where #445 didn't:
- #445 used the **reserved** `system-node-critical`, which **GKE blocks** in non-`kube-system` namespaces (its quota on reserved priority classes) → DaemonSet pods were never created on GKE → reverted.
- This uses a **custom** (non-reserved) class, which GKE does not restrict. It still preempts ordinary workloads on packed nodes (value `1e9`), but sits **below** `system-cluster-critical`/`system-node-critical`, so it never preempts the control plane.

Applied to **both** deployment paths — kustomize `config/zxporter-netmon.yaml` (→ regenerated `dist/` bundles) and the helm `zxporter-nodemon` subchart — and `dist/` regenerated via `make build-installer`.

## Trade-off
`preemptionPolicy: PreemptLowerPriority` (inherited from the existing class) means on a genuinely full node, nodemon may evict a lower-priority pod to land. That's the intended behavior for a node-level telemetry agent.

## Rollout
EKS is unaffected/works today, so the plan is to **land this first**; once the image publishes, **validate on a fresh GKE cluster** (confirm nodemon pods are created — no quota rejection — and schedule) before rolling forward.

Supersedes / re-does #445 the GKE-safe way.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
