### PR TITLE
fix: surface CPU throttle signal for crashlooping/short-lived containers

### DIFF
--- a/.github/workflows/helm-release-nodemon.yml
+++ b/.github/workflows/helm-release-nodemon.yml
@@ -157,15 +157,18 @@ jobs:
                   body: |
                       This PR:
                       - Updates the `version` and `appVersion` fields in `helm-chart/${{ env.CHART_NAME }}/Chart.yaml` to `${{ steps.bump_version.outputs.new_version }}`.
-                      - Bumps the `${{ env.CHART_NAME }}` dependency pin in `helm-chart/zxporter/Chart.yaml` to `${{ steps.bump_version.outputs.new_version }}` and regenerates `helm-chart/zxporter/Chart.lock` and the bundled dependency chart.
+                      - Bumps the `${{ env.CHART_NAME }}` dependency pin in `helm-chart/zxporter/Chart.yaml` to `${{ steps.bump_version.outputs.new_version }}` and regenerates `helm-chart/zxporter/Chart.lock`. (The bundled dependency `.tgz` under `helm-chart/zxporter/charts/` is a build artifact and is gitignored, so it is not committed.)
                       - Regenerates the `dist/` installer bundles so the rendered `zxporter-nodemon` chart labels track `${{ steps.bump_version.outputs.new_version }}`.
                   branch: "update/chart-version-nodemon-${{ steps.bump_version.outputs.new_version }}"
                   add-paths: |
                       helm-chart/${{ env.CHART_NAME }}/Chart.yaml
                       helm-chart/zxporter/Chart.yaml
                       helm-chart/zxporter/Chart.lock
