### PR TITLE
feat(release): one-command release via `just tag` + CI orchestrator

### DIFF
--- a/.github/workflows/chart-netmon.yml
+++ b/.github/workflows/chart-netmon.yml
@@ -1,0 +1,70 @@
+name: "Chart: zxporter-netmon"
+
+on:
+  workflow_call:
+    inputs:
+      version:
+        description: "Release version (vX.Y.Z)"
+        required: true
+        type: string
+      ref:
+        description: "Git ref to checkout (tag/sha to build); empty = triggering ref"
+        required: false
+        type: string
+        default: ""
+
+env:
+  REGISTRY: registry-1.docker.io
+  CHART_NAME: zxporter-netmon
+  ORG: devzeroinc
+  CHART_TAG_PREFIX: chart-netmon-v
+
+jobs:
+  release-chart:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      packages: write
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          ref: ${{ inputs.ref }}
+
+      - uses: azure/setup-helm@v4
+        with:
+          version: "3.12.3"
+
+      - name: Compute bare version
+        id: v
+        env:
+          VERSION: ${{ inputs.version }}
+        run: echo "bare=${VERSION#v}" >> "$GITHUB_OUTPUT"
+
+      - name: Helm registry login
+        run: |
+          echo "${{ secrets.DOCKERHUB_ZXPORTER_BALANCE_TOKEN }}" | \
+            helm registry login registry-1.docker.io \
+              --username "${{ secrets.DOCKERHUB_ZXPORTER_BALANCE_USERNAME }}" --password-stdin
+
+      - name: Create and push chart tag
+        run: |
+          git config --global user.email "actions@github.com"
+          git config --global user.name "GitHub Actions"
+          TAG="${{ env.CHART_TAG_PREFIX }}${{ steps.v.outputs.bare }}"
+          if git rev-parse -q --verify "refs/tags/$TAG" >/dev/null; then
+            echo "tag $TAG exists; skipping"
+          else
+            git tag "$TAG" && git push origin "$TAG"
+          fi
+
+      - name: Package and push chart
+        run: |
+          helm dependency update helm-chart/${{ env.CHART_NAME }}
+          helm lint helm-chart/${{ env.CHART_NAME }}
+          mkdir -p helm-chart/packages
+          helm package helm-chart/${{ env.CHART_NAME }} \
+            --version ${{ steps.v.outputs.bare }} --app-version ${{ steps.v.outputs.bare }} \
+            --destination helm-chart/packages
+          helm push helm-chart/packages/${{ env.CHART_NAME }}-${{ steps.v.outputs.bare }}.tgz \
+            oci://${{ env.REGISTRY }}/${{ env.ORG }}

