### PR TITLE
fix(helm): make global.k8sProvider the single source of truth for provider

### DIFF
--- a/.github/workflows/jvm-metrics-kind-test.yml
+++ b/.github/workflows/jvm-metrics-kind-test.yml
@@ -56,7 +56,7 @@ jobs:
           kubectl create ns devzero-system || true
           helm upgrade --install zxporter-nodemon ./helm-chart/zxporter-nodemon \
             -n devzero-system \
-            --set provider=eks \
+            --set global.k8sProvider=other \
             --set dcgmExporter.enabled=false \
             --set jvmMetrics.enabled=true \
             --set image.repository=zxporter-nodemon \

--- a/.github/workflows/k8s-compatibility-test.yml
+++ b/.github/workflows/k8s-compatibility-test.yml
@@ -237,11 +237,10 @@ jobs:
             yq eval '.zxporter.targetNamespaces = "dztest"' -i helm-chart/zxporter/values.yaml
             yq eval '.zxporter.clusterToken = "test-token-for-ci"' -i helm-chart/zxporter/values.yaml
             yq eval '.zxporter.kubeContextName = "test-kind-cluster"' -i helm-chart/zxporter/values.yaml
-            yq eval '.zxporter.k8sProvider = "other"' -i helm-chart/zxporter/values.yaml
+            yq eval '.global.k8sProvider = "other"' -i helm-chart/zxporter/values.yaml
             yq eval '.zxporter.logLevel = "info"' -i helm-chart/zxporter/values.yaml
             yq eval '.zxporter-nodemon.image.repository = "'"${NODEMON_IMG%:*}"'"' -i helm-chart/zxporter/values.yaml
             yq eval '.zxporter-nodemon.image.tag = "'"${NODEMON_IMG##*:}"'"' -i helm-chart/zxporter/values.yaml
-            yq eval '.zxporter-nodemon.provider = "other"' -i helm-chart/zxporter/values.yaml
             echo "Updated values.yaml:"
             cat helm-chart/zxporter/values.yaml
 

--- a/Makefile
+++ b/Makefile
@@ -361,7 +361,7 @@ build-installer: manifests generate kustomize yq helm ## Generate a consolidated
 	@echo "[INFO] Generate and append default nodemon DaemonSets (provider=other)"
 	@$(HELM) template zxporter-nodemon ./helm-chart/zxporter-nodemon \
 		--namespace $(DEVZERO_MONITORING_NAMESPACE) \
-		--set provider=other \
+		--set global.k8sProvider=other \
 		--set priorityClass.create=false \
 		--set image.repository=$(word 1,$(subst :, ,$(IMG_NODEMON))) \
 		--set image.tag=$(word 2,$(subst :, ,$(IMG_NODEMON))) \
@@ -371,7 +371,7 @@ build-installer: manifests generate kustomize yq helm ## Generate a consolidated
 	@echo "[INFO] Generate and append GCP nodemon DaemonSets (provider=gcp)"
 	@$(HELM) template zxporter-nodemon ./helm-chart/zxporter-nodemon \
 		--namespace $(DEVZERO_MONITORING_NAMESPACE) \
-		--set provider=gcp \
+		--set global.k8sProvider=gcp \
 		--set priorityClass.create=false \
 		--set image.repository=$(word 1,$(subst :, ,$(IMG_NODEMON))) \
 		--set image.tag=$(word 2,$(subst :, ,$(IMG_NODEMON))) \

--- a/docs/nodemon.md
+++ b/docs/nodemon.md
@@ -20,7 +20,7 @@ The Nodemon scrapes metrics from NVIDIA DCGM (Data Center GPU Manager) exporters
 ```bash
 helm install zxporter-nodemon helm-chart/zxporter-nodemon \
   --namespace devzero-system --create-namespace \
-  --set provider=gcp \
+  --set global.k8sProvider=gcp \
   --set dcgmExporter.enabled=true
 ```
 
@@ -29,7 +29,7 @@ helm install zxporter-nodemon helm-chart/zxporter-nodemon \
 ```bash
 helm install zxporter-nodemon helm-chart/zxporter-nodemon \
   --namespace devzero-system --create-namespace \
-  --set provider=gcp \
+  --set global.k8sProvider=gcp \
   --set dcgmExporter.enabled=false \
   --set nodemon.config.DCGM_LABELS="app.kubernetes.io/name=dcgm-exporter"
 ```
