### PR TITLE
ci: fix nodemon helm-release follow-up PR + reconcile chart to 0.0.10

### DIFF
--- a/.github/workflows/helm-release-nodemon.yml
+++ b/.github/workflows/helm-release-nodemon.yml
@@ -157,15 +157,18 @@ jobs:
                   body: |
                       This PR:
                       - Updates the `version` and `appVersion` fields in `helm-chart/${{ env.CHART_NAME }}/Chart.yaml` to `${{ steps.bump_version.outputs.new_version }}`.
-                      - Bumps the `${{ env.CHART_NAME }}` dependency pin in `helm-chart/zxporter/Chart.yaml` to `${{ steps.bump_version.outputs.new_version }}` and regenerates `helm-chart/zxporter/Chart.lock` and the bundled dependency chart.
+                      - Bumps the `${{ env.CHART_NAME }}` dependency pin in `helm-chart/zxporter/Chart.yaml` to `${{ steps.bump_version.outputs.new_version }}` and regenerates `helm-chart/zxporter/Chart.lock`. (The bundled dependency `.tgz` under `helm-chart/zxporter/charts/` is a build artifact and is gitignored, so it is not committed.)
                       - Regenerates the `dist/` installer bundles so the rendered `zxporter-nodemon` chart labels track `${{ steps.bump_version.outputs.new_version }}`.
                   branch: "update/chart-version-nodemon-${{ steps.bump_version.outputs.new_version }}"
                   add-paths: |
                       helm-chart/${{ env.CHART_NAME }}/Chart.yaml
                       helm-chart/zxporter/Chart.yaml
                       helm-chart/zxporter/Chart.lock