--- a/.github/workflows/chart-nodemon.yml
+++ b/.github/workflows/chart-nodemon.yml
@@ -1,0 +1,80 @@
+name: "Chart: zxporter-nodemon"
+
+on:
+  workflow_call:
+    inputs:
+      version:
+        description: "Release version (vX.Y.Z)"
+        required: true
+        type: string
+      ref:
+        description: "Git ref to checkout (tag/sha to build); empty = triggering ref"
+        required: false
+        type: string
+        default: ""
+
+env:
+  REGISTRY: registry-1.docker.io
+  CHART_NAME: zxporter-nodemon
+  ORG: devzeroinc
+  CHART_TAG_PREFIX: chart-nodemon-v
+
+jobs:
+  release-chart:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      packages: write
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          ref: ${{ inputs.ref }}
+
+      - uses: azure/setup-helm@v4
+        with:
+          version: "3.12.3"
+
+      - name: Install yq
+        run: |
+          sudo wget -qO /usr/local/bin/yq https://github.com/mikefarah/yq/releases/latest/download/yq_linux_amd64
+          sudo chmod +x /usr/local/bin/yq
+
+      - name: Compute bare version
+        id: v
+        env:
+          VERSION: ${{ inputs.version }}
+        run: echo "bare=${VERSION#v}" >> "$GITHUB_OUTPUT"
+
+      - name: Helm registry login
+        run: |
+          echo "${{ secrets.DOCKERHUB_ZXPORTER_BALANCE_TOKEN }}" | \
+            helm registry login registry-1.docker.io \
+              --username "${{ secrets.DOCKERHUB_ZXPORTER_BALANCE_USERNAME }}" --password-stdin
+
+      - name: Create and push chart tag
+        run: |
+          git config --global user.email "actions@github.com"
+          git config --global user.name "GitHub Actions"
+          TAG="${{ env.CHART_TAG_PREFIX }}${{ steps.v.outputs.bare }}"
+          if git rev-parse -q --verify "refs/tags/$TAG" >/dev/null; then
+            echo "tag $TAG exists; skipping"
+          else
+            git tag "$TAG" && git push origin "$TAG"
+          fi
+
+      - name: Set nodemon chart version (ephemeral, for packaging labels)
+        run: |
+          yq e -i '.version = "${{ steps.v.outputs.bare }}" | .appVersion = "${{ steps.v.outputs.bare }}"' \
+            helm-chart/zxporter-nodemon/Chart.yaml
+
+      - name: Package and push chart
+        run: |
+          helm dependency update helm-chart/${{ env.CHART_NAME }}
+          helm lint helm-chart/${{ env.CHART_NAME }}
+          mkdir -p helm-chart/packages
+          helm package helm-chart/${{ env.CHART_NAME }} \
+            --version ${{ steps.v.outputs.bare }} --app-version ${{ steps.v.outputs.bare }} \
+            --destination helm-chart/packages
+          helm push helm-chart/packages/${{ env.CHART_NAME }}-${{ steps.v.outputs.bare }}.tgz \
+            oci://${{ env.REGISTRY }}/${{ env.ORG }}

--- a/.github/workflows/chart-zxporter.yml
+++ b/.github/workflows/chart-zxporter.yml
@@ -1,0 +1,83 @@
+name: "Chart: zxporter"
+
+on:
+  workflow_call:
+    inputs:
+      version:
+        description: "Release version (vX.Y.Z)"
+        required: true
+        type: string
+      ref:
+        description: "Git ref to checkout (tag/sha to build); empty = triggering ref"
+        required: false
+        type: string
+        default: ""
+
+env:
+  REGISTRY: registry-1.docker.io
+  CHART_NAME: zxporter
+  ORG: devzeroinc
+  CHART_TAG_PREFIX: chart-v
+
+jobs:
+  release-chart:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      packages: write
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          ref: ${{ inputs.ref }}
+
+      - uses: azure/setup-helm@v4
+        with:
+          version: "3.12.3"
+
+      - name: Install yq
+        run: |
+          sudo wget -qO /usr/local/bin/yq https://github.com/mikefarah/yq/releases/latest/download/yq_linux_amd64
+          sudo chmod +x /usr/local/bin/yq
+
+      - name: Compute bare version
+        id: v
+        env:
+          VERSION: ${{ inputs.version }}
+        run: echo "bare=${VERSION#v}" >> "$GITHUB_OUTPUT"
+
+      - name: Helm registry login
+        run: |
+          echo "${{ secrets.DOCKERHUB_ZXPORTER_BALANCE_TOKEN }}" | \
+            helm registry login registry-1.docker.io \
+              --username "${{ secrets.DOCKERHUB_ZXPORTER_BALANCE_USERNAME }}" --password-stdin
+
+      - name: Create and push chart tag
+        run: |
+          git config --global user.email "actions@github.com"
+          git config --global user.name "GitHub Actions"
+          TAG="${{ env.CHART_TAG_PREFIX }}${{ steps.v.outputs.bare }}"
+          if git rev-parse -q --verify "refs/tags/$TAG" >/dev/null; then
+            echo "tag $TAG exists; skipping"
+          else
+            git tag "$TAG" && git push origin "$TAG"
+          fi
+
+      - name: Sync nodemon version + dependency pin (ephemeral, for packaging)
+        run: |
+          yq e -i '.version = "${{ steps.v.outputs.bare }}" | .appVersion = "${{ steps.v.outputs.bare }}"' \
+            helm-chart/zxporter-nodemon/Chart.yaml
+          yq e -i '(.dependencies[] | select(.name == "zxporter-nodemon")).version = "${{ steps.v.outputs.bare }}"' \
+            helm-chart/zxporter/Chart.yaml
+
+      - name: Package and push chart
+        run: |
+          rm -f helm-chart/zxporter/charts/zxporter-nodemon-*.tgz
+          helm dependency update helm-chart/${{ env.CHART_NAME }}
+          helm lint helm-chart/${{ env.CHART_NAME }}
+          mkdir -p helm-chart/packages
+          helm package helm-chart/${{ env.CHART_NAME }} \
+            --version ${{ steps.v.outputs.bare }} --app-version ${{ steps.v.outputs.bare }} \
+            --destination helm-chart/packages
+          helm push helm-chart/packages/${{ env.CHART_NAME }}-${{ steps.v.outputs.bare }}.tgz \
+            oci://${{ env.REGISTRY }}/${{ env.ORG }}