@@ -42,7 +42,8 @@ Both nodemon and DCGM exporter run as sidecar containers in the same pod. Best f
 
 ```yaml
 # values.yaml
-provider: gcp  # gcp | eks | azure
+global:
+  k8sProvider: gcp  # gcp | aws | azure | oci | other
 dcgmExporter:
   enabled: true
   useExternalHostEngine: false
@@ -54,7 +55,8 @@ If you already have DCGM exporter deployed separately, disable the embedded one 
 
 ```yaml
 # values.yaml
-provider: gcp
+global:
+  k8sProvider: gcp
 dcgmExporter:
   enabled: false
 nodemon:
@@ -68,7 +70,8 @@ For environments where DCGM host engine runs at the node level (e.g., GCP with C
 
 ```yaml
 # values.yaml
-provider: gcp
+global:
+  k8sProvider: gcp
 dcgmExporter:
   enabled: true
   useExternalHostEngine: true  # Connect to DCGM running on host
@@ -80,7 +83,8 @@ Point directly to a specific DCGM exporter instance.
 
 ```yaml
 # values.yaml
-provider: eks
+global:
+  k8sProvider: aws
 dcgmExporter:
   enabled: false
 nodemon:
@@ -135,7 +139,7 @@ kubectl describe nodes | grep -A5 "Allocatable:" | grep nvidia
 
 | Parameter | Description | Default |
 |-----------|-------------|---------|
-| `provider` | Cloud provider: `gcp`, `eks`, `azure` | **Required** |
+| `global.k8sProvider` | Cloud provider: `aws`, `gcp`, `azure`, `oci`, `other` (single source of truth, shared with the parent chart) | **Required** |
 | `dcgmExporter.enabled` | Deploy DCGM exporter sidecar | `true` |
 | `dcgmExporter.useExternalHostEngine` | Connect to host-level DCGM engine | `false` |
 | `dcgmExporter.runtimeClassName` | RuntimeClass for the GPU DaemonSet (`zxporter-nodemon-gpu`). Set to `""` to disable the split and use the original single DaemonSet with an embedded DCGM sidecar. | `"nvidia"` |
@@ -155,7 +159,7 @@ non-GPU nodes) and `zxporter-nodemon-gpu` (GPU Operator nodes only, with
 `nvidia.com/gpu.present=true`, which is set by the NVIDIA GPU Operator's
 node-feature-discovery. On GKE without the GPU Operator, these labels are absent
 so the GPU DaemonSet has zero pods and the base DaemonSet runs everywhere using
-the `provider=gcp` hostPath mount for NVML. GPU nodes added after install are
+the `global.k8sProvider=gcp` hostPath mount for NVML. GPU nodes added after install are
 picked up automatically by the DaemonSet controller.
 
 ## API Reference

--- a/docs/prometheus-migration-guide.md
+++ b/docs/prometheus-migration-guide.md
@@ -576,10 +576,9 @@ helm install zxporter ./helm-chart/zxporter \
   --set zxporter.useSecretForToken=true \
   --set zxporter.clusterToken="$CLUSTER_TOKEN" \
   --set zxporter.kubeContextName="$CLUSTER_NAME" \
-  --set zxporter.k8sProvider="$K8S_PROVIDER" \
+  --set global.k8sProvider="$K8S_PROVIDER" \
   --set zxporter.dakrUrl="$DAKR_URL" \
-  --set zxporter.logLevel="${LOG_LEVEL:-error}" \
-  --set zxporter-nodemon.provider="$K8S_PROVIDER"
+  --set zxporter.logLevel="${LOG_LEVEL:-error}"
 ```
 
 > This creates everything in one shot: namespace, ConfigMap, Secret, Deployment, nodemon DaemonSet. Helm manages all resources.

--- a/hack/install-new-zxporter.sh
+++ b/hack/install-new-zxporter.sh
@@ -41,7 +41,7 @@ helm install "$RELEASE_NAME" ./helm-chart/zxporter \
   --set image.tag="$IMAGE_TAG" \
   --set zxporter.clusterToken="$CLUSTER_TOKEN" \
   --set zxporter.kubeContextName="$KUBE_CONTEXT" \
-  --set zxporter.k8sProvider="$K8S_PROVIDER"
+  --set global.k8sProvider="$K8S_PROVIDER"
 
 echo ""
 echo "=== Installing nodemon DaemonSet ==="
@@ -50,7 +50,7 @@ helm install zxporter-nodemon ./helm-chart/zxporter-nodemon \
   --namespace "$NAMESPACE" \
   --set image.repository=docker.io/parthiba007/nodemon \
   --set image.tag=prom \
-  --set provider="$K8S_PROVIDER"
+  --set global.k8sProvider="$K8S_PROVIDER"
 
 echo ""
 echo "=== Done. Checking pods ==="

--- a/helm-chart/zxporter-nodemon/templates/daemonset.yaml
+++ b/helm-chart/zxporter-nodemon/templates/daemonset.yaml
@@ -1,5 +1,5 @@
 {{- $rc := .Values.dcgmExporter.runtimeClassName | default "" | toString }}
-{{- $provider := required ".Values.provider is required (gcp|aws|azure|oci|other)" .Values.provider }}
+{{- $provider := required ".Values.global.k8sProvider is required (gcp|aws|azure|oci|other)" .Values.global.k8sProvider }}
 {{- $gpuKey := .Values.dcgmExporter.gpuNodeSelector.key | default "" | toString }}
 {{- $gpuVal := .Values.dcgmExporter.gpuNodeSelector.value | default "" | toString }}
 {{- $split := and .Values.dcgmExporter.enabled (ne $rc "") (ne $gpuKey "") }}
@@ -75,7 +75,7 @@ spec:
         - name: {{- include "dcgm-exporter.config-map" $ | indent 1 }}
           configMap:
             name: {{- include "dcgm-exporter.config-map" $ | indent 1 }}
-        {{- if eq $.Values.provider "gcp" }}
+        {{- if eq $.Values.global.k8sProvider "gcp" }}
         - name: "nvidia-install-dir-host"
           hostPath:
             path: /home/kubernetes/bin/nvidia
@@ -178,7 +178,7 @@ spec:
                 - NET_RAW
             runAsNonRoot: false
             runAsUser: 0
-            {{- if eq $.Values.provider "gcp"}}
+            {{- if eq $.Values.global.k8sProvider "gcp"}}
             privileged: true
             {{- end }}
           image: "{{ $.Values.dcgmExporter.image.repository }}:{{ $.Values.dcgmExporter.image.tag }}"
@@ -216,11 +216,11 @@ spec:
             {{- $hasCustomLDLibraryPath = true }}
             {{- end }}
             {{- end }}
-            {{- if and (eq $.Values.provider "gcp") (not $hasCustomLDLibraryPath) }}
+            {{- if and (eq $.Values.global.k8sProvider "gcp") (not $hasCustomLDLibraryPath) }}
             - name: "LD_LIBRARY_PATH"
               value: "/usr/local/nvidia/lib64"
             {{- end }}
-            {{- if eq $.Values.provider "gcp" }}
+            {{- if eq $.Values.global.k8sProvider "gcp" }}
             - name: "DCGM_EXPORTER_KUBERNETES_GPU_ID_TYPE"
               value: "device-name"
             {{- end }}
@@ -231,7 +231,7 @@ spec:
             - name: "pod-gpu-resources"
               readOnly: true
               mountPath: "/var/lib/kubelet/pod-resources"
-            {{- if eq $.Values.provider "gcp" }}
+            {{- if eq $.Values.global.k8sProvider "gcp" }}
             - name: "nvidia-install-dir-host"
               mountPath: /usr/local/nvidia
             {{- end }}

--- a/helm-chart/zxporter-nodemon/values.yaml
+++ b/helm-chart/zxporter-nodemon/values.yaml
@@ -1,4 +1,3 @@
-provider: "" # gcp | aws | azure | oci | other | eks (legacy alias for aws)
 # fullnameOverride pins all nodemon resource names to a stable value, independent of the Helm
 # release name. It MUST stay "zxporter-nodemon" so that:
 #   1. the zxporter controller can discover nodemon pods via the fixed label selector
@@ -50,11 +49,16 @@ nodemon:
 # NOTE: requires hostPID + running nodemon as UID 0 to read /proc/<pid>/root/tmp/hsperfdata_*/<nsPid>
 jvmMetrics:
   enabled: true
-# global.priorityClass.enabled is the single toggle for using the custom
-# PriorityClass. The parent zxporter chart supplies it (auto-propagated to this
-# subchart); this default applies when nodemon is installed standalone (CI,
-# helm-release-nodemon).
+# global values are the single source of truth shared with the parent zxporter
+# chart, which auto-propagates them to this subchart. These defaults apply when
+# nodemon is installed standalone (CI, helm-release-nodemon).
 global:
+  # k8sProvider gates the GPU driver hostPath / LD_LIBRARY_PATH on provider=gcp.
+  # Required (non-empty) at render time. When bundled under the parent chart it is
+  # supplied by global.k8sProvider there — set it ONLY in one place, never both.
+  k8sProvider: ""
+  # global.priorityClass.enabled is the single toggle for using the custom
+  # PriorityClass. The parent zxporter chart supplies it (auto-propagated here).
   priorityClass:
     enabled: true
 # Assigns the node agent a custom PriorityClass so it can schedule on

--- a/helm-chart/zxporter/templates/NOTES.txt
+++ b/helm-chart/zxporter/templates/NOTES.txt
@@ -25,10 +25,10 @@ Please set zxporter.kubeContextName to a unique identifier for your cluster.
 
 {{- end }}
 
-{{- if not .Values.zxporter.k8sProvider }}
+{{- if not .Values.global.k8sProvider }}
 
 NOTE: No Kubernetes provider configured.
-Please set zxporter.k8sProvider to one of: aws, gcp, azure, oci, other
+Please set global.k8sProvider to one of: aws, gcp, azure, oci, other
 
 {{- end }}
 

--- a/helm-chart/zxporter/templates/_helpers.tpl
+++ b/helm-chart/zxporter/templates/_helpers.tpl
@@ -60,12 +60,12 @@ Validate required configuration
     {{- fail "ERROR: zxporter.kubeContextName is required. Please provide a unique identifier for your cluster." -}}
   {{- end -}}
   
-  {{- if empty .Values.zxporter.k8sProvider -}}
-    {{- fail "ERROR: zxporter.k8sProvider is required. Please set it to one of: aws, gcp, azure, oci, other" -}}
+  {{- if empty .Values.global.k8sProvider -}}
+    {{- fail "ERROR: global.k8sProvider is required. Please set it to one of: aws, gcp, azure, oci, other" -}}
   {{- end -}}
-  
+
   {{- $validProviders := list "aws" "gcp" "azure" "oci" "other" -}}
-  {{- if not (has .Values.zxporter.k8sProvider $validProviders) -}}
-    {{- fail (printf "ERROR: zxporter.k8sProvider must be one of: %s. Got: %s" (join ", " $validProviders) .Values.zxporter.k8sProvider) -}}
+  {{- if not (has .Values.global.k8sProvider $validProviders) -}}
+    {{- fail (printf "ERROR: global.k8sProvider must be one of: %s. Got: %s" (join ", " $validProviders) .Values.global.k8sProvider) -}}
   {{- end -}}
 {{- end }}

--- a/helm-chart/zxporter/templates/configmap.yaml
+++ b/helm-chart/zxporter/templates/configmap.yaml
@@ -39,7 +39,7 @@ data:
   EXCLUDED_STATEFULSETS: ""
   EXCLUDED_STORAGECLASSES: ""
   EXCLUDED_VPAS: ""
-  K8S_PROVIDER: "{{ .Values.zxporter.k8sProvider }}"
+  K8S_PROVIDER: "{{ .Values.global.k8sProvider }}"
   KUBE_CONTEXT_NAME: "{{ .Values.zxporter.kubeContextName }}"
   LOG_LEVEL: "{{ .Values.zxporter.logLevel }}"
   MASK_SECRET_DATA: ""

--- a/helm-chart/zxporter/values.yaml
+++ b/helm-chart/zxporter/values.yaml
@@ -4,7 +4,7 @@
 # The following fields MUST be configured before deployment:
 # 1. zxporter.clusterToken OR zxporter.patToken (at least one required)
 # 2. zxporter.kubeContextName - unique identifier for your cluster
-# 3. zxporter.k8sProvider - one of: aws, gcp, azure, oci, other
+# 3. global.k8sProvider - one of: aws, gcp, azure, oci, other
 #
 # For production deployments, we recommend using patToken for automatic token exchange.
 
@@ -34,10 +34,6 @@ zxporter:
   #   - OCI: "ocid1.cluster.oc1.iad.aaaaaaaa..."
   #   - Other: "production-cluster" or "staging-cluster"
   kubeContextName: ""
-  # Kubernetes provider type
-  # Required: Must be one of: "aws", "gcp", "azure", "oci", "other"
-  # This helps optimize collection for specific cloud providers
-  k8sProvider: ""
   # Set to true to store CLUSTER_TOKEN and PAT_TOKEN in Kubernetes Secrets instead of ConfigMap
   # Default is false for backward compatibility
   useSecretForToken: true
@@ -78,6 +74,13 @@ mpaServer:
 # nodemon subchart, so the object (created here) and the DaemonSet reference (in
 # the subchart) can never drift out of sync.
 global:
+  # k8sProvider is the SINGLE source of truth for the cloud provider. It is
+  # shared by the parent chart (controller K8S_PROVIDER env) and the bundled
+  # zxporter-nodemon subchart (which gates its GPU driver hostPath/LD_LIBRARY_PATH
+  # on provider=gcp). Being a global, it auto-propagates to the subchart, so it
+  # must ONLY be set here — never on zxporter-nodemon.provider.
+  # Required: one of "aws", "gcp", "azure", "oci", "other".
+  k8sProvider: ""
   priorityClass:
     enabled: true
 priorityClass:

--- a/verification/verify_e2e.sh
+++ b/verification/verify_e2e.sh
@@ -113,7 +113,7 @@ if [[ "$ENABLE_CONTROL_PLANE_TEST" == "true" ]]; then
         --set monitoring.enabled=false \
         --set highAvailability.enabled=false \
         --set zxporter.kubeContextName="$CLUSTER_CONTEXT" \
-        --set zxporter.k8sProvider="$PROVIDER" \
+        --set global.k8sProvider="$PROVIDER" \
         --set zxporter.logLevel="debug"
         
     echo "Updating zxporter-netmon configuration to point to TestServer..."


### PR DESCRIPTION
## 📚 Description of Changes

- **What Changed:**
  Consolidated the cloud-provider setting into a single `global.k8sProvider` value shared by the parent `zxporter` chart and the bundled `zxporter-nodemon` subchart. Removed the duplicate `zxporter.k8sProvider` (parent) and `provider` (subchart) values, and updated every consumer — `Makefile` dist generation, `hack/install-new-zxporter.sh`, `verification/verify_e2e.sh`, the `k8s-compatibility-test` / `jvm-metrics-kind-test` workflows, and the `nodemon` + `prometheus-migration` docs. The now-redundant `zxporter-nodemon.provider` workaround line in CI was dropped.

- **Why This Change:**
  The parent chart consumed `zxporter.k8sProvider` while the subchart consumed a separate `provider`. Helm only propagates values into a bundled subchart through `global.*`, so installing the parent chart with `zxporter.k8sProvider` alone left the subchart's `provider` empty and its `required` guard failed the whole install — forcing users to set the provider in **two** places. This reuses the chart's existing `global.priorityClass` pattern so the value is set exactly once and auto-propagates.

- **Affected Components:**
- [ ] Compose
- [x] K8s
- [ ] Other (please specify)

## ❓ Motivation and Context

- **Context:**
  Setting `zxporter.k8sProvider` on a parent-chart install did not reach the nodemon subchart, tripping `daemonset.yaml`'s `required` guard. The double-set requirement had already spawned workarounds in the docs (`zxporter-nodemon.provider`) and CI (a `yq` patch line).

## 🔍 Types of Changes

- [ ] **BUGFIX:** Non-breaking fix for an issue.
- [x] **BREAKING CHANGE:** Fix or feature that causes existing functionality to not work as expected.

> **Breaking:** `--set zxporter.k8sProvider=...` / `--set provider=...` must become `--set global.k8sProvider=...`. It fails loudly (validation error) if unset — never silently.

## 🔬 QA / Verification Steps

Verified locally with `helm template` and `helm lint` on both charts:

1. `helm template ./helm-chart/zxporter-nodemon` → fails fast: `.Values.global.k8sProvider is required`.
2. `helm template ./helm-chart/zxporter-nodemon --set global.k8sProvider=gcp` → GPU driver hostPath present; `=other` → absent.
3. `helm template ./helm-chart/zxporter --set zxporter.clusterToken=tok --set zxporter.kubeContextName=ctx --set global.k8sProvider=gcp` → ConfigMap `K8S_PROVIDER: "gcp"` **and** the nodemon subchart renders the gcp GPU paths from the single knob (propagation confirmed).
4. Missing provider → `validateConfig` fails; `--set global.k8sProvider=bogus` → enum error `must be one of: aws, gcp, azure, oci, other`.
5. `helm lint` on both charts → 0 failed.

_`dist/*.yaml` intentionally not regenerated: rendered output is byte-identical (the value's name never appears in output, only its effect)._

## ✅ Global Checklist

- [x] My code follows the code style of this project.
- [x] I have updated the documentation as needed.
- [ ] I have added tests that cover my changes.
- [x] All new and existing tests have passed locally.
- [x] I have run this code in a local environment to verify functionality.
- [x] I have considered the security implications of this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)