-                      helm-chart/zxporter/charts/**
                       dist/install.yaml
+                      dist/install-nvidia-runtime.yaml
                       dist/backend-install.yaml
+                      dist/backend-install-nvidia-runtime.yaml
                       dist/installer_updater.yaml
+                      dist/installer_updater-nvidia-runtime.yaml
                       dist/nodemon.yaml
+                      dist/nodemon-nvidia-runtime.yaml

--- a/dist/backend-install-nvidia-runtime.yaml
+++ b/dist/backend-install-nvidia-runtime.yaml
@@ -769,10 +769,10 @@ metadata:
   name: zxporter-nodemon
   namespace: {{.zxporter_namespace}}
   labels:
-    helm.sh/chart: zxporter-nodemon-0.0.9
+    helm.sh/chart: zxporter-nodemon-0.0.10
     app.kubernetes.io/name: zxporter-nodemon
     app.kubernetes.io/instance: zxporter-nodemon
-    app.kubernetes.io/version: "0.0.9"
+    app.kubernetes.io/version: "0.0.10"
     app.kubernetes.io/managed-by: Helm
 ---
 # Source: zxporter-nodemon/templates/dcgm-exporter-configmap.yaml
@@ -845,10 +845,10 @@ kind: ClusterRole
 metadata:
   name: zxporter-nodemon
   labels:
-    helm.sh/chart: zxporter-nodemon-0.0.9
+    helm.sh/chart: zxporter-nodemon-0.0.10
     app.kubernetes.io/name: zxporter-nodemon
     app.kubernetes.io/instance: zxporter-nodemon
-    app.kubernetes.io/version: "0.0.9"
+    app.kubernetes.io/version: "0.0.10"
     app.kubernetes.io/managed-by: Helm
 rules:
   - apiGroups:
@@ -896,10 +896,10 @@ kind: ClusterRoleBinding
 metadata:
   name: zxporter-nodemon
   labels:
-    helm.sh/chart: zxporter-nodemon-0.0.9
+    helm.sh/chart: zxporter-nodemon-0.0.10
     app.kubernetes.io/name: zxporter-nodemon
     app.kubernetes.io/instance: zxporter-nodemon
-    app.kubernetes.io/version: "0.0.9"
+    app.kubernetes.io/version: "0.0.10"
     app.kubernetes.io/managed-by: Helm
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -917,10 +917,10 @@ metadata:
   name: zxporter-nodemon
   namespace: {{.zxporter_namespace}}
   labels:
-    helm.sh/chart: zxporter-nodemon-0.0.9
+    helm.sh/chart: zxporter-nodemon-0.0.10
     app.kubernetes.io/name: zxporter-nodemon
     app.kubernetes.io/instance: zxporter-nodemon
-    app.kubernetes.io/version: "0.0.9"
+    app.kubernetes.io/version: "0.0.10"
     app.kubernetes.io/managed-by: Helm
 spec:
   selector:
@@ -1005,10 +1005,10 @@ metadata:
   name: zxporter-nodemon-gpu
   namespace: {{.zxporter_namespace}}
   labels:
-    helm.sh/chart: zxporter-nodemon-0.0.9
+    helm.sh/chart: zxporter-nodemon-0.0.10
     app.kubernetes.io/name: zxporter-nodemon
     app.kubernetes.io/instance: zxporter-nodemon-gpu
-    app.kubernetes.io/version: "0.0.9"
+    app.kubernetes.io/version: "0.0.10"
     app.kubernetes.io/managed-by: Helm
   annotations:
     ignore-check.kube-linter.io/privileged-container: "This daemon set needs to run DCGM Exporter as privileged to access the GPU metrics."

--- a/dist/backend-install.yaml
+++ b/dist/backend-install.yaml
@@ -769,10 +769,10 @@ metadata:
   name: zxporter-nodemon
   namespace: {{.zxporter_namespace}}
   labels:
-    helm.sh/chart: zxporter-nodemon-0.0.9
+    helm.sh/chart: zxporter-nodemon-0.0.10
     app.kubernetes.io/name: zxporter-nodemon
     app.kubernetes.io/instance: zxporter-nodemon
-    app.kubernetes.io/version: "0.0.9"
+    app.kubernetes.io/version: "0.0.10"
     app.kubernetes.io/managed-by: Helm
 ---
 # Source: zxporter-nodemon/templates/dcgm-exporter-configmap.yaml
@@ -845,10 +845,10 @@ kind: ClusterRole
 metadata:
   name: zxporter-nodemon
   labels:
-    helm.sh/chart: zxporter-nodemon-0.0.9
+    helm.sh/chart: zxporter-nodemon-0.0.10
     app.kubernetes.io/name: zxporter-nodemon
     app.kubernetes.io/instance: zxporter-nodemon
-    app.kubernetes.io/version: "0.0.9"
+    app.kubernetes.io/version: "0.0.10"
     app.kubernetes.io/managed-by: Helm
 rules:
   - apiGroups:
@@ -896,10 +896,10 @@ kind: ClusterRoleBinding
 metadata:
   name: zxporter-nodemon
   labels:
-    helm.sh/chart: zxporter-nodemon-0.0.9
+    helm.sh/chart: zxporter-nodemon-0.0.10
     app.kubernetes.io/name: zxporter-nodemon
     app.kubernetes.io/instance: zxporter-nodemon
-    app.kubernetes.io/version: "0.0.9"
+    app.kubernetes.io/version: "0.0.10"
     app.kubernetes.io/managed-by: Helm
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -917,10 +917,10 @@ metadata:
   name: zxporter-nodemon
   namespace: {{.zxporter_namespace}}
   labels:
-    helm.sh/chart: zxporter-nodemon-0.0.9
+    helm.sh/chart: zxporter-nodemon-0.0.10
     app.kubernetes.io/name: zxporter-nodemon
     app.kubernetes.io/instance: zxporter-nodemon
-    app.kubernetes.io/version: "0.0.9"
+    app.kubernetes.io/version: "0.0.10"
     app.kubernetes.io/managed-by: Helm
   annotations:
     ignore-check.kube-linter.io/privileged-container: "This daemon set needs to run DCGM Exporter as privileged to access the GPU metrics."

--- a/dist/install-nvidia-runtime.yaml
+++ b/dist/install-nvidia-runtime.yaml
@@ -769,10 +769,10 @@ metadata:
   name: zxporter-nodemon
   namespace: devzero-system
   labels:
-    helm.sh/chart: zxporter-nodemon-0.0.9
+    helm.sh/chart: zxporter-nodemon-0.0.10
     app.kubernetes.io/name: zxporter-nodemon
     app.kubernetes.io/instance: zxporter-nodemon
-    app.kubernetes.io/version: "0.0.9"
+    app.kubernetes.io/version: "0.0.10"
     app.kubernetes.io/managed-by: Helm
 ---
 # Source: zxporter-nodemon/templates/dcgm-exporter-configmap.yaml
@@ -845,10 +845,10 @@ kind: ClusterRole
 metadata:
   name: zxporter-nodemon
   labels:
-    helm.sh/chart: zxporter-nodemon-0.0.9
+    helm.sh/chart: zxporter-nodemon-0.0.10
     app.kubernetes.io/name: zxporter-nodemon
     app.kubernetes.io/instance: zxporter-nodemon
-    app.kubernetes.io/version: "0.0.9"
+    app.kubernetes.io/version: "0.0.10"
     app.kubernetes.io/managed-by: Helm
 rules:
 - apiGroups:
@@ -896,10 +896,10 @@ kind: ClusterRoleBinding
 metadata:
   name: zxporter-nodemon
   labels:
-    helm.sh/chart: zxporter-nodemon-0.0.9
+    helm.sh/chart: zxporter-nodemon-0.0.10
     app.kubernetes.io/name: zxporter-nodemon
     app.kubernetes.io/instance: zxporter-nodemon
-    app.kubernetes.io/version: "0.0.9"
+    app.kubernetes.io/version: "0.0.10"
     app.kubernetes.io/managed-by: Helm
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -917,10 +917,10 @@ metadata:
   name: zxporter-nodemon
   namespace: devzero-system
   labels:
-    helm.sh/chart: zxporter-nodemon-0.0.9
+    helm.sh/chart: zxporter-nodemon-0.0.10
     app.kubernetes.io/name: zxporter-nodemon
     app.kubernetes.io/instance: zxporter-nodemon
-    app.kubernetes.io/version: "0.0.9"
+    app.kubernetes.io/version: "0.0.10"
     app.kubernetes.io/managed-by: Helm
 spec:
   selector:
@@ -1005,10 +1005,10 @@ metadata:
   name: zxporter-nodemon-gpu
   namespace: devzero-system
   labels:
-    helm.sh/chart: zxporter-nodemon-0.0.9
+    helm.sh/chart: zxporter-nodemon-0.0.10
     app.kubernetes.io/name: zxporter-nodemon
     app.kubernetes.io/instance: zxporter-nodemon-gpu
-    app.kubernetes.io/version: "0.0.9"
+    app.kubernetes.io/version: "0.0.10"
     app.kubernetes.io/managed-by: Helm
   annotations:
     ignore-check.kube-linter.io/privileged-container: "This daemon set needs to run DCGM Exporter as privileged to access the GPU metrics."

--- a/dist/install.yaml
+++ b/dist/install.yaml
@@ -769,10 +769,10 @@ metadata:
   name: zxporter-nodemon
   namespace: devzero-system
   labels:
-    helm.sh/chart: zxporter-nodemon-0.0.9
+    helm.sh/chart: zxporter-nodemon-0.0.10
     app.kubernetes.io/name: zxporter-nodemon
     app.kubernetes.io/instance: zxporter-nodemon
-    app.kubernetes.io/version: "0.0.9"
+    app.kubernetes.io/version: "0.0.10"
     app.kubernetes.io/managed-by: Helm
 ---
 # Source: zxporter-nodemon/templates/dcgm-exporter-configmap.yaml
@@ -845,10 +845,10 @@ kind: ClusterRole
 metadata:
   name: zxporter-nodemon
   labels:
-    helm.sh/chart: zxporter-nodemon-0.0.9
+    helm.sh/chart: zxporter-nodemon-0.0.10
     app.kubernetes.io/name: zxporter-nodemon
     app.kubernetes.io/instance: zxporter-nodemon
-    app.kubernetes.io/version: "0.0.9"
+    app.kubernetes.io/version: "0.0.10"
     app.kubernetes.io/managed-by: Helm
 rules:
 - apiGroups:
@@ -896,10 +896,10 @@ kind: ClusterRoleBinding
 metadata:
   name: zxporter-nodemon
   labels:
-    helm.sh/chart: zxporter-nodemon-0.0.9
+    helm.sh/chart: zxporter-nodemon-0.0.10
     app.kubernetes.io/name: zxporter-nodemon
     app.kubernetes.io/instance: zxporter-nodemon
-    app.kubernetes.io/version: "0.0.9"
+    app.kubernetes.io/version: "0.0.10"
     app.kubernetes.io/managed-by: Helm
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -917,10 +917,10 @@ metadata:
   name: zxporter-nodemon
   namespace: devzero-system
   labels:
-    helm.sh/chart: zxporter-nodemon-0.0.9
+    helm.sh/chart: zxporter-nodemon-0.0.10
     app.kubernetes.io/name: zxporter-nodemon
     app.kubernetes.io/instance: zxporter-nodemon
-    app.kubernetes.io/version: "0.0.9"
+    app.kubernetes.io/version: "0.0.10"
     app.kubernetes.io/managed-by: Helm
   annotations:
     ignore-check.kube-linter.io/privileged-container: "This daemon set needs to run DCGM Exporter as privileged to access the GPU metrics."

--- a/dist/installer_updater-nvidia-runtime.yaml
+++ b/dist/installer_updater-nvidia-runtime.yaml
@@ -706,10 +706,10 @@ metadata:
   name: zxporter-nodemon
   namespace: '{{.zxporter_namespace}}'
   labels:
-    helm.sh/chart: zxporter-nodemon-0.0.9
+    helm.sh/chart: zxporter-nodemon-0.0.10
     app.kubernetes.io/name: zxporter-nodemon
     app.kubernetes.io/instance: zxporter-nodemon
-    app.kubernetes.io/version: "0.0.9"
+    app.kubernetes.io/version: "0.0.10"
     app.kubernetes.io/managed-by: Helm
 ---
 # Source: zxporter-nodemon/templates/dcgm-exporter-configmap.yaml
@@ -782,10 +782,10 @@ kind: ClusterRole
 metadata:
   name: zxporter-nodemon
   labels:
-    helm.sh/chart: zxporter-nodemon-0.0.9
+    helm.sh/chart: zxporter-nodemon-0.0.10
     app.kubernetes.io/name: zxporter-nodemon
     app.kubernetes.io/instance: zxporter-nodemon
-    app.kubernetes.io/version: "0.0.9"
+    app.kubernetes.io/version: "0.0.10"
     app.kubernetes.io/managed-by: Helm
 rules:
   - apiGroups:
@@ -833,10 +833,10 @@ kind: ClusterRoleBinding
 metadata:
   name: zxporter-nodemon
   labels:
-    helm.sh/chart: zxporter-nodemon-0.0.9
+    helm.sh/chart: zxporter-nodemon-0.0.10
     app.kubernetes.io/name: zxporter-nodemon
     app.kubernetes.io/instance: zxporter-nodemon
-    app.kubernetes.io/version: "0.0.9"
+    app.kubernetes.io/version: "0.0.10"
     app.kubernetes.io/managed-by: Helm
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -854,10 +854,10 @@ metadata:
   name: zxporter-nodemon
   namespace: '{{.zxporter_namespace}}'
   labels:
-    helm.sh/chart: zxporter-nodemon-0.0.9
+    helm.sh/chart: zxporter-nodemon-0.0.10
     app.kubernetes.io/name: zxporter-nodemon
     app.kubernetes.io/instance: zxporter-nodemon
-    app.kubernetes.io/version: "0.0.9"
+    app.kubernetes.io/version: "0.0.10"
     app.kubernetes.io/managed-by: Helm
 spec:
   selector:
@@ -942,10 +942,10 @@ metadata:
   name: zxporter-nodemon-gpu
   namespace: '{{.zxporter_namespace}}'
   labels:
-    helm.sh/chart: zxporter-nodemon-0.0.9
+    helm.sh/chart: zxporter-nodemon-0.0.10
     app.kubernetes.io/name: zxporter-nodemon
     app.kubernetes.io/instance: zxporter-nodemon-gpu
-    app.kubernetes.io/version: "0.0.9"
+    app.kubernetes.io/version: "0.0.10"
     app.kubernetes.io/managed-by: Helm
   annotations:
     ignore-check.kube-linter.io/privileged-container: "This daemon set needs to run DCGM Exporter as privileged to access the GPU metrics."

--- a/dist/installer_updater.yaml
+++ b/dist/installer_updater.yaml
@@ -706,10 +706,10 @@ metadata:
   name: zxporter-nodemon
   namespace: '{{.zxporter_namespace}}'
   labels:
-    helm.sh/chart: zxporter-nodemon-0.0.9
+    helm.sh/chart: zxporter-nodemon-0.0.10
     app.kubernetes.io/name: zxporter-nodemon
     app.kubernetes.io/instance: zxporter-nodemon
-    app.kubernetes.io/version: "0.0.9"
+    app.kubernetes.io/version: "0.0.10"
     app.kubernetes.io/managed-by: Helm
 ---
 # Source: zxporter-nodemon/templates/dcgm-exporter-configmap.yaml
@@ -782,10 +782,10 @@ kind: ClusterRole
 metadata:
   name: zxporter-nodemon
   labels:
-    helm.sh/chart: zxporter-nodemon-0.0.9
+    helm.sh/chart: zxporter-nodemon-0.0.10
     app.kubernetes.io/name: zxporter-nodemon
     app.kubernetes.io/instance: zxporter-nodemon
-    app.kubernetes.io/version: "0.0.9"
+    app.kubernetes.io/version: "0.0.10"
     app.kubernetes.io/managed-by: Helm
 rules:
   - apiGroups:
@@ -833,10 +833,10 @@ kind: ClusterRoleBinding
 metadata:
   name: zxporter-nodemon
   labels:
-    helm.sh/chart: zxporter-nodemon-0.0.9
+    helm.sh/chart: zxporter-nodemon-0.0.10
     app.kubernetes.io/name: zxporter-nodemon
     app.kubernetes.io/instance: zxporter-nodemon
-    app.kubernetes.io/version: "0.0.9"
+    app.kubernetes.io/version: "0.0.10"
     app.kubernetes.io/managed-by: Helm
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -854,10 +854,10 @@ metadata:
   name: zxporter-nodemon
   namespace: '{{.zxporter_namespace}}'
   labels:
-    helm.sh/chart: zxporter-nodemon-0.0.9
+    helm.sh/chart: zxporter-nodemon-0.0.10
     app.kubernetes.io/name: zxporter-nodemon
     app.kubernetes.io/instance: zxporter-nodemon
-    app.kubernetes.io/version: "0.0.9"
+    app.kubernetes.io/version: "0.0.10"
     app.kubernetes.io/managed-by: Helm
   annotations:
     ignore-check.kube-linter.io/privileged-container: "This daemon set needs to run DCGM Exporter as privileged to access the GPU metrics."

--- a/dist/nodemon-nvidia-runtime.yaml
+++ b/dist/nodemon-nvidia-runtime.yaml
@@ -6,10 +6,10 @@ metadata:
   name: zxporter-nodemon
   namespace: devzero-system
   labels:
-    helm.sh/chart: zxporter-nodemon-0.0.9
+    helm.sh/chart: zxporter-nodemon-0.0.10
     app.kubernetes.io/name: zxporter-nodemon
     app.kubernetes.io/instance: zxporter-nodemon
-    app.kubernetes.io/version: "0.0.9"
+    app.kubernetes.io/version: "0.0.10"
     app.kubernetes.io/managed-by: Helm
 ---
 # Source: zxporter-nodemon/templates/dcgm-exporter-configmap.yaml
@@ -82,10 +82,10 @@ kind: ClusterRole
 metadata:
   name: zxporter-nodemon
   labels:
-    helm.sh/chart: zxporter-nodemon-0.0.9
+    helm.sh/chart: zxporter-nodemon-0.0.10
     app.kubernetes.io/name: zxporter-nodemon
     app.kubernetes.io/instance: zxporter-nodemon
-    app.kubernetes.io/version: "0.0.9"
+    app.kubernetes.io/version: "0.0.10"
     app.kubernetes.io/managed-by: Helm
 rules:
 - apiGroups:
@@ -133,10 +133,10 @@ kind: ClusterRoleBinding
 metadata:
   name: zxporter-nodemon
   labels:
-    helm.sh/chart: zxporter-nodemon-0.0.9
+    helm.sh/chart: zxporter-nodemon-0.0.10
     app.kubernetes.io/name: zxporter-nodemon
     app.kubernetes.io/instance: zxporter-nodemon
-    app.kubernetes.io/version: "0.0.9"
+    app.kubernetes.io/version: "0.0.10"
     app.kubernetes.io/managed-by: Helm
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -154,10 +154,10 @@ metadata:
   name: zxporter-nodemon
   namespace: devzero-system
   labels:
-    helm.sh/chart: zxporter-nodemon-0.0.9
+    helm.sh/chart: zxporter-nodemon-0.0.10
     app.kubernetes.io/name: zxporter-nodemon
     app.kubernetes.io/instance: zxporter-nodemon
-    app.kubernetes.io/version: "0.0.9"
+    app.kubernetes.io/version: "0.0.10"
     app.kubernetes.io/managed-by: Helm
 spec:
   selector:
@@ -242,10 +242,10 @@ metadata:
   name: zxporter-nodemon-gpu
   namespace: devzero-system
   labels:
-    helm.sh/chart: zxporter-nodemon-0.0.9
+    helm.sh/chart: zxporter-nodemon-0.0.10
     app.kubernetes.io/name: zxporter-nodemon
     app.kubernetes.io/instance: zxporter-nodemon-gpu
-    app.kubernetes.io/version: "0.0.9"
+    app.kubernetes.io/version: "0.0.10"
     app.kubernetes.io/managed-by: Helm
   annotations:
     ignore-check.kube-linter.io/privileged-container: "This daemon set needs to run DCGM Exporter as privileged to access the GPU metrics."

--- a/dist/nodemon.yaml
+++ b/dist/nodemon.yaml
@@ -6,10 +6,10 @@ metadata:
   name: zxporter-nodemon
   namespace: devzero-system
   labels:
-    helm.sh/chart: zxporter-nodemon-0.0.9
+    helm.sh/chart: zxporter-nodemon-0.0.10
     app.kubernetes.io/name: zxporter-nodemon
     app.kubernetes.io/instance: zxporter-nodemon
-    app.kubernetes.io/version: "0.0.9"
+    app.kubernetes.io/version: "0.0.10"
     app.kubernetes.io/managed-by: Helm
 ---
 # Source: zxporter-nodemon/templates/dcgm-exporter-configmap.yaml
@@ -82,10 +82,10 @@ kind: ClusterRole
 metadata:
   name: zxporter-nodemon
   labels:
-    helm.sh/chart: zxporter-nodemon-0.0.9
+    helm.sh/chart: zxporter-nodemon-0.0.10
     app.kubernetes.io/name: zxporter-nodemon
     app.kubernetes.io/instance: zxporter-nodemon
-    app.kubernetes.io/version: "0.0.9"
+    app.kubernetes.io/version: "0.0.10"
     app.kubernetes.io/managed-by: Helm
 rules:
 - apiGroups:
@@ -133,10 +133,10 @@ kind: ClusterRoleBinding
 metadata:
   name: zxporter-nodemon
   labels:
-    helm.sh/chart: zxporter-nodemon-0.0.9
+    helm.sh/chart: zxporter-nodemon-0.0.10
     app.kubernetes.io/name: zxporter-nodemon
     app.kubernetes.io/instance: zxporter-nodemon
-    app.kubernetes.io/version: "0.0.9"
+    app.kubernetes.io/version: "0.0.10"
     app.kubernetes.io/managed-by: Helm
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -154,10 +154,10 @@ metadata:
   name: zxporter-nodemon
   namespace: devzero-system
   labels:
-    helm.sh/chart: zxporter-nodemon-0.0.9
+    helm.sh/chart: zxporter-nodemon-0.0.10
     app.kubernetes.io/name: zxporter-nodemon
     app.kubernetes.io/instance: zxporter-nodemon
-    app.kubernetes.io/version: "0.0.9"
+    app.kubernetes.io/version: "0.0.10"
     app.kubernetes.io/managed-by: Helm
   annotations:
     ignore-check.kube-linter.io/privileged-container: "This daemon set needs to run DCGM Exporter as privileged to access the GPU metrics."

--- a/helm-chart/zxporter-nodemon/Chart.yaml
+++ b/helm-chart/zxporter-nodemon/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: zxporter-nodemon
 description: A Helm chart for Kubernetes
 type: application
-version: 0.0.9
-appVersion: "0.0.9"
+version: 0.0.10
+appVersion: "0.0.10"

--- a/helm-chart/zxporter/Chart.lock
+++ b/helm-chart/zxporter/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: zxporter-nodemon
   repository: file://../zxporter-nodemon
-  version: 0.0.9
-digest: sha256:1c240a12f1bb768b7325821d3928477bb1f9a951872fc8a175a9fc293976e5f8
-generated: "2026-06-26T18:15:27.322535+05:30"
+  version: 0.0.10
+digest: sha256:196ca1521326ea1d8202c9d9fec878226109a0e0bd1c6d29b21f0d6cbe50d564
+generated: "2026-06-26T16:07:36.112875-07:00"

--- a/helm-chart/zxporter/Chart.yaml
+++ b/helm-chart/zxporter/Chart.yaml
@@ -17,5 +17,5 @@ keywords:
   - devzero
 dependencies:
   - name: zxporter-nodemon
-    version: "0.0.9"
+    version: "0.0.10"
     repository: "file://../zxporter-nodemon"

--- a/internal/collector/container_resource_collector.go
+++ b/internal/collector/container_resource_collector.go
@@ -888,7 +888,17 @@ func (c *ContainerResourceCollector) emitCPUThrottleEvent(
 	containerMetrics metricsv1beta1.ContainerMetrics,
 	throttleFraction float64,
 ) {
-	dedupKey := fmt.Sprintf("%s/%s/%s", pod.Namespace, pod.Name, containerMetrics.Name)
+	// Include restart count so each container instance gets its own 5-minute
+	// dedup window. Without this, a crashlooping pod's second restart would be
+	// suppressed even though it is a distinct container execution.
+	restartCount := int32(0)
+	for i := range pod.Status.ContainerStatuses {
+		if pod.Status.ContainerStatuses[i].Name == containerMetrics.Name {
+			restartCount = pod.Status.ContainerStatuses[i].RestartCount
+			break
+		}
+	}
+	dedupKey := fmt.Sprintf("%s/%s/%s/%d", pod.Namespace, pod.Name, containerMetrics.Name, restartCount)
 
 	c.throttle.mu.Lock()
 	if lastEmit, ok := c.throttle.lastEmitted[dedupKey]; ok && time.Since(lastEmit) < 5*time.Minute {

--- a/internal/nodemon/cadvisor_scraper_test.go
+++ b/internal/nodemon/cadvisor_scraper_test.go
@@ -188,6 +188,87 @@ func TestCAdvisorScraper_ComputesRatesAfterTwoScrapes(t *testing.T) {
 	assert.InDelta(t, 0.0, m.NetworkTxDropsPerSec, 0.001, "network tx drops/sec (no change)")
 }
 
+// cadvisorReset is a scrape where both CFS counters have reset to low values
+// (simulating a container restart). With the counter-reset estimate fix, the
+// scraper should emit a non-zero throttle fraction (30/100 = 0.30) rather than
+// an empty result, even though both counters are lower than before.
+const cadvisorReset = `# HELP container_cpu_cfs_throttled_periods_total Total throttled CPU periods.
+# TYPE container_cpu_cfs_throttled_periods_total counter
+container_cpu_cfs_throttled_periods_total{container="nginx",namespace="default",pod="web-abc"} 30
+# HELP container_cpu_cfs_periods_total Total CPU CFS periods.
+# TYPE container_cpu_cfs_periods_total counter
+container_cpu_cfs_periods_total{container="nginx",namespace="default",pod="web-abc"} 100
+# HELP container_fs_reads_bytes_total Total bytes read from filesystem.
+# TYPE container_fs_reads_bytes_total counter
+container_fs_reads_bytes_total{container="nginx",namespace="default",pod="web-abc"} 4096
+# HELP container_fs_writes_bytes_total Total bytes written to filesystem.
+# TYPE container_fs_writes_bytes_total counter
+container_fs_writes_bytes_total{container="nginx",namespace="default",pod="web-abc"} 0
+# HELP container_fs_reads_total Total filesystem read operations.
+# TYPE container_fs_reads_total counter
+container_fs_reads_total{container="nginx",namespace="default",pod="web-abc"} 10
+# HELP container_fs_writes_total Total filesystem write operations.
+# TYPE container_fs_writes_total counter
+container_fs_writes_total{container="nginx",namespace="default",pod="web-abc"} 0
+# HELP container_network_receive_packets_total Total network packets received.
+# TYPE container_network_receive_packets_total counter
+container_network_receive_packets_total{namespace="default",pod="web-abc"} 50
+# HELP container_network_transmit_packets_total Total network packets transmitted.
+# TYPE container_network_transmit_packets_total counter
+container_network_transmit_packets_total{namespace="default",pod="web-abc"} 30
+# HELP container_network_receive_errors_total Total network receive errors.
+# TYPE container_network_receive_errors_total counter
+container_network_receive_errors_total{namespace="default",pod="web-abc"} 0
+# HELP container_network_transmit_errors_total Total network transmit errors.
+# TYPE container_network_transmit_errors_total counter
+container_network_transmit_errors_total{namespace="default",pod="web-abc"} 0
+# HELP container_network_receive_packets_dropped_total Total network receive packet drops.
+# TYPE container_network_receive_packets_dropped_total counter
+container_network_receive_packets_dropped_total{namespace="default",pod="web-abc"} 0
+# HELP container_network_transmit_packets_dropped_total Total network transmit packet drops.
+# TYPE container_network_transmit_packets_dropped_total counter
+container_network_transmit_packets_dropped_total{namespace="default",pod="web-abc"} 0
+`
+
+// TestCAdvisorScraper_CounterResetPreservesThrottleSignal verifies that when a
+// container restarts and CFS counters reset to lower values, the scraper still
+// emits a non-zero throttle fraction (value/elapsed) rather than silently
+// dropping the observation. This is critical for crashlooping pods that never
+// survive two scrape intervals with a positive delta.
+func TestCAdvisorScraper_CounterResetPreservesThrottleSignal(t *testing.T) {
+	callCount := 0
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/plain; version=0.0.4")
+		callCount++
+		if callCount == 1 {
+			_, _ = w.Write([]byte(cadvisorSample1)) // high counters from old container
+		} else {
+			_, _ = w.Write([]byte(cadvisorReset)) // counters reset after restart
+		}
+	}))
+	defer srv.Close()
+
+	log := newCAdvisorTestLogger()
+	scraper := nodemon.NewCAdvisorScraper(srv.URL, srv.Client(), log)
+
+	base := time.Now()
+	// First scrape — sets baseline from old container (throttled=300, total=1000).
+	_, err := scraper.Scrape(context.Background(), base)
+	require.NoError(t, err)
+
+	// Second scrape — container restarted; counters reset to throttled=30, total=100.
+	// Both values are less than baseline so delta < 0 for both.
+	// Expected throttle fraction: 30/100 = 0.30 (estimate via value/elapsed).
+	results, err := scraper.Scrape(context.Background(), base.Add(30*time.Second))
+	require.NoError(t, err)
+	require.Len(t, results, 1, "counter reset should still produce an entry, not empty result")
+
+	m := results[0]
+	// throttleFraction = (30/30) / (100/30) = 30/100 = 0.30
+	assert.InDelta(t, 0.30, m.CPUThrottleFraction, 0.001,
+		"throttle fraction on counter reset should be 30/100 = 0.30")
+}
+
 // TestCAdvisorScraper_HandlesHTTPError verifies that an HTTP error from the
 // cAdvisor endpoint is propagated as an error (not silently ignored).
 func TestCAdvisorScraper_HandlesHTTPError(t *testing.T) {

--- a/internal/nodemon/rate_calculator.go
+++ b/internal/nodemon/rate_calculator.go
@@ -29,8 +29,13 @@ func NewRateCalculator() *RateCalculator {
 //
 // Returns 0 on:
 //   - first call for a key (no baseline yet)
-//   - counter reset (current value < previous value)
 //   - zero elapsed time between observations
+//
+// On counter reset (current value < previous value), returns value/elapsed as
+// a conservative estimate of the rate since the reset. This preserves signal
+// for short-lived containers (e.g. crashlooping pods) whose CFS counters reset
+// on every restart — they would otherwise always return 0 because they never
+// survive two scrape intervals with a positive delta.
 func (rc *RateCalculator) Rate(entity, metric string, value float64, ts time.Time) float64 {
 	key := entity + "\x00" + metric
 
@@ -51,8 +56,10 @@ func (rc *RateCalculator) Rate(entity, metric string, value float64, ts time.Tim
 
 	delta := value - prev.value
 	if delta < 0 {
-		// Counter reset — new baseline is already stored above.
-		return 0
+		// Counter reset (e.g. container restart). The new counter has been
+		// accumulating since the reset; use value/elapsed as a conservative
+		// lower-bound estimate rather than dropping the observation entirely.
+		return value / elapsed
 	}
 
 	return delta / elapsed

--- a/internal/nodemon/rate_calculator_test.go
+++ b/internal/nodemon/rate_calculator_test.go
@@ -24,14 +24,39 @@ func TestRateCalculator_SecondSampleComputesRate(t *testing.T) {
 	assert.InDelta(t, 10.0, rate, 0.0001, "expected (1300-1000)/30 = 10.0 per second")
 }
 
-func TestRateCalculator_CounterResetReturnsZero(t *testing.T) {
+func TestRateCalculator_CounterResetReturnsEstimate(t *testing.T) {
 	rc := NewRateCalculator()
 	base := time.Now()
 
+	// Seed a high counter value (simulates a long-running container).
 	rc.Rate("pod/default/nginx", "cpu_total", 5000.0, base)
+
+	// Counter drops to 100 — container restarted, CFS counters reset to 0
+	// and accumulated 100 periods in the 10 seconds since restart.
 	rate := rc.Rate("pod/default/nginx", "cpu_total", 100.0, base.Add(10*time.Second))
 
-	assert.Equal(t, 0.0, rate, "counter reset (current < previous) should return 0")
+	// Expect value/elapsed = 100/10 = 10.0, not 0.
+	// This preserves signal for short-lived containers that never live long
+	// enough for two scrapes with a positive delta.
+	assert.InDelta(t, 10.0, rate, 0.0001, "counter reset should return value/elapsed estimate, not 0")
+}
+
+func TestRateCalculator_AfterResetNextScrapeUsesResetBaseline(t *testing.T) {
+	rc := NewRateCalculator()
+	base := time.Now()
+
+	// Scrape 1: seed a high counter.
+	rc.Rate("pod/default/nginx", "cpu_total", 5000.0, base)
+
+	// Scrape 2: counter reset — new container accumulated 100 periods.
+	rc.Rate("pod/default/nginx", "cpu_total", 100.0, base.Add(30*time.Second))
+
+	// Scrape 3: normal increment from the reset baseline (100 → 130 in 30s).
+	rate := rc.Rate("pod/default/nginx", "cpu_total", 130.0, base.Add(60*time.Second))
+
+	// Rate should use the reset baseline (100), not the pre-reset value (5000).
+	// delta = 130-100 = 30, elapsed = 30s → 1.0/s
+	assert.InDelta(t, 1.0, rate, 0.0001, "post-reset scrape should compute delta from reset baseline")
 }
 
 func TestRateCalculator_IndependentKeys(t *testing.T) {


### PR DESCRIPTION
## Why

When a workload is CPU-constrained and a recommendation is applied that doesn't increase CPU (e.g. only bumps memory), new pods created by the rolling update can enter a crashloop. The pod crashes in seconds — well under the 30s scrape interval — which meant **zero** `container_cpu_throttle_events` were ever emitted for the crashing pod, even if it was being heavily throttled during startup.

This makes it structurally impossible to diagnose or react to "CPU throttle → crashloop" with the current pipeline.

Investigation on a real production case (cluster `18cbf541`, workload `langfuse-web`) confirmed: pod `g7rcj` hit 31 restarts over 6 hours with no throttle events recorded, while surviving sibling pods showed 10–20% throttle at the same CPU request.

## What changed

**`internal/nodemon/rate_calculator.go` — counter-reset estimate**

`RateCalculator.Rate()` previously returned `0` when `delta < 0` (counter reset). On every container restart, cAdvisor CFS counters reset to 0, triggering this path. The new container instance needs two consecutive valid scrapes (60+ seconds) before a non-zero rate can be computed — but a pod crashing in <5 seconds never gets there.

Fix: on counter reset return `value / elapsed` as a conservative lower-bound estimate. The throttle fraction for a restarted container becomes `throttled_periods_new / total_periods_new`, which is accurate regardless of when within the interval the reset happened.

**`internal/collector/container_resource_collector.go` — dedup key includes restart count**

The 5-minute dedup window used key `ns/pod/container`. A pod on restart #5 would be suppressed if restart #4 emitted within the last 5 minutes — exactly the CrashLoop backoff ceiling. Including the restart count ensures each container instance gets its own window.

## Tests added

- `TestRateCalculator_CounterResetReturnsEstimate` — verifies reset returns `value/elapsed`, not 0
- `TestRateCalculator_AfterResetNextScrapeUsesResetBaseline` — verifies the post-reset scrape correctly diffs from the reset baseline (not the pre-reset value)
- `TestCAdvisorScraper_CounterResetPreservesThrottleSignal` — end-to-end: two scrapes where second has lower counter values; verifies a 0.30 throttle fraction is emitted rather than an empty result

All existing unit/integration tests pass.