--- a/.github/workflows/image-netmon.yml
+++ b/.github/workflows/image-netmon.yml
@@ -1,0 +1,93 @@
+name: "Image: zxporter-netmon"
+
+on:
+  workflow_call:
+    inputs:
+      version:
+        description: "Release version to build (vX.Y.Z)"
+        required: true
+        type: string
+      ref:
+        description: "Git ref to checkout (tag/sha to build); empty = triggering ref"
+        required: false
+        type: string
+        default: ""
+
+permissions:
+  contents: read
+  packages: write
+  id-token: write
+
+jobs:
+  package-and-push:
+    name: Package & Push zxporter-netmon image
+    runs-on: namespace-profile-dz-generic
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          ref: ${{ inputs.ref }}
+
+      - name: Log in to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_ZXPORTER_BALANCE_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_ZXPORTER_BALANCE_TOKEN }}
+
+      - name: Set up Docker Buildx
+        uses: namespacelabs/nscloud-setup-buildx-action@v0
+
+      - name: Set build metadata
+        run: |
+          VERSION="${{ inputs.version }}"
+          if [[ ! "$VERSION" =~ ^v([0-9]+)\.([0-9]+)\.([0-9]+)$ ]]; then
+            echo "::error::version '$VERSION' must match vX.Y.Z"; exit 1
+          fi
+          {
+            echo "MAJOR=${BASH_REMATCH[1]}"
+            echo "MINOR=${BASH_REMATCH[2]}"
+            echo "PATCH=${BASH_REMATCH[3]}"
+            echo "GITVERSION=${VERSION}"
+            echo "COMMIT_HASH=$(git rev-parse --short HEAD)"
+            echo "GIT_TREE_STATE=clean"
+            echo "BUILD_DATE=$(date -u +'%Y-%m-%dT%H:%M:%SZ')"
+          } >> "$GITHUB_ENV"
+
+      - name: Fail if image tag already exists
+        run: |
+          if docker manifest inspect docker.io/devzeroinc/zxporter-netmon:${{ inputs.version }} >/dev/null 2>&1; then
+            echo "::error::docker.io/devzeroinc/zxporter-netmon:${{ inputs.version }} already exists; delete it to re-release."
+            exit 1
+          fi
+
+      - name: Configure AWS credentials for ECR using OIDC
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ secrets.AWS_ECR_PUSH_ROLE_ARN }}
+          role-session-name: GitHubActions-ZxporterNetmonBuild
+          aws-region: us-east-1
+
+      - name: Login to Amazon ECR
+        uses: aws-actions/amazon-ecr-login@v2
+        with:
+          registry-type: public
+
+      - name: Build and push multi-arch image
+        run: |
+          docker buildx build \
+            --platform linux/amd64,linux/arm64 \
+            --push \
+            -t docker.io/devzeroinc/zxporter-netmon:${{ inputs.version }} \
+            -t public.ecr.aws/devzeroinc/zxporter-netmon:${{ inputs.version }} \
+            --build-arg TARGETOS \
+            --build-arg TARGETARCH \
+            --build-arg MAJOR="$MAJOR" \
+            --build-arg MINOR="$MINOR" \
+            --build-arg PATCH="$PATCH" \
+            --build-arg GITVERSION="$GITVERSION" \
+            --build-arg COMMIT_HASH="$COMMIT_HASH" \
+            --build-arg GIT_TREE_STATE="$GIT_TREE_STATE" \
+            --build-arg BUILD_DATE="$BUILD_DATE" \
+            -f Dockerfile.netmon \
+            .

