### PR TITLE
ci: fix is_release output so auto helm-bump PR is created on release

### DIFF
--- a/.github/workflows/push-zxporter-image.yml
+++ b/.github/workflows/push-zxporter-image.yml
@@ -53,7 +53,7 @@ jobs:
 
             echo "Debug: MAJOR=${BASH_REMATCH[1]}, MINOR=${BASH_REMATCH[2]}, PATCH=${PATCH}, PATCH_SHORT=${PATCH_SHORT}"
             echo "Debug: FULLV=${FULLV}"
-            echo "is_release=${IS_RELEASE}" >> $GITHUB_OUTPUT
+            echo "is_release=true" >> $GITHUB_OUTPUT
           else
             echo "MAJOR=0" >> $GITHUB_ENV
             echo "MINOR=0" >> $GITHUB_ENV

--- a/.github/workflows/push-zxporter-netmon-image.yml
+++ b/.github/workflows/push-zxporter-netmon-image.yml
@@ -53,7 +53,7 @@ jobs:
 
           echo "Debug: MAJOR=${BASH_REMATCH[1]}, MINOR=${BASH_REMATCH[2]}, PATCH=${PATCH}, PATCH_SHORT=${PATCH_SHORT}"
           echo "Debug: FULLV=${FULLV}"
-          echo "is_release=${IS_RELEASE}" >> $GITHUB_OUTPUT
+          echo "is_release=true" >> $GITHUB_OUTPUT
           else
           echo "MAJOR=0" >> $GITHUB_ENV
           echo "MINOR=0" >> $GITHUB_ENV

--- a/.github/workflows/push-zxporter-nodemon-image.yml
+++ b/.github/workflows/push-zxporter-nodemon-image.yml
@@ -53,7 +53,7 @@ jobs:
 
           echo "Debug: MAJOR=${BASH_REMATCH[1]}, MINOR=${BASH_REMATCH[2]}, PATCH=${PATCH}, PATCH_SHORT=${PATCH_SHORT}"
           echo "Debug: FULLV=${FULLV}"
-          echo "is_release=${IS_RELEASE}" >> $GITHUB_OUTPUT
+          echo "is_release=true" >> $GITHUB_OUTPUT
           else
           echo "MAJOR=0" >> $GITHUB_ENV
           echo "MINOR=0" >> $GITHUB_ENV


### PR DESCRIPTION
## Problem
On every `v*` tag push, the `Update Helm values image.tag and create PR` job is **skipped**, so the auto image-tag bump PR is never created — releases (v0.0.87, v0.0.88) have required manual `bump zxp vX` PRs.

## Root cause
In the `Extract Version Info` step:
```bash
echo "IS_RELEASE=true" >> $GITHUB_ENV          # env FILE — applies to LATER steps only
...
echo "is_release=${IS_RELEASE}" >> $GITHUB_OUTPUT   # ${IS_RELEASE} is EMPTY in this same step
```
Variables written to `$GITHUB_ENV` are not exported into the **current** step's shell, only subsequent steps. So `${IS_RELEASE}` expanded to an empty string, the step output `is_release` became `""`, and the downstream gate `needs.package-and-push.outputs.is_release == 'true'` evaluated false → job skipped.

Confirmed via run logs: the v0.0.88 run detected `FULLV=v0.0.88` correctly but the PR job still shows `skipped`.

## Fix
Write the literal `true` to `$GITHUB_OUTPUT` (the `else` branch already hardcodes `false`). Applied to all three image push workflows (zxporter, nodemon, netmon).

🤖 Generated with [Claude Code](https://claude.com/claude-code)