### PR TITLE
add pod UID to metrics info

### DIFF
--- a/internal/collector/container_metrics.go
+++ b/internal/collector/container_metrics.go
@@ -7,6 +7,7 @@ type ContainerMetricsSnapshot struct {
 	// Container identification
 	ContainerName string `json:"containerName"`
 	PodName       string `json:"podName"`
+	PodUID        string `json:"podUid,omitempty"`
 	Namespace     string `json:"namespace"`
 	NodeName      string `json:"nodeName"`
 
@@ -112,6 +113,7 @@ func BuildOOMSnapshot(pod *corev1.Pod, cs corev1.ContainerStatus) *ContainerMetr
 	return &ContainerMetricsSnapshot{
 		ContainerName:         cs.Name,
 		PodName:               pod.Name,
+		PodUID:                string(pod.UID),
 		Namespace:             pod.Namespace,
 		NodeName:              pod.Spec.NodeName,
 		WorkloadName:          workloadName,

--- a/internal/collector/container_resource_collector.go
+++ b/internal/collector/container_resource_collector.go
@@ -547,6 +547,7 @@ func (c *ContainerResourceCollector) processContainerMetrics(
 		// Container identification
 		ContainerName: containerMetrics.Name,
 		PodName:       pod.Name,
+		PodUID:        string(pod.UID),
 		Namespace:     pod.Namespace,
 		NodeName:      pod.Spec.NodeName,
 


### PR DESCRIPTION
adds pod UID to metrics info, needed for discerning new rollouts for sts and other compound objects with static pod names. fully backcompat wrt control plane.