--- a/.github/workflows/image-nodemon.yml
+++ b/.github/workflows/image-nodemon.yml
@@ -1,0 +1,93 @@
+name: "Image: zxporter-nodemon"
+
+on:
+  workflow_call:
+    inputs:
+      version:
+        description: "Release version to build (vX.Y.Z)"
+        required: true
+        type: string
+      ref:
+        description: "Git ref to checkout (tag/sha to build); empty = triggering ref"
+        required: false
+        type: string
+        default: ""
+
+permissions:
+  contents: read
+  packages: write
+  id-token: write
+
+jobs:
+  package-and-push:
+    name: Package & Push zxporter-nodemon image
+    runs-on: namespace-profile-dz-generic
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          ref: ${{ inputs.ref }}
+
+      - name: Log in to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_ZXPORTER_BALANCE_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_ZXPORTER_BALANCE_TOKEN }}
+
+      - name: Set up Docker Buildx
+        uses: namespacelabs/nscloud-setup-buildx-action@v0
+
+      - name: Set build metadata
+        run: |
+          VERSION="${{ inputs.version }}"
+          if [[ ! "$VERSION" =~ ^v([0-9]+)\.([0-9]+)\.([0-9]+)$ ]]; then
+            echo "::error::version '$VERSION' must match vX.Y.Z"; exit 1
+          fi
+          {
+            echo "MAJOR=${BASH_REMATCH[1]}"
+            echo "MINOR=${BASH_REMATCH[2]}"
+            echo "PATCH=${BASH_REMATCH[3]}"
+            echo "GITVERSION=${VERSION}"
+            echo "COMMIT_HASH=$(git rev-parse --short HEAD)"
+            echo "GIT_TREE_STATE=clean"
+            echo "BUILD_DATE=$(date -u +'%Y-%m-%dT%H:%M:%SZ')"
+          } >> "$GITHUB_ENV"
+
+      - name: Fail if image tag already exists
+        run: |
+          if docker manifest inspect docker.io/devzeroinc/zxporter-nodemon:${{ inputs.version }} >/dev/null 2>&1; then
+            echo "::error::docker.io/devzeroinc/zxporter-nodemon:${{ inputs.version }} already exists; delete it to re-release."
+            exit 1
+          fi
+
+      - name: Configure AWS credentials for ECR using OIDC
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ secrets.AWS_ECR_PUSH_ROLE_ARN }}
+          role-session-name: GitHubActions-ZxporterNodemonBuild
+          aws-region: us-east-1
+
+      - name: Login to Amazon ECR
+        uses: aws-actions/amazon-ecr-login@v2
+        with:
+          registry-type: public
+
+      - name: Build and push multi-arch image
+        run: |
+          docker buildx build \
+            --platform linux/amd64,linux/arm64 \
+            --push \
+            -t docker.io/devzeroinc/zxporter-nodemon:${{ inputs.version }} \
+            -t public.ecr.aws/devzeroinc/zxporter-nodemon:${{ inputs.version }} \
+            --build-arg TARGETOS \
+            --build-arg TARGETARCH \
+            --build-arg MAJOR="$MAJOR" \
+            --build-arg MINOR="$MINOR" \
+            --build-arg PATCH="$PATCH" \
+            --build-arg GITVERSION="$GITVERSION" \
+            --build-arg COMMIT_HASH="$COMMIT_HASH" \
+            --build-arg GIT_TREE_STATE="$GIT_TREE_STATE" \
+            --build-arg BUILD_DATE="$BUILD_DATE" \
+            -f Dockerfile.nodemon \
+            .

