### PR TITLE
update zxp release command

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,6 +1,6 @@
 name: Release
 
-# Dispatch-only. `just tag zxporter vX.Y.Z` runs `gh workflow run release.yml -f version=vX.Y.Z`.
+# Dispatch-only. `just release zxporter vX.Y.Z` runs `gh workflow run release.yml -f version=vX.Y.Z`.
 # We deliberately do NOT trigger on tag push: the tag must point at the *bumped* commit, so
 # CI bumps first and creates the tag itself (see the bump-and-tag job). A bare tag push on
 # pre-bump main would embed stale image/chart versions in the tagged tree.

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -3,14 +3,14 @@
 Releases are **one command**; CI does the rest.
 
 ```bash
-just tag zxporter vX.Y.Z        # cut release vX.Y.Z
-just tag zxporter vX.Y.Z dry    # preview only
-just tag-list                   # recent release/chart tags
+just release zxporter vX.Y.Z        # cut release vX.Y.Z
+just release zxporter vX.Y.Z dry    # preview only
+just tag-list                       # recent release/chart tags
 ```
 
 Prereq: `gh` CLI authenticated with access to `devzero-inc/zxporter`.
 
-`just tag` validates `vX.Y.Z` and dispatches the **Release** workflow
+`just release` validates `vX.Y.Z` and dispatches the **Release** workflow
 (`.github/workflows/release.yml`), which:
 
 1. Bumps chart/image versions, regenerates `Chart.lock` + `dist/`, and tags

--- a/justfile
+++ b/justfile
@@ -1,5 +1,5 @@
 # zxporter release automation.
-# `just tag zxporter vX.Y.Z` validates + pushes ONE tag; CI (release.yml) does the rest:
+# `just release zxporter vX.Y.Z` validates + pushes ONE tag; CI (release.yml) does the rest:
 # builds/pushes the 3 images, publishes the 3 OCI charts at a unified version, opens one
 # auto-merged bump PR (Chart.yaml/lock, values.yaml, dist/), cuts the GitHub Release, and
 # dispatches the cross-repo services metadata/manifest update.
@@ -15,8 +15,8 @@ tag-list:
 
 # Cut a unified release. Dispatches the Release workflow, which bumps versions, tags the
 # bumped commit, builds/pushes images + charts, opens the bump PR, and updates services.
-# Usage: just tag zxporter v0.1.0     (append `dry` to preview: just tag zxporter v0.1.0 dry)
-tag component version dry="":
+# Usage: just release zxporter v0.1.0     (append `dry` to preview: just release zxporter v0.1.0 dry)
+release component version dry="":
     #!/usr/bin/env bash
     set -euo pipefail
     if [[ "{{component}}" != "zxporter" ]]; then


### PR DESCRIPTION
----
## Summary by Gitar

- **Release automation:**
  - Renamed `just tag` to `just release` command in `justfile`, `RELEASE.md`, and `release.yml` for clarity.

<sub>This will update automatically on new commits.</sub>