-                      helm-chart/zxporter/charts/**
                       dist/install.yaml
+                      dist/install-nvidia-runtime.yaml
                       dist/backend-install.yaml
+                      dist/backend-install-nvidia-runtime.yaml
                       dist/installer_updater.yaml
+                      dist/installer_updater-nvidia-runtime.yaml
                       dist/nodemon.yaml
+                      dist/nodemon-nvidia-runtime.yaml

--- a/dist/backend-install-nvidia-runtime.yaml
+++ b/dist/backend-install-nvidia-runtime.yaml
@@ -769,10 +769,10 @@ metadata:
   name: zxporter-nodemon
   namespace: {{.zxporter_namespace}}
   labels:
-    helm.sh/chart: zxporter-nodemon-0.0.9
+    helm.sh/chart: zxporter-nodemon-0.0.10
     app.kubernetes.io/name: zxporter-nodemon
     app.kubernetes.io/instance: zxporter-nodemon
-    app.kubernetes.io/version: "0.0.9"
+    app.kubernetes.io/version: "0.0.10"
     app.kubernetes.io/managed-by: Helm
 ---
 # Source: zxporter-nodemon/templates/dcgm-exporter-configmap.yaml
@@ -845,10 +845,10 @@ kind: ClusterRole
 metadata:
   name: zxporter-nodemon
   labels:
-    helm.sh/chart: zxporter-nodemon-0.0.9
+    helm.sh/chart: zxporter-nodemon-0.0.10
     app.kubernetes.io/name: zxporter-nodemon
     app.kubernetes.io/instance: zxporter-nodemon
-    app.kubernetes.io/version: "0.0.9"
+    app.kubernetes.io/version: "0.0.10"
     app.kubernetes.io/managed-by: Helm
 rules:
   - apiGroups:
@@ -896,10 +896,10 @@ kind: ClusterRoleBinding
 metadata:
   name: zxporter-nodemon
   labels:
-    helm.sh/chart: zxporter-nodemon-0.0.9
+    helm.sh/chart: zxporter-nodemon-0.0.10
     app.kubernetes.io/name: zxporter-nodemon
     app.kubernetes.io/instance: zxporter-nodemon
-    app.kubernetes.io/version: "0.0.9"
+    app.kubernetes.io/version: "0.0.10"
     app.kubernetes.io/managed-by: Helm
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -917,10 +917,10 @@ metadata:
   name: zxporter-nodemon
   namespace: {{.zxporter_namespace}}
   labels:
-    helm.sh/chart: zxporter-nodemon-0.0.9
+    helm.sh/chart: zxporter-nodemon-0.0.10
     app.kubernetes.io/name: zxporter-nodemon
     app.kubernetes.io/instance: zxporter-nodemon
-    app.kubernetes.io/version: "0.0.9"
+    app.kubernetes.io/version: "0.0.10"
     app.kubernetes.io/managed-by: Helm
 spec:
   selector:
@@ -1005,10 +1005,10 @@ metadata:
   name: zxporter-nodemon-gpu
   namespace: {{.zxporter_namespace}}
   labels:
-    helm.sh/chart: zxporter-nodemon-0.0.9
+    helm.sh/chart: zxporter-nodemon-0.0.10
     app.kubernetes.io/name: zxporter-nodemon
     app.kubernetes.io/instance: zxporter-nodemon-gpu
-    app.kubernetes.io/version: "0.0.9"
+    app.kubernetes.io/version: "0.0.10"
     app.kubernetes.io/managed-by: Helm
   annotations:
     ignore-check.kube-linter.io/privileged-container: "This daemon set needs to run DCGM Exporter as privileged to access the GPU metrics."

--- a/dist/backend-install.yaml
+++ b/dist/backend-install.yaml
@@ -769,10 +769,10 @@ metadata:
   name: zxporter-nodemon
   namespace: {{.zxporter_namespace}}
   labels:
-    helm.sh/chart: zxporter-nodemon-0.0.9
+    helm.sh/chart: zxporter-nodemon-0.0.10
     app.kubernetes.io/name: zxporter-nodemon
     app.kubernetes.io/instance: zxporter-nodemon
-    app.kubernetes.io/version: "0.0.9"
+    app.kubernetes.io/version: "0.0.10"
     app.kubernetes.io/managed-by: Helm
 ---
 # Source: zxporter-nodemon/templates/dcgm-exporter-configmap.yaml
@@ -845,10 +845,10 @@ kind: ClusterRole
 metadata:
   name: zxporter-nodemon
   labels:
-    helm.sh/chart: zxporter-nodemon-0.0.9
+    helm.sh/chart: zxporter-nodemon-0.0.10
     app.kubernetes.io/name: zxporter-nodemon
     app.kubernetes.io/instance: zxporter-nodemon
-    app.kubernetes.io/version: "0.0.9"
+    app.kubernetes.io/version: "0.0.10"
     app.kubernetes.io/managed-by: Helm
 rules:
   - apiGroups:
@@ -896,10 +896,10 @@ kind: ClusterRoleBinding
 metadata:
   name: zxporter-nodemon
   labels:
-    helm.sh/chart: zxporter-nodemon-0.0.9
+    helm.sh/chart: zxporter-nodemon-0.0.10
     app.kubernetes.io/name: zxporter-nodemon
     app.kubernetes.io/instance: zxporter-nodemon
-    app.kubernetes.io/version: "0.0.9"
+    app.kubernetes.io/version: "0.0.10"
     app.kubernetes.io/managed-by: Helm
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -917,10 +917,10 @@ metadata:
   name: zxporter-nodemon
   namespace: {{.zxporter_namespace}}
   labels:
-    helm.sh/chart: zxporter-nodemon-0.0.9
+    helm.sh/chart: zxporter-nodemon-0.0.10
     app.kubernetes.io/name: zxporter-nodemon
     app.kubernetes.io/instance: zxporter-nodemon
-    app.kubernetes.io/version: "0.0.9"
+    app.kubernetes.io/version: "0.0.10"
     app.kubernetes.io/managed-by: Helm
   annotations:
     ignore-check.kube-linter.io/privileged-container: "This daemon set needs to run DCGM Exporter as privileged to access the GPU metrics."

--- a/dist/install-nvidia-runtime.yaml
+++ b/dist/install-nvidia-runtime.yaml
@@ -769,10 +769,10 @@ metadata:
   name: zxporter-nodemon
   namespace: devzero-system
   labels:
-    helm.sh/chart: zxporter-nodemon-0.0.9
+    helm.sh/chart: zxporter-nodemon-0.0.10
     app.kubernetes.io/name: zxporter-nodemon
     app.kubernetes.io/instance: zxporter-nodemon
-    app.kubernetes.io/version: "0.0.9"
+    app.kubernetes.io/version: "0.0.10"
     app.kubernetes.io/managed-by: Helm
 ---
 # Source: zxporter-nodemon/templates/dcgm-exporter-configmap.yaml
@@ -845,10 +845,10 @@ kind: ClusterRole
 metadata:
   name: zxporter-nodemon
   labels:
-    helm.sh/chart: zxporter-nodemon-0.0.9
+    helm.sh/chart: zxporter-nodemon-0.0.10
     app.kubernetes.io/name: zxporter-nodemon
     app.kubernetes.io/instance: zxporter-nodemon
-    app.kubernetes.io/version: "0.0.9"
+    app.kubernetes.io/version: "0.0.10"
     app.kubernetes.io/managed-by: Helm
 rules:
 - apiGroups:
@@ -896,10 +896,10 @@ kind: ClusterRoleBinding
 metadata:
   name: zxporter-nodemon
   labels:
-    helm.sh/chart: zxporter-nodemon-0.0.9
+    helm.sh/chart: zxporter-nodemon-0.0.10
     app.kubernetes.io/name: zxporter-nodemon
     app.kubernetes.io/instance: zxporter-nodemon
-    app.kubernetes.io/version: "0.0.9"
+    app.kubernetes.io/version: "0.0.10"
     app.kubernetes.io/managed-by: Helm
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -917,10 +917,10 @@ metadata:
   name: zxporter-nodemon
   namespace: devzero-system
   labels:
-    helm.sh/chart: zxporter-nodemon-0.0.9
+    helm.sh/chart: zxporter-nodemon-0.0.10
     app.kubernetes.io/name: zxporter-nodemon
     app.kubernetes.io/instance: zxporter-nodemon
-    app.kubernetes.io/version: "0.0.9"
+    app.kubernetes.io/version: "0.0.10"
     app.kubernetes.io/managed-by: Helm
 spec:
   selector:
@@ -1005,10 +1005,10 @@ metadata:
   name: zxporter-nodemon-gpu
   namespace: devzero-system
   labels:
-    helm.sh/chart: zxporter-nodemon-0.0.9
+    helm.sh/chart: zxporter-nodemon-0.0.10
     app.kubernetes.io/name: zxporter-nodemon
     app.kubernetes.io/instance: zxporter-nodemon-gpu
-    app.kubernetes.io/version: "0.0.9"
+    app.kubernetes.io/version: "0.0.10"
     app.kubernetes.io/managed-by: Helm
   annotations:
     ignore-check.kube-linter.io/privileged-container: "This daemon set needs to run DCGM Exporter as privileged to access the GPU metrics."

--- a/dist/install.yaml
+++ b/dist/install.yaml
@@ -769,10 +769,10 @@ metadata:
   name: zxporter-nodemon
   namespace: devzero-system
   labels:
-    helm.sh/chart: zxporter-nodemon-0.0.9
+    helm.sh/chart: zxporter-nodemon-0.0.10
     app.kubernetes.io/name: zxporter-nodemon
     app.kubernetes.io/instance: zxporter-nodemon
-    app.kubernetes.io/version: "0.0.9"
+    app.kubernetes.io/version: "0.0.10"
     app.kubernetes.io/managed-by: Helm
 ---
 # Source: zxporter-nodemon/templates/dcgm-exporter-configmap.yaml
@@ -845,10 +845,10 @@ kind: ClusterRole
 metadata:
   name: zxporter-nodemon
   labels:
-    helm.sh/chart: zxporter-nodemon-0.0.9
+    helm.sh/chart: zxporter-nodemon-0.0.10
     app.kubernetes.io/name: zxporter-nodemon
     app.kubernetes.io/instance: zxporter-nodemon
-    app.kubernetes.io/version: "0.0.9"
+    app.kubernetes.io/version: "0.0.10"
     app.kubernetes.io/managed-by: Helm
 rules:
 - apiGroups:
@@ -896,10 +896,10 @@ kind: ClusterRoleBinding
 metadata:
   name: zxporter-nodemon
   labels:
-    helm.sh/chart: zxporter-nodemon-0.0.9
+    helm.sh/chart: zxporter-nodemon-0.0.10
     app.kubernetes.io/name: zxporter-nodemon
     app.kubernetes.io/instance: zxporter-nodemon
-    app.kubernetes.io/version: "0.0.9"
+    app.kubernetes.io/version: "0.0.10"
     app.kubernetes.io/managed-by: Helm
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -917,10 +917,10 @@ metadata:
   name: zxporter-nodemon
   namespace: devzero-system
   labels:
-    helm.sh/chart: zxporter-nodemon-0.0.9
+    helm.sh/chart: zxporter-nodemon-0.0.10
     app.kubernetes.io/name: zxporter-nodemon
     app.kubernetes.io/instance: zxporter-nodemon
-    app.kubernetes.io/version: "0.0.9"
+    app.kubernetes.io/version: "0.0.10"
     app.kubernetes.io/managed-by: Helm
   annotations:
     ignore-check.kube-linter.io/privileged-container: "This daemon set needs to run DCGM Exporter as privileged to access the GPU metrics."

--- a/dist/installer_updater-nvidia-runtime.yaml
+++ b/dist/installer_updater-nvidia-runtime.yaml
@@ -706,10 +706,10 @@ metadata:
   name: zxporter-nodemon
   namespace: '{{.zxporter_namespace}}'
   labels:
-    helm.sh/chart: zxporter-nodemon-0.0.9
+    helm.sh/chart: zxporter-nodemon-0.0.10
     app.kubernetes.io/name: zxporter-nodemon
     app.kubernetes.io/instance: zxporter-nodemon
-    app.kubernetes.io/version: "0.0.9"
+    app.kubernetes.io/version: "0.0.10"
     app.kubernetes.io/managed-by: Helm
 ---
 # Source: zxporter-nodemon/templates/dcgm-exporter-configmap.yaml
@@ -782,10 +782,10 @@ kind: ClusterRole
 metadata:
   name: zxporter-nodemon
   labels:
-    helm.sh/chart: zxporter-nodemon-0.0.9
+    helm.sh/chart: zxporter-nodemon-0.0.10
     app.kubernetes.io/name: zxporter-nodemon
     app.kubernetes.io/instance: zxporter-nodemon
-    app.kubernetes.io/version: "0.0.9"
+    app.kubernetes.io/version: "0.0.10"
     app.kubernetes.io/managed-by: Helm
 rules:
   - apiGroups:
@@ -833,10 +833,10 @@ kind: ClusterRoleBinding
 metadata:
   name: zxporter-nodemon
   labels:
-    helm.sh/chart: zxporter-nodemon-0.0.9
+    helm.sh/chart: zxporter-nodemon-0.0.10
     app.kubernetes.io/name: zxporter-nodemon
     app.kubernetes.io/instance: zxporter-nodemon
-    app.kubernetes.io/version: "0.0.9"
+    app.kubernetes.io/version: "0.0.10"
     app.kubernetes.io/managed-by: Helm
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -854,10 +854,10 @@ metadata:
   name: zxporter-nodemon
   namespace: '{{.zxporter_namespace}}'
   labels:
-    helm.sh/chart: zxporter-nodemon-0.0.9
+    helm.sh/chart: zxporter-nodemon-0.0.10
     app.kubernetes.io/name: zxporter-nodemon
     app.kubernetes.io/instance: zxporter-nodemon
-    app.kubernetes.io/version: "0.0.9"
+    app.kubernetes.io/version: "0.0.10"
     app.kubernetes.io/managed-by: Helm
 spec:
   selector:
@@ -942,10 +942,10 @@ metadata:
   name: zxporter-nodemon-gpu
   namespace: '{{.zxporter_namespace}}'
   labels:
-    helm.sh/chart: zxporter-nodemon-0.0.9
+    helm.sh/chart: zxporter-nodemon-0.0.10
     app.kubernetes.io/name: zxporter-nodemon
     app.kubernetes.io/instance: zxporter-nodemon-gpu
-    app.kubernetes.io/version: "0.0.9"
+    app.kubernetes.io/version: "0.0.10"
     app.kubernetes.io/managed-by: Helm
   annotations:
     ignore-check.kube-linter.io/privileged-container: "This daemon set needs to run DCGM Exporter as privileged to access the GPU metrics."

--- a/dist/installer_updater.yaml
+++ b/dist/installer_updater.yaml
@@ -706,10 +706,10 @@ metadata:
   name: zxporter-nodemon
   namespace: '{{.zxporter_namespace}}'
   labels:
-    helm.sh/chart: zxporter-nodemon-0.0.9
+    helm.sh/chart: zxporter-nodemon-0.0.10
     app.kubernetes.io/name: zxporter-nodemon
     app.kubernetes.io/instance: zxporter-nodemon
-    app.kubernetes.io/version: "0.0.9"
+    app.kubernetes.io/version: "0.0.10"
     app.kubernetes.io/managed-by: Helm
 ---
 # Source: zxporter-nodemon/templates/dcgm-exporter-configmap.yaml
@@ -782,10 +782,10 @@ kind: ClusterRole
 metadata:
   name: zxporter-nodemon
   labels:
-    helm.sh/chart: zxporter-nodemon-0.0.9
+    helm.sh/chart: zxporter-nodemon-0.0.10
     app.kubernetes.io/name: zxporter-nodemon
     app.kubernetes.io/instance: zxporter-nodemon
-    app.kubernetes.io/version: "0.0.9"
+    app.kubernetes.io/version: "0.0.10"
     app.kubernetes.io/managed-by: Helm
 rules:
   - apiGroups:
@@ -833,10 +833,10 @@ kind: ClusterRoleBinding
 metadata:
   name: zxporter-nodemon
   labels:
-    helm.sh/chart: zxporter-nodemon-0.0.9
+    helm.sh/chart: zxporter-nodemon-0.0.10
     app.kubernetes.io/name: zxporter-nodemon
     app.kubernetes.io/instance: zxporter-nodemon
-    app.kubernetes.io/version: "0.0.9"
+    app.kubernetes.io/version: "0.0.10"
     app.kubernetes.io/managed-by: Helm
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -854,10 +854,10 @@ metadata:
   name: zxporter-nodemon
   namespace: '{{.zxporter_namespace}}'
   labels:
-    helm.sh/chart: zxporter-nodemon-0.0.9
+    helm.sh/chart: zxporter-nodemon-0.0.10
     app.kubernetes.io/name: zxporter-nodemon
     app.kubernetes.io/instance: zxporter-nodemon
-    app.kubernetes.io/version: "0.0.9"
+    app.kubernetes.io/version: "0.0.10"
     app.kubernetes.io/managed-by: Helm
   annotations:
     ignore-check.kube-linter.io/privileged-container: "This daemon set needs to run DCGM Exporter as privileged to access the GPU metrics."

--- a/dist/nodemon-nvidia-runtime.yaml
+++ b/dist/nodemon-nvidia-runtime.yaml
@@ -6,10 +6,10 @@ metadata:
   name: zxporter-nodemon
   namespace: devzero-system
   labels:
-    helm.sh/chart: zxporter-nodemon-0.0.9
+    helm.sh/chart: zxporter-nodemon-0.0.10
     app.kubernetes.io/name: zxporter-nodemon
     app.kubernetes.io/instance: zxporter-nodemon
-    app.kubernetes.io/version: "0.0.9"
+    app.kubernetes.io/version: "0.0.10"
     app.kubernetes.io/managed-by: Helm
 ---
 # Source: zxporter-nodemon/templates/dcgm-exporter-configmap.yaml
@@ -82,10 +82,10 @@ kind: ClusterRole
 metadata:
   name: zxporter-nodemon
   labels:
-    helm.sh/chart: zxporter-nodemon-0.0.9
+    helm.sh/chart: zxporter-nodemon-0.0.10
     app.kubernetes.io/name: zxporter-nodemon
     app.kubernetes.io/instance: zxporter-nodemon
-    app.kubernetes.io/version: "0.0.9"
+    app.kubernetes.io/version: "0.0.10"
     app.kubernetes.io/managed-by: Helm
 rules:
 - apiGroups:
@@ -133,10 +133,10 @@ kind: ClusterRoleBinding
 metadata:
   name: zxporter-nodemon
   labels:
-    helm.sh/chart: zxporter-nodemon-0.0.9
+    helm.sh/chart: zxporter-nodemon-0.0.10
     app.kubernetes.io/name: zxporter-nodemon
     app.kubernetes.io/instance: zxporter-nodemon
-    app.kubernetes.io/version: "0.0.9"
+    app.kubernetes.io/version: "0.0.10"
     app.kubernetes.io/managed-by: Helm
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -154,10 +154,10 @@ metadata:
   name: zxporter-nodemon
   namespace: devzero-system
   labels:
-    helm.sh/chart: zxporter-nodemon-0.0.9
+    helm.sh/chart: zxporter-nodemon-0.0.10
     app.kubernetes.io/name: zxporter-nodemon
     app.kubernetes.io/instance: zxporter-nodemon
-    app.kubernetes.io/version: "0.0.9"
+    app.kubernetes.io/version: "0.0.10"
     app.kubernetes.io/managed-by: Helm
 spec:
   selector:
@@ -242,10 +242,10 @@ metadata:
   name: zxporter-nodemon-gpu
   namespace: devzero-system
   labels:
-    helm.sh/chart: zxporter-nodemon-0.0.9
+    helm.sh/chart: zxporter-nodemon-0.0.10
     app.kubernetes.io/name: zxporter-nodemon
     app.kubernetes.io/instance: zxporter-nodemon-gpu
-    app.kubernetes.io/version: "0.0.9"
+    app.kubernetes.io/version: "0.0.10"
     app.kubernetes.io/managed-by: Helm
   annotations:
     ignore-check.kube-linter.io/privileged-container: "This daemon set needs to run DCGM Exporter as privileged to access the GPU metrics."

--- a/dist/nodemon.yaml
+++ b/dist/nodemon.yaml
@@ -6,10 +6,10 @@ metadata:
   name: zxporter-nodemon
   namespace: devzero-system
   labels:
-    helm.sh/chart: zxporter-nodemon-0.0.9
+    helm.sh/chart: zxporter-nodemon-0.0.10
     app.kubernetes.io/name: zxporter-nodemon
     app.kubernetes.io/instance: zxporter-nodemon
-    app.kubernetes.io/version: "0.0.9"
+    app.kubernetes.io/version: "0.0.10"
     app.kubernetes.io/managed-by: Helm
 ---
 # Source: zxporter-nodemon/templates/dcgm-exporter-configmap.yaml
@@ -82,10 +82,10 @@ kind: ClusterRole
 metadata:
   name: zxporter-nodemon
   labels:
-    helm.sh/chart: zxporter-nodemon-0.0.9
+    helm.sh/chart: zxporter-nodemon-0.0.10
     app.kubernetes.io/name: zxporter-nodemon
     app.kubernetes.io/instance: zxporter-nodemon
-    app.kubernetes.io/version: "0.0.9"
+    app.kubernetes.io/version: "0.0.10"
     app.kubernetes.io/managed-by: Helm
 rules:
 - apiGroups:
@@ -133,10 +133,10 @@ kind: ClusterRoleBinding
 metadata:
   name: zxporter-nodemon
   labels:
-    helm.sh/chart: zxporter-nodemon-0.0.9
+    helm.sh/chart: zxporter-nodemon-0.0.10
     app.kubernetes.io/name: zxporter-nodemon
     app.kubernetes.io/instance: zxporter-nodemon
-    app.kubernetes.io/version: "0.0.9"
+    app.kubernetes.io/version: "0.0.10"
     app.kubernetes.io/managed-by: Helm
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -154,10 +154,10 @@ metadata:
   name: zxporter-nodemon
   namespace: devzero-system
   labels:
-    helm.sh/chart: zxporter-nodemon-0.0.9
+    helm.sh/chart: zxporter-nodemon-0.0.10
     app.kubernetes.io/name: zxporter-nodemon
     app.kubernetes.io/instance: zxporter-nodemon
-    app.kubernetes.io/version: "0.0.9"
+    app.kubernetes.io/version: "0.0.10"
     app.kubernetes.io/managed-by: Helm
   annotations:
     ignore-check.kube-linter.io/privileged-container: "This daemon set needs to run DCGM Exporter as privileged to access the GPU metrics."

--- a/helm-chart/zxporter-nodemon/Chart.yaml
+++ b/helm-chart/zxporter-nodemon/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: zxporter-nodemon
 description: A Helm chart for Kubernetes
 type: application
-version: 0.0.9
-appVersion: "0.0.9"
+version: 0.0.10
+appVersion: "0.0.10"

--- a/helm-chart/zxporter/Chart.lock
+++ b/helm-chart/zxporter/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: zxporter-nodemon
   repository: file://../zxporter-nodemon
-  version: 0.0.9
-digest: sha256:1c240a12f1bb768b7325821d3928477bb1f9a951872fc8a175a9fc293976e5f8
-generated: "2026-06-26T18:15:27.322535+05:30"
+  version: 0.0.10
+digest: sha256:196ca1521326ea1d8202c9d9fec878226109a0e0bd1c6d29b21f0d6cbe50d564
+generated: "2026-06-26T16:07:36.112875-07:00"

--- a/helm-chart/zxporter/Chart.yaml
+++ b/helm-chart/zxporter/Chart.yaml
@@ -17,5 +17,5 @@ keywords:
   - devzero
 dependencies:
   - name: zxporter-nodemon
-    version: "0.0.9"
+    version: "0.0.10"
     repository: "file://../zxporter-nodemon"


### PR DESCRIPTION
## Two things

### 1. Workflow fix
The **Release Helm Chart (Nodemon)** workflow fails at its final step (`Create PR to update Chart.yaml version`) on every run. [Example run](https://github.com/devzero-inc/zxporter/actions/runs/28269953630/job/83765085796):
```
fatal: pathspec 'helm-chart/zxporter/charts/**' did not match any files
```
The nodemon chart itself publishes fine (tag + OCI push happen earlier) — only the follow-up version-bump PR fails, leaving `Chart.yaml` out of sync with the published chart.

**Root cause:** `add-paths` lists `helm-chart/zxporter/charts/**`. The chart moved to a `file://../zxporter-nodemon` dependency and `*.tgz` is gitignored (`.gitignore:7`), so that dir only holds an ignored build artifact. `git add` on a glob matching no committable files aborts the action.

**Fix:** remove `helm-chart/zxporter/charts/**` from `add-paths`; add the `dist/*-nvidia-runtime.yaml` bundles (regenerated by `make build-installer` but previously not staged → would drift).

### 2. Reconcile the half-completed 0.0.10 release
The failed run already published nodemon chart **0.0.10** + tag `chart-nodemon-v0.0.10`, but the repo was left at 0.0.9. This PR also lands the bump the workflow would have made:
- `helm-chart/zxporter-nodemon/Chart.yaml` version + appVersion → **0.0.10**
- zxporter dependency pin → 0.0.10, `Chart.lock` regenerated
- `dist/` bundles regenerated (nodemon chart labels → 0.0.10)

🤖 Generated with [Claude Code](https://claude.com/claude-code)