--- a/.github/workflows/image-zxporter.yml
+++ b/.github/workflows/image-zxporter.yml
@@ -1,0 +1,92 @@
+name: "Image: zxporter"
+
+on:
+  workflow_call:
+    inputs:
+      version:
+        description: "Release version to build (vX.Y.Z)"
+        required: true
+        type: string
+      ref:
+        description: "Git ref to checkout (tag/sha to build); empty = triggering ref"
+        required: false
+        type: string
+        default: ""
+
+permissions:
+  contents: read
+  packages: write
+  id-token: write
+
+jobs:
+  package-and-push:
+    name: Package & Push zxporter image
+    runs-on: namespace-profile-dz-generic
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          ref: ${{ inputs.ref }}
+
+      - name: Log in to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_ZXPORTER_BALANCE_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_ZXPORTER_BALANCE_TOKEN }}
+
+      - name: Set up Docker Buildx
+        uses: namespacelabs/nscloud-setup-buildx-action@v0
+
+      - name: Set build metadata
+        run: |
+          VERSION="${{ inputs.version }}"
+          if [[ ! "$VERSION" =~ ^v([0-9]+)\.([0-9]+)\.([0-9]+)$ ]]; then
+            echo "::error::version '$VERSION' must match vX.Y.Z"; exit 1
+          fi
+          {
+            echo "MAJOR=${BASH_REMATCH[1]}"
+            echo "MINOR=${BASH_REMATCH[2]}"
+            echo "PATCH=${BASH_REMATCH[3]}"
+            echo "GITVERSION=${VERSION}"
+            echo "COMMIT_HASH=$(git rev-parse --short HEAD)"
+            echo "GIT_TREE_STATE=clean"
+            echo "BUILD_DATE=$(date -u +'%Y-%m-%dT%H:%M:%SZ')"
+          } >> "$GITHUB_ENV"
+
+      - name: Fail if image tag already exists
+        run: |
+          if docker manifest inspect docker.io/devzeroinc/zxporter:${{ inputs.version }} >/dev/null 2>&1; then
+            echo "::error::docker.io/devzeroinc/zxporter:${{ inputs.version }} already exists; delete it to re-release."
+            exit 1
+          fi
+
+      - name: Configure AWS credentials for ECR using OIDC
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ secrets.AWS_ECR_PUSH_ROLE_ARN }}
+          role-session-name: GitHubActions-ZxporterBuild
+          aws-region: us-east-1
+
+      - name: Login to Amazon ECR
+        uses: aws-actions/amazon-ecr-login@v2
+        with:
+          registry-type: public
+
+      - name: Build and push multi-arch image
+        run: |
+          docker buildx build \
+            --platform linux/amd64,linux/arm64 \
+            --push \
+            -t docker.io/devzeroinc/zxporter:${{ inputs.version }} \
+            -t public.ecr.aws/devzeroinc/zxporter:${{ inputs.version }} \
+            --build-arg TARGETOS \
+            --build-arg TARGETARCH \
+            --build-arg MAJOR="$MAJOR" \
+            --build-arg MINOR="$MINOR" \
+            --build-arg PATCH="$PATCH" \
+            --build-arg GITVERSION="$GITVERSION" \
+            --build-arg COMMIT_HASH="$COMMIT_HASH" \
+            --build-arg GIT_TREE_STATE="$GIT_TREE_STATE" \
+            --build-arg BUILD_DATE="$BUILD_DATE" \
+            .

--- a/.github/workflows/push-zxporter-image.yml
+++ b/.github/workflows/push-zxporter-image.yml
@@ -8,9 +8,6 @@ on:
         required: false
         type: boolean
         default: false
-  push:
-    tags:
-      - "v*"
 
 permissions:
   contents: write

--- a/.github/workflows/push-zxporter-netmon-image.yml
+++ b/.github/workflows/push-zxporter-netmon-image.yml
@@ -8,9 +8,6 @@ on:
         required: false
         type: boolean
         default: false
-  push:
-    tags:
-      - "v*"
 
 permissions:
   contents: write

--- a/.github/workflows/push-zxporter-nodemon-image.yml
+++ b/.github/workflows/push-zxporter-nodemon-image.yml
@@ -8,9 +8,6 @@ on:
         required: false
         type: boolean
         default: false
