### PR TITLE
bump zxp image tags to v0.0.88 + fix auto helm-bump PR creation

### DIFF
--- a/.github/workflows/push-zxporter-image.yml
+++ b/.github/workflows/push-zxporter-image.yml
@@ -53,7 +53,7 @@ jobs:
 
             echo "Debug: MAJOR=${BASH_REMATCH[1]}, MINOR=${BASH_REMATCH[2]}, PATCH=${PATCH}, PATCH_SHORT=${PATCH_SHORT}"
             echo "Debug: FULLV=${FULLV}"
-            echo "is_release=${IS_RELEASE}" >> $GITHUB_OUTPUT
+            echo "is_release=true" >> $GITHUB_OUTPUT
           else
             echo "MAJOR=0" >> $GITHUB_ENV
             echo "MINOR=0" >> $GITHUB_ENV

--- a/.github/workflows/push-zxporter-netmon-image.yml
+++ b/.github/workflows/push-zxporter-netmon-image.yml
@@ -53,7 +53,7 @@ jobs:
 
           echo "Debug: MAJOR=${BASH_REMATCH[1]}, MINOR=${BASH_REMATCH[2]}, PATCH=${PATCH}, PATCH_SHORT=${PATCH_SHORT}"
           echo "Debug: FULLV=${FULLV}"
-          echo "is_release=${IS_RELEASE}" >> $GITHUB_OUTPUT
+          echo "is_release=true" >> $GITHUB_OUTPUT
           else
           echo "MAJOR=0" >> $GITHUB_ENV
           echo "MINOR=0" >> $GITHUB_ENV

--- a/.github/workflows/push-zxporter-nodemon-image.yml
+++ b/.github/workflows/push-zxporter-nodemon-image.yml
@@ -53,7 +53,7 @@ jobs:
 
           echo "Debug: MAJOR=${BASH_REMATCH[1]}, MINOR=${BASH_REMATCH[2]}, PATCH=${PATCH}, PATCH_SHORT=${PATCH_SHORT}"
           echo "Debug: FULLV=${FULLV}"
-          echo "is_release=${IS_RELEASE}" >> $GITHUB_OUTPUT
+          echo "is_release=true" >> $GITHUB_OUTPUT
           else
           echo "MAJOR=0" >> $GITHUB_ENV
           echo "MINOR=0" >> $GITHUB_ENV

--- a/helm-chart/zxporter-netmon/values.yaml
+++ b/helm-chart/zxporter-netmon/values.yaml
@@ -2,7 +2,7 @@ image:
   repository: devzeroinc/zxporter-netmon
   pullPolicy: IfNotPresent
   # Overrides the image tag whose default is the chart appVersion.
-  tag: "v0.0.87"
+  tag: "v0.0.88"
 
 imagePullSecrets: []
 nameOverride: ""

--- a/helm-chart/zxporter-nodemon/values.yaml
+++ b/helm-chart/zxporter-nodemon/values.yaml
@@ -19,7 +19,7 @@ serviceAccount:
 image:
   repository: docker.io/devzeroinc/zxporter-nodemon
   pullPolicy: IfNotPresent
-  tag: "v0.0.87"
+  tag: "v0.0.88"
 
 nodemon:
   # nodemon.affinity -- optional pod affinity/anti-affinity. Leave empty so nodemon schedules on

--- a/helm-chart/zxporter/values.yaml
+++ b/helm-chart/zxporter/values.yaml
@@ -11,7 +11,7 @@
 image:
   repository: docker.io/devzeroinc/zxporter
   pullPolicy: IfNotPresent
-  tag: "v0.0.87"
+  tag: "v0.0.88"
 
 # ZXPorter configuration
 zxporter:


### PR DESCRIPTION
## Summary
1. **Bumps `image.tag` to v0.0.88** in all three chart values files (`zxporter`, `zxporter-nodemon`, `zxporter-netmon`) — unblocks cutting the v0.0.88 Helm chart release. All three v0.0.88 images are verified published to Docker Hub.
2. **Fixes the `is_release` step output** so the `Update Helm values image.tag and create PR` job stops being skipped on every release (the reason this bump had to be done manually).

## The CI bug (fix #2)
In the `Extract Version Info` step of all three push workflows:
```bash
echo "IS_RELEASE=true" >> $GITHUB_ENV              # env FILE — applies to LATER steps only
echo "is_release=${IS_RELEASE}" >> $GITHUB_OUTPUT  # ${IS_RELEASE} is EMPTY in this same step
```
`$GITHUB_ENV` doesn't export into the current step's shell, so `${IS_RELEASE}` expanded to `""`, the output `is_release` became empty, and the gate `needs.package-and-push.outputs.is_release == 'true'` failed → the PR-creation job was `skipped` on v0.0.87 and v0.0.88 (version detection itself worked — logs show `FULLV=v0.0.88`). Fix: write the literal `true` (matching the `else` branch that already hardcodes `false`).

## Release steps (after merge)
1. Run **Release Helm Chart (Nodemon)** workflow_dispatch (publishes nodemon chart + auto-bumps the zxporter dependency pin)
2. Run **Release Helm Chart (Netmon)** workflow_dispatch
3. Run **Release Helm Chart** (zxporter) workflow_dispatch

`make build-installer` produced no `dist/` changes — those bundles use `latest`/placeholder image refs, not the version.

🤖 Generated with [Claude Code](https://claude.com/claude-code)