-  push:
-    tags:
-      - "v*"
 
 permissions:
   contents: write

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,198 @@
+name: Release
+
+# Dispatch-only. `just tag zxporter vX.Y.Z` runs `gh workflow run release.yml -f version=vX.Y.Z`.
+# We deliberately do NOT trigger on tag push: the tag must point at the *bumped* commit, so
+# CI bumps first and creates the tag itself (see the bump-and-tag job). A bare tag push on
+# pre-bump main would embed stale image/chart versions in the tagged tree.
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: "Release version (vX.Y.Z)"
+        required: true
+        type: string
+
+permissions:
+  contents: write
+  packages: write
+  id-token: write
+  pull-requests: write
+
+jobs:
+  resolve:
+    runs-on: ubuntu-latest
+    outputs:
+      version: ${{ steps.v.outputs.version }}
+      bare: ${{ steps.v.outputs.bare }}
+    steps:
+      - id: v
+        env:
+          INPUT_VERSION: ${{ inputs.version }}
+        run: |
+          VERSION="$INPUT_VERSION"
+          if [[ ! "$VERSION" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo "::error::version '$VERSION' must be vX.Y.Z"; exit 1
+          fi
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+          echo "bare=${VERSION#v}" >> "$GITHUB_OUTPUT"
+
+  # Bump versions on a branch, tag that bumped commit, then open an auto-merged PR to bring the
+  # bump into main. The tag is an immutable ref to the bumped commit, so it carries vX.Y.Z even
+  # before the PR merges. Downstream jobs check out the tag, so images build from the bumped code
+  # and charts embed image.tag=vX.Y.Z.
+  bump-and-tag:
+    needs: resolve
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: main
+          fetch-depth: 0
+          token: ${{ secrets.DEBO_GITHUB_PAT }}
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: "go.mod"
+          cache: true
+      - uses: azure/setup-helm@v4
+        with:
+          version: "3.12.3"
+      - name: Install yq
+        run: |
+          sudo wget -qO /usr/local/bin/yq https://github.com/mikefarah/yq/releases/latest/download/yq_linux_amd64
+          sudo chmod +x /usr/local/bin/yq
+      - name: Bump versions, tag the bump commit, open auto-merge PR
+        env:
+          GH_TOKEN: ${{ secrets.DEBO_GITHUB_PAT }}
+          V: ${{ needs.resolve.outputs.version }}
+          B: ${{ needs.resolve.outputs.bare }}
+        run: |
+          set -euo pipefail
+          git config user.name "github-actions-dzbot"
+          git config user.email "github-actions@github.com"
+
+          # Fail fast if this version was already released (a UI workflow_dispatch bypasses the
+          # justfile guard), before doing any bump/build work.
+          if git ls-remote --exit-code --tags origin "$V" >/dev/null 2>&1; then
+            echo "::error::tag $V already exists on origin"; exit 1
+          fi
+
+          branch="release/bump-$V"
+          git checkout -b "$branch"
+
+          # Unified version bumps (chart versions, nodemon dependency pin, image tags).
+          for c in zxporter zxporter-nodemon zxporter-netmon; do
+            yq e -i ".version = \"$B\" | .appVersion = \"$B\"" "helm-chart/$c/Chart.yaml"
+          done
+          yq e -i "(.dependencies[] | select(.name == \"zxporter-nodemon\")).version = \"$B\"" \
+            helm-chart/zxporter/Chart.yaml
+          yq e -i ".image.tag = \"$V\"" helm-chart/zxporter/values.yaml
+          yq e -i ".image.tag = \"$V\"" helm-chart/zxporter-nodemon/values.yaml
+          yq e -i ".image.tag = \"$V\"" helm-chart/zxporter-netmon/values.yaml
+
+          # Regenerate Chart.lock + dist bundles. build-installer runs with DEFAULTS: dist/
+          # backend bundles stay pinned to :latest (the services retriever pins the version at
+          # copy time) so this matches build-installer-check.yml. Only legitimate dist/ delta
+          # is the bumped nodemon `helm.sh/chart: zxporter-nodemon-<bare>` label.
+          rm -f helm-chart/zxporter/charts/zxporter-nodemon-*.tgz
+          helm dependency update helm-chart/zxporter
+          make build-installer
+
+          if [[ -z "$(git status --porcelain)" ]]; then
+            echo "::error::version bump produced no changes"; exit 1
+          fi
+          git add helm-chart dist
+          git commit -m "chore(release): bump charts + image tags to $B / $V and sync dist"
+
+          # Tag the bump commit (immutable ref -> carries vX.Y.Z even before the PR merges),
+          # then push the branch and the tag.
+          git tag -a "$V" -m "release $V"
+          git push origin --force "$branch"
+          git push origin "$V"
+
+          # Open the PR that brings the bump into main and let it auto-merge once checks pass.
+          gh pr create --base main --head "$branch" \
+            --title "chore(release): bump to $V" \
+            --body "Unified release $V: chart versions=$B, image.tag=$V, nodemon dep=$B, regenerated Chart.lock + dist/. The tag $V points at this commit." \
+            || true
+          gh pr merge "$branch" --auto --squash || \
+            echo "::warning::auto-merge unavailable; PR left open for manual merge"
+
+  image-zxporter:
+    needs: [resolve, bump-and-tag]
+    uses: ./.github/workflows/image-zxporter.yml
+    secrets: inherit
+    with:
+      version: ${{ needs.resolve.outputs.version }}
+      ref: ${{ needs.resolve.outputs.version }}
+
+  image-nodemon:
+    needs: [resolve, bump-and-tag]
+    uses: ./.github/workflows/image-nodemon.yml
+    secrets: inherit
+    with:
+      version: ${{ needs.resolve.outputs.version }}
+      ref: ${{ needs.resolve.outputs.version }}
+
+  image-netmon:
+    needs: [resolve, bump-and-tag]
+    uses: ./.github/workflows/image-netmon.yml
+    secrets: inherit
+    with:
+      version: ${{ needs.resolve.outputs.version }}
+      ref: ${{ needs.resolve.outputs.version }}
+
+  chart-netmon:
+    needs: [resolve, bump-and-tag, image-netmon]
+    uses: ./.github/workflows/chart-netmon.yml
+    secrets: inherit
+    with:
+      version: ${{ needs.resolve.outputs.version }}
+      ref: ${{ needs.resolve.outputs.version }}
+
+  chart-nodemon:
+    needs: [resolve, bump-and-tag, image-nodemon]
+    uses: ./.github/workflows/chart-nodemon.yml
+    secrets: inherit
+    with:
+      version: ${{ needs.resolve.outputs.version }}
+      ref: ${{ needs.resolve.outputs.version }}
+
+  chart-zxporter:
+    needs: [resolve, bump-and-tag, image-zxporter, chart-nodemon]
+    uses: ./.github/workflows/chart-zxporter.yml
+    secrets: inherit
+    with:
+      version: ${{ needs.resolve.outputs.version }}
+      ref: ${{ needs.resolve.outputs.version }}
+
+  release-notes:
+    needs: [resolve, bump-and-tag, image-zxporter, image-nodemon, image-netmon]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Create GitHub Release
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          V="${{ needs.resolve.outputs.version }}"
+          if gh release view "$V" >/dev/null 2>&1; then
+            echo "release $V exists; skipping"
+          else
+            gh release create "$V" --generate-notes --title "$V"
+          fi
+
+  trigger-services:
+    needs: [resolve, chart-zxporter, chart-nodemon, chart-netmon]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Dispatch services metadata retriever
+        env:
+          GH_TOKEN: ${{ secrets.DEBO_GITHUB_PAT }}
+        run: |
+          gh workflow run latest_zxporter_metadata_retriever.yml \
+            --repo devzero-inc/services --ref main

--- a/justfile
+++ b/justfile
@@ -1,0 +1,36 @@
+# zxporter release automation.
+# `just tag zxporter vX.Y.Z` validates + pushes ONE tag; CI (release.yml) does the rest:
+# builds/pushes the 3 images, publishes the 3 OCI charts at a unified version, opens one
+# auto-merged bump PR (Chart.yaml/lock, values.yaml, dist/), cuts the GitHub Release, and
+# dispatches the cross-repo services metadata/manifest update.
+
+set shell := ["bash", "-uc"]
+
+_default:
+    @just --list
+
+# Show recent release + chart tags.
+tag-list:
+    @git tag --sort=-creatordate | grep -E '^(v|chart-)' | head -n 20
+
+# Cut a unified release. Dispatches the Release workflow, which bumps versions, tags the
+# bumped commit, builds/pushes images + charts, opens the bump PR, and updates services.
+# Usage: just tag zxporter v0.1.0     (append `dry` to preview: just tag zxporter v0.1.0 dry)
+tag component version dry="":
+    #!/usr/bin/env bash
+    set -euo pipefail
+    if [[ "{{component}}" != "zxporter" ]]; then
+      echo "error: only 'zxporter' is supported (got '{{component}}')" >&2; exit 1
+    fi
+    if [[ ! "{{version}}" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+      echo "error: version must match vX.Y.Z (got '{{version}}')" >&2; exit 1
+    fi
+    if git ls-remote --exit-code --tags origin "{{version}}" >/dev/null 2>&1; then
+      echo "error: tag {{version}} already exists on origin" >&2; exit 1
+    fi
+    if [[ "{{dry}}" == "dry" ]]; then
+      echo "[dry-run] would: gh workflow run release.yml --repo devzero-inc/zxporter -f version={{version}}"
+      exit 0
+    fi
+    gh workflow run release.yml --repo devzero-inc/zxporter -f version="{{version}}"
+    echo "Dispatched release {{version}}. Watch: https://github.com/devzero-inc/zxporter/actions/workflows/release.yml"


### PR DESCRIPTION
## What

Reduces a full zxporter release to a single command:

```
just tag zxporter v0.1.0
```

`just` only dispatches the Release workflow; **all build/publish/bump/cross-repo work runs in CI**, with the tag created **on the bumped commit** so the git tag, the OCI chart, and git-based consumers (e.g. an ArgoCD `Application` with `targetRevision: v0.1.0`) all carry `v0.1.0` — not the stale `main` value.

## How

- **`justfile`** — thin `tag` recipe: validates `component` + `vX.Y.Z` + tag-not-on-origin, then `gh workflow run release.yml -f version=...`. `dry` previews; `tag-list` lists tags. No local build/push.
- **`release.yml`** (`workflow_dispatch` only — intentionally not on tag push): `resolve → bump-and-tag → images×3 → charts×3 → release-notes → trigger-services`.
  - `bump-and-tag` bumps all chart versions, the nodemon dependency pin, and all three `image.tag` on a `release/bump-vX.Y.Z` branch; runs `make build-installer`; commits; **tags that commit**; pushes branch + tag; opens a PR and `gh pr merge --auto --squash`. Never writes `main` directly. Early guard fails fast if the version is already tagged.
  - Downstream image/chart jobs check out `ref: vX.Y.Z`, so they build from the bumped commit and charts embed `image.tag=vX.Y.Z`.
- **Reusable workflows** (`workflow_call`, `version` + `ref` inputs): `image-{zxporter,nodemon,netmon}.yml` (multi-arch → Docker Hub + public ECR, tag-exists guard) and `chart-{zxporter,nodemon,netmon}.yml` (package + push OCI chart, create the `chart-*` tag the services retriever reads).

## Unified versioning

One `vX.Y.Z` drives all image tags, all chart versions, and `image.tag` in every `values.yaml`. `build-installer` runs with defaults so `dist/` stays in sync with `build-installer-check.yml` and the `{{ .cluster_token }}` placeholder is preserved.

## Legacy coexistence

`push-zxporter-*-image.yml` are neutralized to `workflow_dispatch`-only (dropped their `on: push: tags: v*`) so they no longer double-fire on the release tag; files kept as a manual fallback. `helm-release*.yml` (already dispatch-only) and `create-tag-and-exit.yml` are left in place — remove once the new flow is confirmed.

## Before first real run

- Repo **"Allow auto-merge"** enabled (else the bump PR stays open — non-fatal).
- **`DEBO_GITHUB_PAT`** has repo push (branch + tag) + PR create/merge rights, and `workflow` scope on `devzero-inc/services`.
- Validated locally: YAML parse, `actionlint` (clean bar the known custom-runner-label warning), justfile guards, and a `make build-installer` parity check (only the nodemon `helm.sh/chart` label churns; placeholder preserved).