### PR TITLE
feat: low-privilege dist/ bundles + CI coverage (runtime metrics disabled)

### DIFF
--- a/.github/workflows/build-installer-check.yml
+++ b/.github/workflows/build-installer-check.yml
@@ -41,12 +41,12 @@ jobs:
       
       - name: Check for uncommitted changes in dist/
         run: |
-          # build-installer regenerates every bundle under dist/ (install.yaml,
-          # install-nvidia-runtime.yaml, installer_updater*, backend-install*,
-          # nodemon.yaml, nodemon-nvidia-runtime.yaml, zxporter.yaml). Guard the
-          # whole directory: previously only dist/install.yaml was checked, so the
-          # NVIDIA-runtime nodemon manifest -- appended only to
-          # install-nvidia-runtime.yaml -- could drift without failing CI.
+          # build-installer regenerates every bundle under dist/: install*.yaml,
+          # installer_updater*.yaml, backend-install*.yaml, nodemon*.yaml,
+          # zxporter.yaml -- each with a -gcp provider variant and a -lowpriv
+          # (runtimeMetrics.enabled=false) variant. Guard the whole directory:
+          # previously only dist/install.yaml was checked, so bundles appended
+          # by later variants could drift without failing CI.
           if [[ -n $(git status --porcelain dist/) ]]; then
             echo "::error::Running 'make build-installer' produced uncommitted changes under dist/."
             echo "Please run 'make build-installer' locally and commit the dist/ changes before pushing."

--- a/.github/workflows/k8s-compatibility-test.yml
+++ b/.github/workflows/k8s-compatibility-test.yml
@@ -119,7 +119,14 @@ jobs:
           - v1.36.1
         deployment-method:
           - helm
+          # "manifest" (unchanged name — required-status-check contexts in the
+          # branch ruleset are pinned to "Test on K8s <version> (manifest)" for
+          # all six k8s-versions; renaming it would silently strand those checks
+          # and block every future merge) exercises dist/install.yaml. The new
+          # manifest-lowpriv variant exercises dist/install-lowpriv.yaml — same
+          # coverage, extended to the no-hostPID/root/SYS_PTRACE bundle.
           - manifest
+          - manifest-lowpriv
           
     steps:
       - name: Set Docker image names
@@ -246,6 +253,9 @@ jobs:
 
             helm dependency update helm-chart/zxporter/
             make helm-chart-install YQ=/usr/local/bin/yq
+          elif [ "${{ matrix.deployment-method }}" = "manifest-lowpriv" ]; then
+            echo "Deploying ZXporter using make deploy-lowpriv (nodemon: no hostPID/root/SYS_PTRACE, no runtime metrics)..."
+            make deploy-lowpriv IMG=${{ env.ZXPORTER_IMG }} IMG_NODEMON=${{ env.NODEMON_IMG }} DAKR_URL=http://testserver.devzero-system.svc.cluster.local:50051 TARGET_NAMESPACES=dztest CLUSTER_TOKEN=test-token-for-ci
           else
             echo "Deploying ZXporter using make deploy..."
             make deploy IMG=${{ env.ZXPORTER_IMG }} IMG_NODEMON=${{ env.NODEMON_IMG }} DAKR_URL=http://testserver.devzero-system.svc.cluster.local:50051 TARGET_NAMESPACES=dztest CLUSTER_TOKEN=test-token-for-ci

--- a/.github/workflows/runtime-metrics-kind-test.yml
+++ b/.github/workflows/runtime-metrics-kind-test.yml
@@ -84,6 +84,32 @@ jobs:
           grep -q 'hostPID: true' /tmp/render-canonical.yaml
           grep -q 'SYS_PTRACE' /tmp/render-canonical.yaml
 
+      - name: Static dist/ low-privilege bundle coverage
+        run: |
+          # dist/*-lowpriv.yaml are committed `helm template --set
+          # runtimeMetrics.enabled=false` output (see Makefile's build-installer
+          # target) -- the manifests actually served by the plain curl+kubectl
+          # installer and dakr's backend, not just a live helm-template render.
+          # The Helm key parity step above already proves the template logic
+          # itself is correct; this proves the *committed* static output matches,
+          # so a stale dist/ (someone hand-edited the chart but forgot `make
+          # build-installer`) fails CI here rather than shipping quietly.
+          for f in dist/nodemon-lowpriv.yaml dist/nodemon-gcp-lowpriv.yaml; do
+            echo "checking $f"
+            if grep -qE 'hostPID: true|SYS_PTRACE' "$f"; then
+              echo "::error::$f still grants process-introspection privileges"; exit 1
+            fi
+            if ! grep -A1 'RUNTIME_METRICS_ENABLED' "$f" | grep -q '"false"'; then
+              echo "::error::$f did not disable runtime metrics"; exit 1
+            fi
+          done
+          # And the privileged bundles must still carry them, proving the greps
+          # above aren't vacuous.
+          for f in dist/nodemon.yaml dist/nodemon-gcp.yaml; do
+            grep -q 'hostPID: true' "$f"
+            grep -q 'SYS_PTRACE' "$f"
+          done
+
       - name: Build nodemon image
         run: |
           docker build -f Dockerfile.nodemon -t zxporter-nodemon:runtime-ci .

--- a/Makefile
+++ b/Makefile
@@ -79,6 +79,14 @@ DIST_BACKEND_INSTALL_GCP_BUNDLE ?= $(DIST_DIR)/backend-install-gcp.yaml
 DIST_INSTALLER_UPDATER_BUNDLE ?= $(DIST_DIR)/installer_updater.yaml
 DIST_INSTALLER_UPDATER_GCP_BUNDLE ?= $(DIST_DIR)/installer_updater-gcp.yaml
 DIST_ZXPORTER_BUNDLE ?= $(DIST_DIR)/zxporter.yaml
+# -lowpriv variants: nodemon rendered with runtimeMetrics.enabled=false, i.e. no
+# hostPID / root / SYS_PTRACE. Mirrors the -gcp provider-suffix convention above.
+DIST_INSTALL_LOWPRIV_BUNDLE ?= $(DIST_DIR)/install-lowpriv.yaml
+DIST_INSTALL_GCP_LOWPRIV_BUNDLE ?= $(DIST_DIR)/install-gcp-lowpriv.yaml
+DIST_BACKEND_INSTALL_LOWPRIV_BUNDLE ?= $(DIST_DIR)/backend-install-lowpriv.yaml
+DIST_BACKEND_INSTALL_GCP_LOWPRIV_BUNDLE ?= $(DIST_DIR)/backend-install-gcp-lowpriv.yaml
+DIST_INSTALLER_UPDATER_LOWPRIV_BUNDLE ?= $(DIST_DIR)/installer_updater-lowpriv.yaml
+DIST_INSTALLER_UPDATER_GCP_LOWPRIV_BUNDLE ?= $(DIST_DIR)/installer_updater-gcp-lowpriv.yaml
 
 # ENVTEST_K8S_VERSION refers to the version of kubebuilder assets to be downloaded by envtest binary.
 ENVTEST_K8S_VERSION = 1.31.0
@@ -276,7 +284,7 @@ docker-buildx: ## Build and push docker image for the manager for cross-platform
 
 .PHONY: final-installer
 final-installer:
-	@cp dist/install.yaml $(DIST_BACKEND_INSTALL_BUNDLE)
+	@cp $(DIST_INSTALL_BUNDLE) $(DIST_BACKEND_INSTALL_BUNDLE)
 	@$(YQ) -i '(select(.kind == "ConfigMap" and .metadata.name == "devzero-zxporter-env-config") | .data.DAKR_URL) = "{{ .api_url }}/dakr"' $(DIST_BACKEND_INSTALL_BUNDLE)
 	@$(YQ) -i '(select(.kind == "Deployment") | .spec.template.spec.containers[]? | select(.image == "ttl.sh/zxporter:latest")).image = "docker.io/devzeroinc/zxporter:latest"' $(DIST_BACKEND_INSTALL_BUNDLE)
 # nodemon's DaemonSet image must also come off the ephemeral ttl.sh registry and
@@ -355,8 +363,11 @@ build-installer: manifests generate kustomize yq helm ## Generate a consolidated
 	fi
 	@cat $(DIST_ZXPORTER_BUNDLE) >> $(DIST_INSTALL_BUNDLE)
 	@# Save the base bundle (namespace + controller) before appending nodemon — used
-	@# as the starting point for both the default and GCP installer variants.
+	@# as the starting point for both the default and GCP installer variants, and
+	@# the low-privilege (runtimeMetrics.enabled=false) variants of each.
 	@cp $(DIST_INSTALL_BUNDLE) $(DIST_INSTALL_GCP_BUNDLE)
+	@cp $(DIST_INSTALL_BUNDLE) $(DIST_INSTALL_LOWPRIV_BUNDLE)
+	@cp $(DIST_INSTALL_BUNDLE) $(DIST_INSTALL_GCP_LOWPRIV_BUNDLE)
 
 	@echo "[INFO] Generate and append default nodemon DaemonSets (provider=other)"
 	@$(HELM) template zxporter-nodemon ./helm-chart/zxporter-nodemon \
@@ -378,8 +389,39 @@ build-installer: manifests generate kustomize yq helm ## Generate a consolidated
 		> $(DIST_DIR)/nodemon-gcp.yaml
 	@cat $(DIST_DIR)/nodemon-gcp.yaml >> $(DIST_INSTALL_GCP_BUNDLE)
 
+	@echo "[INFO] Generate and append low-privilege default nodemon DaemonSets (provider=other, runtimeMetrics.enabled=false)"
+	@$(HELM) template zxporter-nodemon ./helm-chart/zxporter-nodemon \
+		--namespace $(DEVZERO_MONITORING_NAMESPACE) \
+		--set global.k8sProvider=other \
+		--set priorityClass.create=false \
+		--set runtimeMetrics.enabled=false \
+		--set image.repository=$(word 1,$(subst :, ,$(IMG_NODEMON))) \
+		--set image.tag=$(word 2,$(subst :, ,$(IMG_NODEMON))) \
+		> $(DIST_DIR)/nodemon-lowpriv.yaml
+	@cat $(DIST_DIR)/nodemon-lowpriv.yaml >> $(DIST_INSTALL_LOWPRIV_BUNDLE)
+
+	@echo "[INFO] Generate and append low-privilege GCP nodemon DaemonSets (provider=gcp, runtimeMetrics.enabled=false)"
+	@$(HELM) template zxporter-nodemon ./helm-chart/zxporter-nodemon \
+		--namespace $(DEVZERO_MONITORING_NAMESPACE) \
+		--set global.k8sProvider=gcp \
+		--set priorityClass.create=false \
+		--set runtimeMetrics.enabled=false \
+		--set image.repository=$(word 1,$(subst :, ,$(IMG_NODEMON))) \
+		--set image.tag=$(word 2,$(subst :, ,$(IMG_NODEMON))) \
+		> $(DIST_DIR)/nodemon-gcp-lowpriv.yaml
+	@cat $(DIST_DIR)/nodemon-gcp-lowpriv.yaml >> $(DIST_INSTALL_GCP_LOWPRIV_BUNDLE)
+
 	@echo "[INFO] Building backend installer"
 	@$(MAKE) final-installer
+
+	@echo "[INFO] Building low-privilege backend installer (runtime metrics disabled)"
+	@$(MAKE) final-installer \
+		DIST_INSTALL_BUNDLE=$(DIST_INSTALL_LOWPRIV_BUNDLE) \
+		DIST_INSTALL_GCP_BUNDLE=$(DIST_INSTALL_GCP_LOWPRIV_BUNDLE) \
+		DIST_BACKEND_INSTALL_BUNDLE=$(DIST_BACKEND_INSTALL_LOWPRIV_BUNDLE) \
+		DIST_BACKEND_INSTALL_GCP_BUNDLE=$(DIST_BACKEND_INSTALL_GCP_LOWPRIV_BUNDLE) \
+		DIST_INSTALLER_UPDATER_BUNDLE=$(DIST_INSTALLER_UPDATER_LOWPRIV_BUNDLE) \
+		DIST_INSTALLER_UPDATER_GCP_BUNDLE=$(DIST_INSTALLER_UPDATER_GCP_LOWPRIV_BUNDLE)
 
 .PHONY: build-env-configmap
 build-env-configmap: DIST_INSTALL_BUNDLE=$(DIST_DIR)/env_configmap.yaml

--- a/Makefile
+++ b/Makefile
@@ -88,6 +88,14 @@ DIST_BACKEND_INSTALL_GCP_LOWPRIV_BUNDLE ?= $(DIST_DIR)/backend-install-gcp-lowpr
 DIST_INSTALLER_UPDATER_LOWPRIV_BUNDLE ?= $(DIST_DIR)/installer_updater-lowpriv.yaml
 DIST_INSTALLER_UPDATER_GCP_LOWPRIV_BUNDLE ?= $(DIST_DIR)/installer_updater-gcp-lowpriv.yaml
 
+# final-installer's dakr-sync destination filenames (see DAKR_DIR below). Parameterized
+# so build-installer's second (lowpriv) final-installer invocation can override them to
+# the -lowpriv names instead of clobbering the privileged sync from the first invocation.
+DAKR_INSTALL_DEST ?= install.yaml
+DAKR_INSTALL_GCP_DEST ?= install-gcp.yaml
+DAKR_UPDATER_DEST ?= installer_updater.yaml
+DAKR_UPDATER_GCP_DEST ?= installer_updater-gcp.yaml
+
 # ENVTEST_K8S_VERSION refers to the version of kubebuilder assets to be downloaded by envtest binary.
 ENVTEST_K8S_VERSION = 1.31.0
 
@@ -310,10 +318,10 @@ final-installer:
 		-e 's|name: $(DEVZERO_MONITORING_NAMESPACE)|name: {{.zxporter_namespace}}|g' \
 		$(DIST_BACKEND_INSTALL_GCP_BUNDLE) > $(DIST_BACKEND_INSTALL_GCP_BUNDLE).tmp && mv $(DIST_BACKEND_INSTALL_GCP_BUNDLE).tmp $(DIST_BACKEND_INSTALL_GCP_BUNDLE)
 	@if [ -d "$(DAKR_DIR)/services/dakr_installers" ]; then \
-		cp $(DIST_BACKEND_INSTALL_BUNDLE) $(DAKR_DIR)/services/dakr_installers/install.yaml; \
-		cp $(DIST_BACKEND_INSTALL_GCP_BUNDLE) $(DAKR_DIR)/services/dakr_installers/install-gcp.yaml; \
-		cp $(DIST_INSTALLER_UPDATER_BUNDLE) $(DAKR_DIR)/services/dakr_installers/installer_updater.yaml; \
-		cp $(DIST_INSTALLER_UPDATER_GCP_BUNDLE) $(DAKR_DIR)/services/dakr_installers/installer_updater-gcp.yaml; \
+		cp $(DIST_BACKEND_INSTALL_BUNDLE) $(DAKR_DIR)/services/dakr_installers/$(DAKR_INSTALL_DEST); \
+		cp $(DIST_BACKEND_INSTALL_GCP_BUNDLE) $(DAKR_DIR)/services/dakr_installers/$(DAKR_INSTALL_GCP_DEST); \
+		cp $(DIST_INSTALLER_UPDATER_BUNDLE) $(DAKR_DIR)/services/dakr_installers/$(DAKR_UPDATER_DEST); \
+		cp $(DIST_INSTALLER_UPDATER_GCP_BUNDLE) $(DAKR_DIR)/services/dakr_installers/$(DAKR_UPDATER_GCP_DEST); \
 		echo "[INFO] Synced installer files to $(DAKR_DIR)/services/dakr_installers/"; \
 	fi
 
@@ -421,7 +429,11 @@ build-installer: manifests generate kustomize yq helm ## Generate a consolidated
 		DIST_BACKEND_INSTALL_BUNDLE=$(DIST_BACKEND_INSTALL_LOWPRIV_BUNDLE) \
 		DIST_BACKEND_INSTALL_GCP_BUNDLE=$(DIST_BACKEND_INSTALL_GCP_LOWPRIV_BUNDLE) \
 		DIST_INSTALLER_UPDATER_BUNDLE=$(DIST_INSTALLER_UPDATER_LOWPRIV_BUNDLE) \
-		DIST_INSTALLER_UPDATER_GCP_BUNDLE=$(DIST_INSTALLER_UPDATER_GCP_LOWPRIV_BUNDLE)
+		DIST_INSTALLER_UPDATER_GCP_BUNDLE=$(DIST_INSTALLER_UPDATER_GCP_LOWPRIV_BUNDLE) \
+		DAKR_INSTALL_DEST=install-lowpriv.yaml \
+		DAKR_INSTALL_GCP_DEST=install-gcp-lowpriv.yaml \
+		DAKR_UPDATER_DEST=installer_updater-lowpriv.yaml \
+		DAKR_UPDATER_GCP_DEST=installer_updater-gcp-lowpriv.yaml
 
 .PHONY: build-env-configmap
 build-env-configmap: DIST_INSTALL_BUNDLE=$(DIST_DIR)/env_configmap.yaml

--- a/Makefile
+++ b/Makefile
@@ -528,6 +528,10 @@ uninstall: manifests kustomize ## Uninstall CRDs from the K8s cluster specified 
 deploy: build-installer ## Deploy controller to the K8s cluster specified in ~/.kube/config.
 	cat $(DIST_INSTALL_BUNDLE) | $(KUBECTL) apply -f -
 
+.PHONY: deploy-lowpriv
+deploy-lowpriv: build-installer ## Deploy controller with the low-privilege nodemon variant (no hostPID/root/SYS_PTRACE, no runtime metrics) to the K8s cluster specified in ~/.kube/config.
+	cat $(DIST_INSTALL_LOWPRIV_BUNDLE) | $(KUBECTL) apply -f -
+
 .PHONY: local-deploy
 local-deploy: manifests kustomize ## Deploy controller to the K8s cluster specified in ~/.kube/config.
 	cd config/manager && $(KUSTOMIZE) edit set image controller=${IMG}

--- a/dist/backend-install-gcp-lowpriv.yaml
+++ b/dist/backend-install-gcp-lowpriv.yaml
@@ -769,10 +769,10 @@ metadata:
   name: zxporter-nodemon
   namespace: {{.zxporter_namespace}}
   labels:
-    helm.sh/chart: zxporter-nodemon-0.0.97
+    helm.sh/chart: zxporter-nodemon-0.0.98
     app.kubernetes.io/name: zxporter-nodemon
     app.kubernetes.io/instance: zxporter-nodemon
-    app.kubernetes.io/version: "0.0.97"
+    app.kubernetes.io/version: "0.0.98"
     app.kubernetes.io/managed-by: Helm
 ---
 # Source: zxporter-nodemon/templates/dcgm-exporter-configmap.yaml
@@ -845,10 +845,10 @@ kind: ClusterRole
 metadata:
   name: zxporter-nodemon
   labels:
-    helm.sh/chart: zxporter-nodemon-0.0.97
+    helm.sh/chart: zxporter-nodemon-0.0.98
     app.kubernetes.io/name: zxporter-nodemon
     app.kubernetes.io/instance: zxporter-nodemon
-    app.kubernetes.io/version: "0.0.97"
+    app.kubernetes.io/version: "0.0.98"
     app.kubernetes.io/managed-by: Helm
 rules:
   - apiGroups:
@@ -895,10 +895,10 @@ kind: ClusterRoleBinding
 metadata:
   name: zxporter-nodemon
   labels:
-    helm.sh/chart: zxporter-nodemon-0.0.97
+    helm.sh/chart: zxporter-nodemon-0.0.98
     app.kubernetes.io/name: zxporter-nodemon
     app.kubernetes.io/instance: zxporter-nodemon
-    app.kubernetes.io/version: "0.0.97"
+    app.kubernetes.io/version: "0.0.98"
     app.kubernetes.io/managed-by: Helm
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -916,10 +916,10 @@ metadata:
   name: zxporter-nodemon
   namespace: {{.zxporter_namespace}}
   labels:
-    helm.sh/chart: zxporter-nodemon-0.0.97
+    helm.sh/chart: zxporter-nodemon-0.0.98
     app.kubernetes.io/name: zxporter-nodemon
     app.kubernetes.io/instance: zxporter-nodemon
-    app.kubernetes.io/version: "0.0.97"
+    app.kubernetes.io/version: "0.0.98"
     app.kubernetes.io/managed-by: Helm
   annotations:
     ignore-check.kube-linter.io/privileged-container: "This daemon set needs to run DCGM Exporter as privileged to access the GPU metrics."
@@ -1051,10 +1051,10 @@ metadata:
   name: zxporter-nodemon-gpu
   namespace: {{.zxporter_namespace}}
   labels:
-    helm.sh/chart: zxporter-nodemon-0.0.97
+    helm.sh/chart: zxporter-nodemon-0.0.98
     app.kubernetes.io/name: zxporter-nodemon
     app.kubernetes.io/instance: zxporter-nodemon-gpu
-    app.kubernetes.io/version: "0.0.97"
+    app.kubernetes.io/version: "0.0.98"
     app.kubernetes.io/managed-by: Helm
   annotations:
     ignore-check.kube-linter.io/privileged-container: "This daemon set needs to run DCGM Exporter as privileged to access the GPU metrics."

--- a/dist/backend-install-gcp-lowpriv.yaml
+++ b/dist/backend-install-gcp-lowpriv.yaml
@@ -1,0 +1,1181 @@
+# ZXPorter installer bundle
+apiVersion: v1
+kind: Namespace
+metadata:
+  labels:
+    control-plane: controller-manager
+    app.kubernetes.io/name: {{.zxporter_namespace}}
+  name: {{.zxporter_namespace}}
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  labels:
+    app.kubernetes.io/managed-by: kustomize
+    app.kubernetes.io/name: devzero-zxporter
+    control-plane: controller-manager
+  name: {{.zxporter_namespace}}
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  labels:
+    app.kubernetes.io/managed-by: kustomize
+    app.kubernetes.io/name: devzero-zxporter
+  name: devzero-zxporter-controller-manager
+  namespace: {{.zxporter_namespace}}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  labels:
+    app.kubernetes.io/managed-by: kustomize
+    app.kubernetes.io/name: devzero-zxporter
+  name: devzero-zxporter-leader-election-role
+  namespace: {{.zxporter_namespace}}
+rules:
+  - apiGroups:
+      - ""
+    resources:
+      - configmaps
+      - deployments
+      - serviceaccounts
+      - services
+    verbs:
+      - get
+      - list
+      - watch
+      - create
+      - update
+      - patch
+      - delete
+  - apiGroups:
+      - apps
+    resources:
+      - deployments
+    verbs:
+      - get
+      - list
+      - watch
+      - create
+      - update
+      - patch
+      - delete
+  - apiGroups:
+      - coordination.k8s.io
+    resources:
+      - leases
+    verbs:
+      - get
+      - list
+      - watch
+      - create
+      - update
+      - patch
+      - delete
+  - apiGroups:
+      - ""
+    resources:
+      - events
+    verbs:
+      - create
+      - patch
+  - apiGroups:
+      - rbac.authorization.k8s.io
+    resources:
+      - rolebindings
+      - roles
+      - clusterrolebindings
+      - clusterroles
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    app.kubernetes.io/managed-by: kustomize
+    app.kubernetes.io/name: devzero-zxporter
+  name: devzero-zxporter-collectionpolicy-editor-role
+rules:
+  - apiGroups:
+      - devzero.io
+    resources:
+      - collectionpolicies
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - devzero.io
+    resources:
+      - collectionpolicies/status
+    verbs:
+      - get
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    app.kubernetes.io/managed-by: kustomize
+    app.kubernetes.io/name: devzero-zxporter
+  name: devzero-zxporter-collectionpolicy-viewer-role
+rules:
+  - apiGroups:
+      - devzero.io
+    resources:
+      - collectionpolicies
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - devzero.io
+    resources:
+      - collectionpolicies/status
+    verbs:
+      - get
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: devzero-zxporter-manager-role
+rules:
+  - apiGroups:
+      - ""
+    resources:
+      - configmaps
+    verbs:
+      - get
+      - list
+      - update
+      - watch
+  - apiGroups:
+      - ""
+    resources:
+      - endpoints
+      - events
+      - limitranges
+      - namespaces
+      - nodes
+      - persistentvolumeclaims
+      - persistentvolumes
+      - pods
+      - replicationcontrollers
+      - resourcequotas
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - ""
+    resources:
+      - nodes/metrics
+      - nodes/proxy
+      - nodes/status
+      - pods/status
+    verbs:
+      - get
+  - apiGroups:
+      - ""
+    resources:
+      - secrets
+    verbs:
+      - create
+  - apiGroups:
+      - ""
+    resourceNames:
+      - devzero-zxporter-token
+    resources:
+      - secrets
+    verbs:
+      - get
+      - patch
+      - update
+  - apiGroups:
+      - ""
+    resources:
+      - serviceaccounts
+      - services
+    verbs:
+      - create
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - apiextensions.k8s.io
+    resources:
+      - customresourcedefinitions
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - apiregistration.k8s.io
+    resources:
+      - apiservices
+    verbs:
+      - create
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - apps
+    resources:
+      - daemonsets
+      - replicasets
+      - statefulsets
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - apps
+    resources:
+      - deployments
+    verbs:
+      - create
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - argoproj.io
+    resources:
+      - rollouts
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - autoscaling
+    resources:
+      - horizontalpodautoscalers
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - autoscaling.k8s.io
+    resources:
+      - verticalpodautoscalers
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - batch
+    resources:
+      - cronjobs
+      - jobs
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - batch.volcano.sh
+    resources:
+      - jobs
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - dakr.devzero.io
+    resources:
+      - workloadrecommendations
+      - workloadrules
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - datadoghq.com
+    resources:
+      - extendeddaemonsetreplicasets
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - devzero.io
+    resources:
+      - collectionpolicies
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - devzero.io
+    resources:
+      - collectionpolicies/finalizers
+    verbs:
+      - update
+  - apiGroups:
+      - devzero.io
+    resources:
+      - collectionpolicies/status
+    verbs:
+      - get
+      - patch
+      - update
+  - apiGroups:
+      - devzero.karpenter.sh
+    resources:
+      - karpentersettings
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - karpenter.azure.com
+    resources:
+      - aksnodeclasses
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - karpenter.k8s.aws
+    resources:
+      - awsnodetemplates
+      - ec2nodeclasses
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - karpenter.k8s.gcp
+    resources:
+      - gcenodeclasses
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - karpenter.k8s.oracle
+    resources:
+      - ocinodeclasses
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - karpenter.sh
+    resources:
+      - machines
+      - nodeclaims
+      - nodeoverlays
+      - nodepools
+      - provisioners
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - keda.sh
+    resources:
+      - clustertriggerauthentications
+      - scaledjobs
+      - scaledobjects
+      - triggerauthentications
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - kubeflow.org
+    resources:
+      - notebooks
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - metrics.k8s.io
+    resources:
+      - nodes
+      - pods
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - networking.k8s.io
+    resources:
+      - ingressclasses
+      - ingresses
+      - networkpolicies
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - policy
+    resources:
+      - poddisruptionbudgets
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - postgresql.cnpg.io
+    resources:
+      - clusters
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - rbac.authorization.k8s.io
+    resources:
+      - clusterrolebindings
+      - clusterroles
+      - rolebindings
+    verbs:
+      - create
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - rbac.authorization.k8s.io
+    resources:
+      - roles
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - sparkoperator.k8s.io
+    resources:
+      - scheduledsparkapplications
+      - sparkapplications
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - storage.k8s.io
+    resources:
+      - csidrivers
+      - csinodes
+      - csistoragecapacities
+      - storageclasses
+      - volumeattachments
+    verbs:
+      - get
+      - list
+      - watch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: devzero-zxporter-metrics-auth-role
+rules:
+  - apiGroups:
+      - authentication.k8s.io
+    resources:
+      - tokenreviews
+    verbs:
+      - create
+  - apiGroups:
+      - authorization.k8s.io
+    resources:
+      - subjectaccessreviews
+    verbs:
+      - create
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: devzero-zxporter-metrics-reader
+rules:
+  - nonResourceURLs:
+      - /metrics
+    verbs:
+      - get
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  labels:
+    app.kubernetes.io/managed-by: kustomize
+    app.kubernetes.io/name: devzero-zxporter
+  name: devzero-zxporter-leader-election-rolebinding
+  namespace: {{.zxporter_namespace}}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: devzero-zxporter-leader-election-role
+subjects:
+  - kind: ServiceAccount
+    name: devzero-zxporter-controller-manager
+    namespace: {{.zxporter_namespace}}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  labels:
+    app.kubernetes.io/managed-by: kustomize
+    app.kubernetes.io/name: devzero-zxporter
+  name: devzero-zxporter-manager-rolebinding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: devzero-zxporter-manager-role
+subjects:
+  - kind: ServiceAccount
+    name: devzero-zxporter-controller-manager
+    namespace: {{.zxporter_namespace}}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: devzero-zxporter-metrics-auth-rolebinding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: devzero-zxporter-metrics-auth-role
+subjects:
+  - kind: ServiceAccount
+    name: devzero-zxporter-controller-manager
+    namespace: {{.zxporter_namespace}}
+---
+apiVersion: v1
+data:
+  BUFFER_SIZE: ""
+  CLUSTER_TOKEN: ""
+  COLLECTION_FREQUENCY: ""
+  DAKR_URL: '{{ .api_url }}/dakr'
+  DISABLED_COLLECTORS: ""
+  EXCLUDED_CLUSTERROLEBINDINGS: ""
+  EXCLUDED_CLUSTERROLES: ""
+  EXCLUDED_CRDGROUPS: ""
+  EXCLUDED_CRDS: ""
+  EXCLUDED_CRONJOBS: ""
+  EXCLUDED_DAEMONSETS: ""
+  EXCLUDED_DEPLOYMENTS: ""
+  EXCLUDED_ENDPOINTS: ""
+  EXCLUDED_EVENTS: ""
+  EXCLUDED_HPAS: ""
+  EXCLUDED_INGRESSCLASSES: ""
+  EXCLUDED_INGRESSES: ""
+  EXCLUDED_JOBS: ""
+  EXCLUDED_LIMITRANGES: ""
+  EXCLUDED_NAMESPACES: ""
+  EXCLUDED_NETWORKPOLICIES: ""
+  EXCLUDED_NODES: ""
+  EXCLUDED_PDBS: ""
+  EXCLUDED_PODS: ""
+  EXCLUDED_PSPS: ""
+  EXCLUDED_PVCS: ""
+  EXCLUDED_PVS: ""
+  EXCLUDED_REPLICATIONCONTROLLERS: ""
+  EXCLUDED_RESOURCEQUOTAS: ""
+  EXCLUDED_ROLEBINDINGS: ""
+  EXCLUDED_ROLES: ""
+  EXCLUDED_SERVICEACCOUNTS: ""
+  EXCLUDED_SERVICES: ""
+  EXCLUDED_STATEFULSETS: ""
+  EXCLUDED_STORAGECLASSES: ""
+  EXCLUDED_VPAS: ""
+  K8S_PROVIDER: '{{ .k8s_provider }}'
+  KUBE_CONTEXT_NAME: '{{ .kube_context_name }}'
+  MASK_SECRET_DATA: ""
+  NODE_METRICS_INTERVAL: ""
+  TARGET_NAMESPACES: ""
+  TOKEN_CONFIGMAP_NAME: devzero-zxporter-env-config
+  TOKEN_CREDENTIALS_SECRET_NAME: devzero-zxporter-credentials
+  TOKEN_RUNTIME_SECRET_NAME: devzero-zxporter-token
+  TOKEN_SECRET_NAME: devzero-zxporter-token
+  USE_SECRET_FOR_TOKEN: "true"
+  WATCHED_CRDS: ""
+kind: ConfigMap
+metadata:
+  name: devzero-zxporter-env-config
+  namespace: {{.zxporter_namespace}}
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: devzero-zxporter-token
+  namespace: {{.zxporter_namespace}}
+stringData:
+  CLUSTER_TOKEN: '{{ .cluster_token }}'
+type: Opaque
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app.kubernetes.io/managed-by: kustomize
+    app.kubernetes.io/name: devzero-zxporter
+    control-plane: controller-manager
+  name: devzero-zxporter-controller-manager-metrics-service
+  namespace: {{.zxporter_namespace}}
+spec:
+  ports:
+    - name: https
+      port: 8443
+      protocol: TCP
+      targetPort: 8443
+  selector:
+    control-plane: controller-manager
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app.kubernetes.io/name: devzero-zxporter
+    control-plane: controller-manager
+  name: devzero-zxporter-controller-manager-mpa
+  namespace: {{.zxporter_namespace}}
+spec:
+  ports:
+    - name: mpa-grpc
+      port: 50051
+      protocol: TCP
+      targetPort: mpa-grpc
+  selector:
+    control-plane: controller-manager
+  type: ClusterIP
+---
+apiVersion: scheduling.k8s.io/v1
+description: This priority class is for critical zxporter infrastructure components.
+globalDefault: false
+kind: PriorityClass
+metadata:
+  name: devzero-zxporter-devzero-zxporter-critical
+preemptionPolicy: PreemptLowerPriority
+value: 1000000000
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app.kubernetes.io/managed-by: kustomize
+    app.kubernetes.io/name: devzero-zxporter
+    control-plane: controller-manager
+  name: devzero-zxporter-controller-manager
+  namespace: {{.zxporter_namespace}}
+spec:
+  replicas: 2
+  selector:
+    matchLabels:
+      control-plane: controller-manager
+  template:
+    metadata:
+      annotations:
+        kubectl.kubernetes.io/default-container: manager
+      labels:
+        app.kubernetes.io/instance: zxporter
+        app.kubernetes.io/name: zxporter
+        control-plane: controller-manager
+    spec:
+      containers:
+        - args:
+            - --metrics-bind-address=:8443
+            - --leader-elect
+            - --mpa-server-port=50051
+            - --health-probe-bind-address=:8081
+          env:
+            - name: POD_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+            - name: CLUSTER_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  key: CLUSTER_TOKEN
+                  name: devzero-zxporter-token
+                  optional: true
+          image: docker.io/devzeroinc/zxporter:latest
+          livenessProbe:
+            httpGet:
+              path: /healthz
+              port: 8081
+            initialDelaySeconds: 15
+            periodSeconds: 20
+          name: manager
+          ports:
+            - containerPort: 50051
+              name: mpa-grpc
+              protocol: TCP
+          readinessProbe:
+            httpGet:
+              path: /readyz
+              port: 8081
+            initialDelaySeconds: 5
+            periodSeconds: 10
+          resources:
+            requests:
+              cpu: 200m
+              memory: 2Gi
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
+          volumeMounts:
+            - mountPath: /etc/zxporter/config
+              name: config-volume
+              readOnly: true
+      priorityClassName: devzero-zxporter-devzero-zxporter-critical
+      securityContext:
+        runAsNonRoot: true
+      serviceAccountName: devzero-zxporter-controller-manager
+      terminationGracePeriodSeconds: 10
+      volumes:
+        - configMap:
+            name: devzero-zxporter-env-config
+          name: config-volume
+---
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: devzero-zxporter-devzero-zxporter-pdb
+  namespace: {{.zxporter_namespace}}
+spec:
+  minAvailable: 1
+  selector:
+    matchLabels:
+      control-plane: controller-manager
+---
+# Source: zxporter-nodemon/templates/rbac.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: zxporter-nodemon
+  namespace: {{.zxporter_namespace}}
+  labels:
+    helm.sh/chart: zxporter-nodemon-0.0.97
+    app.kubernetes.io/name: zxporter-nodemon
+    app.kubernetes.io/instance: zxporter-nodemon
+    app.kubernetes.io/version: "0.0.97"
+    app.kubernetes.io/managed-by: Helm
+---
+# Source: zxporter-nodemon/templates/dcgm-exporter-configmap.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: zxporter-nodemon-dcgm-metrics
+  namespace: {{.zxporter_namespace}}
+data:
+  counters.csv: |
+    # Temperature and power usage,,
+    DCGM_FI_DEV_GPU_TEMP, gauge, Current temperature readings for the device in degrees C.
+    DCGM_FI_DEV_MEMORY_TEMP, gauge, Memory temperature for the device.
+    DCGM_FI_DEV_POWER_USAGE, gauge, Power usage for the device in Watts.
+
+    # Utilization,,
+    # DCGM_FI_DEV_GPU_UTIL provides overall GPU utilization which is useful for scenarios
+    # like fractional GPU sharing (e.g., EKS time-slicing, MIG) where profiling metrics may not be available.
+    DCGM_FI_DEV_GPU_UTIL, gauge, GPU utilization (in %).
+    # DCGM_FI_PROF_SM_ACTIVE, gauge, The ratio of cycles an SM has at least 1 warp assigned
+    # DCGM_FI_PROF_SM_OCCUPANCY, gauge, The fraction of resident warps on a multiprocessor
+    # DCGM_FI_PROF_GR_ENGINE_ACTIVE, gauge, Ratio of time the graphics engine is active (in %).
+    # DCGM_FI_PROF_DRAM_ACTIVE, gauge, The ratio of cycles the device memory interface is active sending or receiving data.
+
+    # Memory usage,,
+    DCGM_FI_DEV_FB_FREE, gauge, Framebuffer memory free (in MiB).
+    DCGM_FI_DEV_FB_USED, gauge, Framebuffer memory used (in MiB).
+    DCGM_FI_DEV_FB_TOTAL, gauge, Total Frame Buffer of the GPU in MB.
+    DCGM_FI_DEV_MEM_COPY_UTIL, gauge, Utilization of the memory copy engine.
+
+    # PCIE,,
+    # DCGM_FI_PROF_PCIE_TX_BYTES, gauge, Total number of bytes transmitted through PCIe TX
+    # DCGM_FI_PROF_PCIE_RX_BYTES, gauge, Total number of bytes received through PCIe RX
+    DCGM_FI_DEV_PCIE_LINK_GEN, gauge, PCIe Current Link Generation.
+    DCGM_FI_DEV_PCIE_LINK_WIDTH, gauge, PCIe Current Link Width.
+
+    # Pipelines,,
+    # DCGM_FI_PROF_PIPE_INT_ACTIVE, gauge, Ratio of cycles the integer pipe is active.
+    # DCGM_FI_PROF_PIPE_FP16_ACTIVE, gauge, Ratio of cycles the fp16 pipe is active.
+    # DCGM_FI_PROF_PIPE_FP32_ACTIVE, gauge, Ratio of cycles the fp32 pipe is active.
+    # DCGM_FI_PROF_PIPE_FP64_ACTIVE, gauge, Ratio of cycles the fp64 pipe is active.
+    # DCGM_FI_PROF_PIPE_TENSOR_ACTIVE, gauge, The ratio of cycles the tensor (HMMA) pipe is active (off the peak sustained elapsed cycles)
+
+    # Health,,
+    # DCGM_FI_DEV_CLOCKS_EVENT_REASONS is not supported by DCGM 3.3.7
+    # DCGM_FI_DEV_CLOCKS_EVENT_REASONS, gauge, Current clock event reasons (bitmask of DCGM_CLOCKS_EVENT_REASON_*)
+    DCGM_FI_DEV_XID_ERRORS, gauge, The value is the specific XID error
+    DCGM_FI_DEV_POWER_VIOLATION, gauge, Power Violation time in ns.
+    DCGM_FI_DEV_THERMAL_VIOLATION, gauge, Thermal Violation time in ns.
+
+    # NVLink,,
+    # DCGM_FI_PROF_NVLINK_TX_BYTES, gauge, The number of bytes of active NvLink tx (transmit) data including both header and payload.
+    # DCGM_FI_PROF_NVLINK_RX_BYTES, gauge, The number of bytes of active NvLink rx (read) data including both header and payload.
+
+    # Clocks,,
+    DCGM_FI_DEV_SM_CLOCK, gauge, SM clock frequency (in MHz).
+    DCGM_FI_DEV_MEM_CLOCK, gauge, Memory clock frequency (in MHz).
+---
+# Source: zxporter-nodemon/templates/nodemon-configmap.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: zxporter-nodemon-zxporter-nodemon
+  namespace: {{.zxporter_namespace}}
+data:
+---
+# Source: zxporter-nodemon/templates/rbac.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: zxporter-nodemon
+  labels:
+    helm.sh/chart: zxporter-nodemon-0.0.97
+    app.kubernetes.io/name: zxporter-nodemon
+    app.kubernetes.io/instance: zxporter-nodemon
+    app.kubernetes.io/version: "0.0.97"
+    app.kubernetes.io/managed-by: Helm
+rules:
+  - apiGroups:
+      - ""
+    resources:
+      - pods
+    verbs:
+      - get
+      - list
+  - apiGroups:
+      - apps
+    resources:
+      - replicasets
+      - deployments
+      - statefulsets
+      - daemonsets
+    verbs:
+      - get
+  - apiGroups:
+      - batch
+    resources:
+      - jobs
+      - cronjobs
+    verbs:
+      - get
+  - apiGroups:
+      - argoproj.io
+    resources:
+      - rollouts
+    verbs:
+      - get
+  - apiGroups:
+      - ""
+    resources:
+      - nodes/proxy
+      - nodes/metrics
+      - nodes/stats
+    verbs:
+      - get
+---
+# Source: zxporter-nodemon/templates/rbac.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: zxporter-nodemon
+  labels:
+    helm.sh/chart: zxporter-nodemon-0.0.97
+    app.kubernetes.io/name: zxporter-nodemon
+    app.kubernetes.io/instance: zxporter-nodemon
+    app.kubernetes.io/version: "0.0.97"
+    app.kubernetes.io/managed-by: Helm
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: zxporter-nodemon
+subjects:
+  - kind: ServiceAccount
+    name: zxporter-nodemon
+    namespace: {{.zxporter_namespace}}
+---
+# Source: zxporter-nodemon/templates/daemonset.yaml
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: zxporter-nodemon
+  namespace: {{.zxporter_namespace}}
+  labels:
+    helm.sh/chart: zxporter-nodemon-0.0.97
+    app.kubernetes.io/name: zxporter-nodemon
+    app.kubernetes.io/instance: zxporter-nodemon
+    app.kubernetes.io/version: "0.0.97"
+    app.kubernetes.io/managed-by: Helm
+  annotations:
+    ignore-check.kube-linter.io/privileged-container: "This daemon set needs to run DCGM Exporter as privileged to access the GPU metrics."
+    ignore-check.kube-linter.io/run-as-non-root: "This daemon set needs to run DCGM Exporter as root to access the GPU metrics."
+    ignore-check.kube-linter.io/privilege-escalation-container: "This daemon set needs escalate privileges for DCGM Exporter."
+    ignore-check.kube-linter.io/no-read-only-root-fs: "This daemon set needs to run DCGM Exporter with read-only root filesystem."
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: zxporter-nodemon
+      app.kubernetes.io/instance: zxporter-nodemon
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: zxporter-nodemon
+        app.kubernetes.io/instance: zxporter-nodemon
+    spec:
+      priorityClassName: devzero-zxporter-devzero-zxporter-critical
+      serviceAccountName: zxporter-nodemon
+      volumes:
+        - name: "pod-gpu-resources"
+          hostPath:
+            path: /var/lib/kubelet/pod-resources
+        - name: zxporter-nodemon-dcgm-metrics
+          configMap:
+            name: zxporter-nodemon-dcgm-metrics
+        - name: "nvidia-install-dir-host"
+          hostPath:
+            path: /home/kubernetes/bin/nvidia
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+              - matchExpressions:
+                  - key: nvidia.com/gpu.present
+                    operator: NotIn
+                    values:
+                      - "true"
+      tolerations:
+        - effect: NoExecute
+          operator: Exists
+        - effect: NoSchedule
+          operator: Exists
+        - effect: PreferNoSchedule
+          operator: Exists
+      containers:
+        - name: zxporter-nodemon
+          securityContext:
+            readOnlyRootFilesystem: true
+            runAsNonRoot: true
+          image: "docker.io/devzeroinc/zxporter-nodemon:latest"
+          imagePullPolicy: IfNotPresent
+          ports:
+            - name: http
+              containerPort: 6061
+              protocol: TCP
+          livenessProbe:
+            httpGet:
+              path: /healthz
+              port: http
+          readinessProbe:
+            httpGet:
+              path: /healthz
+              port: http
+          envFrom:
+            - configMapRef:
+                name: zxporter-nodemon-zxporter-nodemon
+          env:
+            - name: "NODE_NAME"
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.nodeName
+            - name: "RUNTIME_METRICS_ENABLED"
+              value: "false"
+            - name: "DCGM_HOST"
+              value: "localhost"
+          resources:
+            limits:
+              memory: 256Mi
+            requests:
+              cpu: 60m
+              memory: 256Mi
+        - name: dcgm-exporter
+          securityContext:
+            capabilities:
+              add:
+                - SYS_ADMIN
+              drop:
+                - NET_RAW
+            runAsNonRoot: false
+            runAsUser: 0
+            privileged: true
+          image: "nvcr.io/nvidia/k8s/dcgm-exporter:4.5.2-4.8.1-ubuntu22.04"
+          imagePullPolicy: IfNotPresent
+          command: ["/bin/bash", "-c"]
+          args:
+            - hostname $NODE_NAME; for ((;;)) { r=$(dcgm-exporter -f /etc/dcgm-exporter/counters.csv); echo "dcgm-exporter could not run"; sleep 60 ; }
+          ports:
+            - name: "metrics"
+              containerPort: 9400
+          env:
+            - name: "DCGM_EXPORTER_KUBERNETES"
+              value: "true"
+            - name: "DCGM_EXPORTER_LISTEN"
+              value: ":9400"
+            - name: "DCGM_EXPORTER_INTERVAL"
+              value: "5000"
+            - name: "NODE_NAME"
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.nodeName
+            - name: "LD_LIBRARY_PATH"
+              value: "/usr/local/nvidia/lib64"
+            - name: "DCGM_EXPORTER_KUBERNETES_GPU_ID_TYPE"
+              value: "device-name"
+          volumeMounts:
+            - name: "pod-gpu-resources"
+              readOnly: true
+              mountPath: "/var/lib/kubelet/pod-resources"
+            - name: "nvidia-install-dir-host"
+              mountPath: /usr/local/nvidia
+            - name: zxporter-nodemon-dcgm-metrics
+              mountPath: "/etc/dcgm-exporter"
+---
+# Source: zxporter-nodemon/templates/daemonset.yaml
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: zxporter-nodemon-gpu
+  namespace: {{.zxporter_namespace}}
+  labels:
+    helm.sh/chart: zxporter-nodemon-0.0.97
+    app.kubernetes.io/name: zxporter-nodemon
+    app.kubernetes.io/instance: zxporter-nodemon-gpu
+    app.kubernetes.io/version: "0.0.97"
+    app.kubernetes.io/managed-by: Helm
+  annotations:
+    ignore-check.kube-linter.io/privileged-container: "This daemon set needs to run DCGM Exporter as privileged to access the GPU metrics."
+    ignore-check.kube-linter.io/run-as-non-root: "This daemon set needs to run DCGM Exporter as root to access the GPU metrics."
+    ignore-check.kube-linter.io/privilege-escalation-container: "This daemon set needs escalate privileges for DCGM Exporter."
+    ignore-check.kube-linter.io/no-read-only-root-fs: "This daemon set needs to run DCGM Exporter with read-only root filesystem."
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: zxporter-nodemon
+      app.kubernetes.io/instance: zxporter-nodemon-gpu
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: zxporter-nodemon
+        app.kubernetes.io/instance: zxporter-nodemon-gpu
+    spec:
+      priorityClassName: devzero-zxporter-devzero-zxporter-critical
+      runtimeClassName: "nvidia"
+      serviceAccountName: zxporter-nodemon
+      volumes:
+        - name: "pod-gpu-resources"
+          hostPath:
+            path: /var/lib/kubelet/pod-resources
+        - name: zxporter-nodemon-dcgm-metrics
+          configMap:
+            name: zxporter-nodemon-dcgm-metrics
+        - name: "nvidia-install-dir-host"
+          hostPath:
+            path: /home/kubernetes/bin/nvidia
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+              - matchExpressions:
+                  - key: nvidia.com/gpu.present
+                    operator: In
+                    values:
+                      - "true"
+      tolerations:
+        - effect: NoExecute
+          operator: Exists
+        - effect: NoSchedule
+          operator: Exists
+        - effect: PreferNoSchedule
+          operator: Exists
+      containers:
+        - name: zxporter-nodemon
+          securityContext:
+            readOnlyRootFilesystem: true
+            runAsNonRoot: true
+          image: "docker.io/devzeroinc/zxporter-nodemon:latest"
+          imagePullPolicy: IfNotPresent
+          ports:
+            - name: http
+              containerPort: 6061
+              protocol: TCP
+          livenessProbe:
+            httpGet:
+              path: /healthz
+              port: http
+          readinessProbe:
+            httpGet:
+              path: /healthz
+              port: http
+          envFrom:
+            - configMapRef:
+                name: zxporter-nodemon-zxporter-nodemon
+          env:
+            - name: "NODE_NAME"
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.nodeName
+            - name: "RUNTIME_METRICS_ENABLED"
+              value: "false"
+            - name: "DCGM_HOST"
+              value: "localhost"
+          resources:
+            limits:
+              memory: 256Mi
+            requests:
+              cpu: 60m
+              memory: 256Mi
+        - name: dcgm-exporter
+          securityContext:
+            capabilities:
+              add:
+                - SYS_ADMIN
+              drop:
+                - NET_RAW
+            runAsNonRoot: false
+            runAsUser: 0
+            privileged: true
+          image: "nvcr.io/nvidia/k8s/dcgm-exporter:4.5.2-4.8.1-ubuntu22.04"
+          imagePullPolicy: IfNotPresent
+          command: ["/bin/bash", "-c"]
+          args:
+            - hostname $NODE_NAME; for ((;;)) { r=$(dcgm-exporter -f /etc/dcgm-exporter/counters.csv); echo "dcgm-exporter could not run"; sleep 60 ; }
+          ports:
+            - name: "metrics"
+              containerPort: 9400
+          env:
+            - name: "DCGM_EXPORTER_KUBERNETES"
+              value: "true"
+            - name: "DCGM_EXPORTER_LISTEN"
+              value: ":9400"
+            - name: "DCGM_EXPORTER_INTERVAL"
+              value: "5000"
+            - name: "NODE_NAME"
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.nodeName
+            - name: "LD_LIBRARY_PATH"
+              value: "/usr/local/nvidia/lib64"
+            - name: "DCGM_EXPORTER_KUBERNETES_GPU_ID_TYPE"
+              value: "device-name"
+          volumeMounts:
+            - name: "pod-gpu-resources"
+              readOnly: true
+              mountPath: "/var/lib/kubelet/pod-resources"
+            - name: "nvidia-install-dir-host"
+              mountPath: /usr/local/nvidia
+            - name: zxporter-nodemon-dcgm-metrics
+              mountPath: "/etc/dcgm-exporter"

--- a/dist/backend-install-lowpriv.yaml
+++ b/dist/backend-install-lowpriv.yaml
@@ -1,0 +1,1161 @@
+# ZXPorter installer bundle
+apiVersion: v1
+kind: Namespace
+metadata:
+  labels:
+    control-plane: controller-manager
+    app.kubernetes.io/name: {{.zxporter_namespace}}
+  name: {{.zxporter_namespace}}
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  labels:
+    app.kubernetes.io/managed-by: kustomize
+    app.kubernetes.io/name: devzero-zxporter
+    control-plane: controller-manager
+  name: {{.zxporter_namespace}}
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  labels:
+    app.kubernetes.io/managed-by: kustomize
+    app.kubernetes.io/name: devzero-zxporter
+  name: devzero-zxporter-controller-manager
+  namespace: {{.zxporter_namespace}}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  labels:
+    app.kubernetes.io/managed-by: kustomize
+    app.kubernetes.io/name: devzero-zxporter
+  name: devzero-zxporter-leader-election-role
+  namespace: {{.zxporter_namespace}}
+rules:
+  - apiGroups:
+      - ""
+    resources:
+      - configmaps
+      - deployments
+      - serviceaccounts
+      - services
+    verbs:
+      - get
+      - list
+      - watch
+      - create
+      - update
+      - patch
+      - delete
+  - apiGroups:
+      - apps
+    resources:
+      - deployments
+    verbs:
+      - get
+      - list
+      - watch
+      - create
+      - update
+      - patch
+      - delete
+  - apiGroups:
+      - coordination.k8s.io
+    resources:
+      - leases
+    verbs:
+      - get
+      - list
+      - watch
+      - create
+      - update
+      - patch
+      - delete
+  - apiGroups:
+      - ""
+    resources:
+      - events
+    verbs:
+      - create
+      - patch
+  - apiGroups:
+      - rbac.authorization.k8s.io
+    resources:
+      - rolebindings
+      - roles
+      - clusterrolebindings
+      - clusterroles
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    app.kubernetes.io/managed-by: kustomize
+    app.kubernetes.io/name: devzero-zxporter
+  name: devzero-zxporter-collectionpolicy-editor-role
+rules:
+  - apiGroups:
+      - devzero.io
+    resources:
+      - collectionpolicies
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - devzero.io
+    resources:
+      - collectionpolicies/status
+    verbs:
+      - get
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    app.kubernetes.io/managed-by: kustomize
+    app.kubernetes.io/name: devzero-zxporter
+  name: devzero-zxporter-collectionpolicy-viewer-role
+rules:
+  - apiGroups:
+      - devzero.io
+    resources:
+      - collectionpolicies
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - devzero.io
+    resources:
+      - collectionpolicies/status
+    verbs:
+      - get
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: devzero-zxporter-manager-role
+rules:
+  - apiGroups:
+      - ""
+    resources:
+      - configmaps
+    verbs:
+      - get
+      - list
+      - update
+      - watch
+  - apiGroups:
+      - ""
+    resources:
+      - endpoints
+      - events
+      - limitranges
+      - namespaces
+      - nodes
+      - persistentvolumeclaims
+      - persistentvolumes
+      - pods
+      - replicationcontrollers
+      - resourcequotas
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - ""
+    resources:
+      - nodes/metrics
+      - nodes/proxy
+      - nodes/status
+      - pods/status
+    verbs:
+      - get
+  - apiGroups:
+      - ""
+    resources:
+      - secrets
+    verbs:
+      - create
+  - apiGroups:
+      - ""
+    resourceNames:
+      - devzero-zxporter-token
+    resources:
+      - secrets
+    verbs:
+      - get
+      - patch
+      - update
+  - apiGroups:
+      - ""
+    resources:
+      - serviceaccounts
+      - services
+    verbs:
+      - create
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - apiextensions.k8s.io
+    resources:
+      - customresourcedefinitions
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - apiregistration.k8s.io
+    resources:
+      - apiservices
+    verbs:
+      - create
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - apps
+    resources:
+      - daemonsets
+      - replicasets
+      - statefulsets
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - apps
+    resources:
+      - deployments
+    verbs:
+      - create
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - argoproj.io
+    resources:
+      - rollouts
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - autoscaling
+    resources:
+      - horizontalpodautoscalers
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - autoscaling.k8s.io
+    resources:
+      - verticalpodautoscalers
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - batch
+    resources:
+      - cronjobs
+      - jobs
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - batch.volcano.sh
+    resources:
+      - jobs
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - dakr.devzero.io
+    resources:
+      - workloadrecommendations
+      - workloadrules
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - datadoghq.com
+    resources:
+      - extendeddaemonsetreplicasets
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - devzero.io
+    resources:
+      - collectionpolicies
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - devzero.io
+    resources:
+      - collectionpolicies/finalizers
+    verbs:
+      - update
+  - apiGroups:
+      - devzero.io
+    resources:
+      - collectionpolicies/status
+    verbs:
+      - get
+      - patch
+      - update
+  - apiGroups:
+      - devzero.karpenter.sh
+    resources:
+      - karpentersettings
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - karpenter.azure.com
+    resources:
+      - aksnodeclasses
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - karpenter.k8s.aws
+    resources:
+      - awsnodetemplates
+      - ec2nodeclasses
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - karpenter.k8s.gcp
+    resources:
+      - gcenodeclasses
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - karpenter.k8s.oracle
+    resources:
+      - ocinodeclasses
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - karpenter.sh
+    resources:
+      - machines
+      - nodeclaims
+      - nodeoverlays
+      - nodepools
+      - provisioners
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - keda.sh
+    resources:
+      - clustertriggerauthentications
+      - scaledjobs
+      - scaledobjects
+      - triggerauthentications
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - kubeflow.org
+    resources:
+      - notebooks
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - metrics.k8s.io
+    resources:
+      - nodes
+      - pods
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - networking.k8s.io
+    resources:
+      - ingressclasses
+      - ingresses
+      - networkpolicies
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - policy
+    resources:
+      - poddisruptionbudgets
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - postgresql.cnpg.io
+    resources:
+      - clusters
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - rbac.authorization.k8s.io
+    resources:
+      - clusterrolebindings
+      - clusterroles
+      - rolebindings
+    verbs:
+      - create
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - rbac.authorization.k8s.io
+    resources:
+      - roles
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - sparkoperator.k8s.io
+    resources:
+      - scheduledsparkapplications
+      - sparkapplications
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - storage.k8s.io
+    resources:
+      - csidrivers
+      - csinodes
+      - csistoragecapacities
+      - storageclasses
+      - volumeattachments
+    verbs:
+      - get
+      - list
+      - watch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: devzero-zxporter-metrics-auth-role
+rules:
+  - apiGroups:
+      - authentication.k8s.io
+    resources:
+      - tokenreviews
+    verbs:
+      - create
+  - apiGroups:
+      - authorization.k8s.io
+    resources:
+      - subjectaccessreviews
+    verbs:
+      - create
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: devzero-zxporter-metrics-reader
+rules:
+  - nonResourceURLs:
+      - /metrics
+    verbs:
+      - get
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  labels:
+    app.kubernetes.io/managed-by: kustomize
+    app.kubernetes.io/name: devzero-zxporter
+  name: devzero-zxporter-leader-election-rolebinding
+  namespace: {{.zxporter_namespace}}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: devzero-zxporter-leader-election-role
+subjects:
+  - kind: ServiceAccount
+    name: devzero-zxporter-controller-manager
+    namespace: {{.zxporter_namespace}}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  labels:
+    app.kubernetes.io/managed-by: kustomize
+    app.kubernetes.io/name: devzero-zxporter
+  name: devzero-zxporter-manager-rolebinding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: devzero-zxporter-manager-role
+subjects:
+  - kind: ServiceAccount
+    name: devzero-zxporter-controller-manager
+    namespace: {{.zxporter_namespace}}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: devzero-zxporter-metrics-auth-rolebinding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: devzero-zxporter-metrics-auth-role
+subjects:
+  - kind: ServiceAccount
+    name: devzero-zxporter-controller-manager
+    namespace: {{.zxporter_namespace}}
+---
+apiVersion: v1
+data:
+  BUFFER_SIZE: ""
+  CLUSTER_TOKEN: ""
+  COLLECTION_FREQUENCY: ""
+  DAKR_URL: '{{ .api_url }}/dakr'
+  DISABLED_COLLECTORS: ""
+  EXCLUDED_CLUSTERROLEBINDINGS: ""
+  EXCLUDED_CLUSTERROLES: ""
+  EXCLUDED_CRDGROUPS: ""
+  EXCLUDED_CRDS: ""
+  EXCLUDED_CRONJOBS: ""
+  EXCLUDED_DAEMONSETS: ""
+  EXCLUDED_DEPLOYMENTS: ""
+  EXCLUDED_ENDPOINTS: ""
+  EXCLUDED_EVENTS: ""
+  EXCLUDED_HPAS: ""
+  EXCLUDED_INGRESSCLASSES: ""
+  EXCLUDED_INGRESSES: ""
+  EXCLUDED_JOBS: ""
+  EXCLUDED_LIMITRANGES: ""
+  EXCLUDED_NAMESPACES: ""
+  EXCLUDED_NETWORKPOLICIES: ""
+  EXCLUDED_NODES: ""
+  EXCLUDED_PDBS: ""
+  EXCLUDED_PODS: ""
+  EXCLUDED_PSPS: ""
+  EXCLUDED_PVCS: ""
+  EXCLUDED_PVS: ""
+  EXCLUDED_REPLICATIONCONTROLLERS: ""
+  EXCLUDED_RESOURCEQUOTAS: ""
+  EXCLUDED_ROLEBINDINGS: ""
+  EXCLUDED_ROLES: ""
+  EXCLUDED_SERVICEACCOUNTS: ""
+  EXCLUDED_SERVICES: ""
+  EXCLUDED_STATEFULSETS: ""
+  EXCLUDED_STORAGECLASSES: ""
+  EXCLUDED_VPAS: ""
+  K8S_PROVIDER: '{{ .k8s_provider }}'
+  KUBE_CONTEXT_NAME: '{{ .kube_context_name }}'
+  MASK_SECRET_DATA: ""
+  NODE_METRICS_INTERVAL: ""
+  TARGET_NAMESPACES: ""
+  TOKEN_CONFIGMAP_NAME: devzero-zxporter-env-config
+  TOKEN_CREDENTIALS_SECRET_NAME: devzero-zxporter-credentials
+  TOKEN_RUNTIME_SECRET_NAME: devzero-zxporter-token
+  TOKEN_SECRET_NAME: devzero-zxporter-token
+  USE_SECRET_FOR_TOKEN: "true"
+  WATCHED_CRDS: ""
+kind: ConfigMap
+metadata:
+  name: devzero-zxporter-env-config
+  namespace: {{.zxporter_namespace}}
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: devzero-zxporter-token
+  namespace: {{.zxporter_namespace}}
+stringData:
+  CLUSTER_TOKEN: '{{ .cluster_token }}'
+type: Opaque
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app.kubernetes.io/managed-by: kustomize
+    app.kubernetes.io/name: devzero-zxporter
+    control-plane: controller-manager
+  name: devzero-zxporter-controller-manager-metrics-service
+  namespace: {{.zxporter_namespace}}
+spec:
+  ports:
+    - name: https
+      port: 8443
+      protocol: TCP
+      targetPort: 8443
+  selector:
+    control-plane: controller-manager
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app.kubernetes.io/name: devzero-zxporter
+    control-plane: controller-manager
+  name: devzero-zxporter-controller-manager-mpa
+  namespace: {{.zxporter_namespace}}
+spec:
+  ports:
+    - name: mpa-grpc
+      port: 50051
+      protocol: TCP
+      targetPort: mpa-grpc
+  selector:
+    control-plane: controller-manager
+  type: ClusterIP
+---
+apiVersion: scheduling.k8s.io/v1
+description: This priority class is for critical zxporter infrastructure components.
+globalDefault: false
+kind: PriorityClass
+metadata:
+  name: devzero-zxporter-devzero-zxporter-critical
+preemptionPolicy: PreemptLowerPriority
+value: 1000000000
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app.kubernetes.io/managed-by: kustomize
+    app.kubernetes.io/name: devzero-zxporter
+    control-plane: controller-manager
+  name: devzero-zxporter-controller-manager
+  namespace: {{.zxporter_namespace}}
+spec:
+  replicas: 2
+  selector:
+    matchLabels:
+      control-plane: controller-manager
+  template:
+    metadata:
+      annotations:
+        kubectl.kubernetes.io/default-container: manager
+      labels:
+        app.kubernetes.io/instance: zxporter
+        app.kubernetes.io/name: zxporter
+        control-plane: controller-manager
+    spec:
+      containers:
+        - args:
+            - --metrics-bind-address=:8443
+            - --leader-elect
+            - --mpa-server-port=50051
+            - --health-probe-bind-address=:8081
+          env:
+            - name: POD_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+            - name: CLUSTER_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  key: CLUSTER_TOKEN
+                  name: devzero-zxporter-token
+                  optional: true
+          image: docker.io/devzeroinc/zxporter:latest
+          livenessProbe:
+            httpGet:
+              path: /healthz
+              port: 8081
+            initialDelaySeconds: 15
+            periodSeconds: 20
+          name: manager
+          ports:
+            - containerPort: 50051
+              name: mpa-grpc
+              protocol: TCP
+          readinessProbe:
+            httpGet:
+              path: /readyz
+              port: 8081
+            initialDelaySeconds: 5
+            periodSeconds: 10
+          resources:
+            requests:
+              cpu: 200m
+              memory: 2Gi
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
+          volumeMounts:
+            - mountPath: /etc/zxporter/config
+              name: config-volume
+              readOnly: true
+      priorityClassName: devzero-zxporter-devzero-zxporter-critical
+      securityContext:
+        runAsNonRoot: true
+      serviceAccountName: devzero-zxporter-controller-manager
+      terminationGracePeriodSeconds: 10
+      volumes:
+        - configMap:
+            name: devzero-zxporter-env-config
+          name: config-volume
+---
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: devzero-zxporter-devzero-zxporter-pdb
+  namespace: {{.zxporter_namespace}}
+spec:
+  minAvailable: 1
+  selector:
+    matchLabels:
+      control-plane: controller-manager
+---
+# Source: zxporter-nodemon/templates/rbac.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: zxporter-nodemon
+  namespace: {{.zxporter_namespace}}
+  labels:
+    helm.sh/chart: zxporter-nodemon-0.0.97
+    app.kubernetes.io/name: zxporter-nodemon
+    app.kubernetes.io/instance: zxporter-nodemon
+    app.kubernetes.io/version: "0.0.97"
+    app.kubernetes.io/managed-by: Helm
+---
+# Source: zxporter-nodemon/templates/dcgm-exporter-configmap.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: zxporter-nodemon-dcgm-metrics
+  namespace: {{.zxporter_namespace}}
+data:
+  counters.csv: |
+    # Temperature and power usage,,
+    DCGM_FI_DEV_GPU_TEMP, gauge, Current temperature readings for the device in degrees C.
+    DCGM_FI_DEV_MEMORY_TEMP, gauge, Memory temperature for the device.
+    DCGM_FI_DEV_POWER_USAGE, gauge, Power usage for the device in Watts.
+
+    # Utilization,,
+    # DCGM_FI_DEV_GPU_UTIL provides overall GPU utilization which is useful for scenarios
+    # like fractional GPU sharing (e.g., EKS time-slicing, MIG) where profiling metrics may not be available.
+    DCGM_FI_DEV_GPU_UTIL, gauge, GPU utilization (in %).
+    # DCGM_FI_PROF_SM_ACTIVE, gauge, The ratio of cycles an SM has at least 1 warp assigned
+    # DCGM_FI_PROF_SM_OCCUPANCY, gauge, The fraction of resident warps on a multiprocessor
+    # DCGM_FI_PROF_GR_ENGINE_ACTIVE, gauge, Ratio of time the graphics engine is active (in %).
+    # DCGM_FI_PROF_DRAM_ACTIVE, gauge, The ratio of cycles the device memory interface is active sending or receiving data.
+
+    # Memory usage,,
+    DCGM_FI_DEV_FB_FREE, gauge, Framebuffer memory free (in MiB).
+    DCGM_FI_DEV_FB_USED, gauge, Framebuffer memory used (in MiB).
+    DCGM_FI_DEV_FB_TOTAL, gauge, Total Frame Buffer of the GPU in MB.
+    DCGM_FI_DEV_MEM_COPY_UTIL, gauge, Utilization of the memory copy engine.
+
+    # PCIE,,
+    # DCGM_FI_PROF_PCIE_TX_BYTES, gauge, Total number of bytes transmitted through PCIe TX
+    # DCGM_FI_PROF_PCIE_RX_BYTES, gauge, Total number of bytes received through PCIe RX
+    DCGM_FI_DEV_PCIE_LINK_GEN, gauge, PCIe Current Link Generation.
+    DCGM_FI_DEV_PCIE_LINK_WIDTH, gauge, PCIe Current Link Width.
+
+    # Pipelines,,
+    # DCGM_FI_PROF_PIPE_INT_ACTIVE, gauge, Ratio of cycles the integer pipe is active.
+    # DCGM_FI_PROF_PIPE_FP16_ACTIVE, gauge, Ratio of cycles the fp16 pipe is active.
+    # DCGM_FI_PROF_PIPE_FP32_ACTIVE, gauge, Ratio of cycles the fp32 pipe is active.
+    # DCGM_FI_PROF_PIPE_FP64_ACTIVE, gauge, Ratio of cycles the fp64 pipe is active.
+    # DCGM_FI_PROF_PIPE_TENSOR_ACTIVE, gauge, The ratio of cycles the tensor (HMMA) pipe is active (off the peak sustained elapsed cycles)
+
+    # Health,,
+    # DCGM_FI_DEV_CLOCKS_EVENT_REASONS is not supported by DCGM 3.3.7
+    # DCGM_FI_DEV_CLOCKS_EVENT_REASONS, gauge, Current clock event reasons (bitmask of DCGM_CLOCKS_EVENT_REASON_*)
+    DCGM_FI_DEV_XID_ERRORS, gauge, The value is the specific XID error
+    DCGM_FI_DEV_POWER_VIOLATION, gauge, Power Violation time in ns.
+    DCGM_FI_DEV_THERMAL_VIOLATION, gauge, Thermal Violation time in ns.
+
+    # NVLink,,
+    # DCGM_FI_PROF_NVLINK_TX_BYTES, gauge, The number of bytes of active NvLink tx (transmit) data including both header and payload.
+    # DCGM_FI_PROF_NVLINK_RX_BYTES, gauge, The number of bytes of active NvLink rx (read) data including both header and payload.
+
+    # Clocks,,
+    DCGM_FI_DEV_SM_CLOCK, gauge, SM clock frequency (in MHz).
+    DCGM_FI_DEV_MEM_CLOCK, gauge, Memory clock frequency (in MHz).
+---
+# Source: zxporter-nodemon/templates/nodemon-configmap.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: zxporter-nodemon-zxporter-nodemon
+  namespace: {{.zxporter_namespace}}
+data:
+---
+# Source: zxporter-nodemon/templates/rbac.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: zxporter-nodemon
+  labels:
+    helm.sh/chart: zxporter-nodemon-0.0.97
+    app.kubernetes.io/name: zxporter-nodemon
+    app.kubernetes.io/instance: zxporter-nodemon
+    app.kubernetes.io/version: "0.0.97"
+    app.kubernetes.io/managed-by: Helm
+rules:
+  - apiGroups:
+      - ""
+    resources:
+      - pods
+    verbs:
+      - get
+      - list
+  - apiGroups:
+      - apps
+    resources:
+      - replicasets
+      - deployments
+      - statefulsets
+      - daemonsets
+    verbs:
+      - get
+  - apiGroups:
+      - batch
+    resources:
+      - jobs
+      - cronjobs
+    verbs:
+      - get
+  - apiGroups:
+      - argoproj.io
+    resources:
+      - rollouts
+    verbs:
+      - get
+  - apiGroups:
+      - ""
+    resources:
+      - nodes/proxy
+      - nodes/metrics
+      - nodes/stats
+    verbs:
+      - get
+---
+# Source: zxporter-nodemon/templates/rbac.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: zxporter-nodemon
+  labels:
+    helm.sh/chart: zxporter-nodemon-0.0.97
+    app.kubernetes.io/name: zxporter-nodemon
+    app.kubernetes.io/instance: zxporter-nodemon
+    app.kubernetes.io/version: "0.0.97"
+    app.kubernetes.io/managed-by: Helm
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: zxporter-nodemon
+subjects:
+  - kind: ServiceAccount
+    name: zxporter-nodemon
+    namespace: {{.zxporter_namespace}}
+---
+# Source: zxporter-nodemon/templates/daemonset.yaml
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: zxporter-nodemon
+  namespace: {{.zxporter_namespace}}
+  labels:
+    helm.sh/chart: zxporter-nodemon-0.0.97
+    app.kubernetes.io/name: zxporter-nodemon
+    app.kubernetes.io/instance: zxporter-nodemon
+    app.kubernetes.io/version: "0.0.97"
+    app.kubernetes.io/managed-by: Helm
+  annotations:
+    ignore-check.kube-linter.io/privileged-container: "This daemon set needs to run DCGM Exporter as privileged to access the GPU metrics."
+    ignore-check.kube-linter.io/run-as-non-root: "This daemon set needs to run DCGM Exporter as root to access the GPU metrics."
+    ignore-check.kube-linter.io/privilege-escalation-container: "This daemon set needs escalate privileges for DCGM Exporter."
+    ignore-check.kube-linter.io/no-read-only-root-fs: "This daemon set needs to run DCGM Exporter with read-only root filesystem."
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: zxporter-nodemon
+      app.kubernetes.io/instance: zxporter-nodemon
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: zxporter-nodemon
+        app.kubernetes.io/instance: zxporter-nodemon
+    spec:
+      priorityClassName: devzero-zxporter-devzero-zxporter-critical
+      serviceAccountName: zxporter-nodemon
+      volumes:
+        - name: "pod-gpu-resources"
+          hostPath:
+            path: /var/lib/kubelet/pod-resources
+        - name: zxporter-nodemon-dcgm-metrics
+          configMap:
+            name: zxporter-nodemon-dcgm-metrics
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+              - matchExpressions:
+                  - key: nvidia.com/gpu.present
+                    operator: NotIn
+                    values:
+                      - "true"
+      tolerations:
+        - effect: NoExecute
+          operator: Exists
+        - effect: NoSchedule
+          operator: Exists
+        - effect: PreferNoSchedule
+          operator: Exists
+      containers:
+        - name: zxporter-nodemon
+          securityContext:
+            readOnlyRootFilesystem: true
+            runAsNonRoot: true
+          image: "docker.io/devzeroinc/zxporter-nodemon:latest"
+          imagePullPolicy: IfNotPresent
+          ports:
+            - name: http
+              containerPort: 6061
+              protocol: TCP
+          livenessProbe:
+            httpGet:
+              path: /healthz
+              port: http
+          readinessProbe:
+            httpGet:
+              path: /healthz
+              port: http
+          envFrom:
+            - configMapRef:
+                name: zxporter-nodemon-zxporter-nodemon
+          env:
+            - name: "NODE_NAME"
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.nodeName
+            - name: "RUNTIME_METRICS_ENABLED"
+              value: "false"
+            - name: "DCGM_HOST"
+              value: "localhost"
+          resources:
+            limits:
+              memory: 256Mi
+            requests:
+              cpu: 60m
+              memory: 256Mi
+        - name: dcgm-exporter
+          securityContext:
+            capabilities:
+              add:
+                - SYS_ADMIN
+              drop:
+                - NET_RAW
+            runAsNonRoot: false
+            runAsUser: 0
+          image: "nvcr.io/nvidia/k8s/dcgm-exporter:4.5.2-4.8.1-ubuntu22.04"
+          imagePullPolicy: IfNotPresent
+          command: ["/bin/bash", "-c"]
+          args:
+            - hostname $NODE_NAME; for ((;;)) { r=$(dcgm-exporter -f /etc/dcgm-exporter/counters.csv); echo "dcgm-exporter could not run"; sleep 60 ; }
+          ports:
+            - name: "metrics"
+              containerPort: 9400
+          env:
+            - name: "DCGM_EXPORTER_KUBERNETES"
+              value: "true"
+            - name: "DCGM_EXPORTER_LISTEN"
+              value: ":9400"
+            - name: "DCGM_EXPORTER_INTERVAL"
+              value: "5000"
+            - name: "NODE_NAME"
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.nodeName
+          volumeMounts:
+            - name: "pod-gpu-resources"
+              readOnly: true
+              mountPath: "/var/lib/kubelet/pod-resources"
+            - name: zxporter-nodemon-dcgm-metrics
+              mountPath: "/etc/dcgm-exporter"
+---
+# Source: zxporter-nodemon/templates/daemonset.yaml
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: zxporter-nodemon-gpu
+  namespace: {{.zxporter_namespace}}
+  labels:
+    helm.sh/chart: zxporter-nodemon-0.0.97
+    app.kubernetes.io/name: zxporter-nodemon
+    app.kubernetes.io/instance: zxporter-nodemon-gpu
+    app.kubernetes.io/version: "0.0.97"
+    app.kubernetes.io/managed-by: Helm
+  annotations:
+    ignore-check.kube-linter.io/privileged-container: "This daemon set needs to run DCGM Exporter as privileged to access the GPU metrics."
+    ignore-check.kube-linter.io/run-as-non-root: "This daemon set needs to run DCGM Exporter as root to access the GPU metrics."
+    ignore-check.kube-linter.io/privilege-escalation-container: "This daemon set needs escalate privileges for DCGM Exporter."
+    ignore-check.kube-linter.io/no-read-only-root-fs: "This daemon set needs to run DCGM Exporter with read-only root filesystem."
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: zxporter-nodemon
+      app.kubernetes.io/instance: zxporter-nodemon-gpu
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: zxporter-nodemon
+        app.kubernetes.io/instance: zxporter-nodemon-gpu
+    spec:
+      priorityClassName: devzero-zxporter-devzero-zxporter-critical
+      runtimeClassName: "nvidia"
+      serviceAccountName: zxporter-nodemon
+      volumes:
+        - name: "pod-gpu-resources"
+          hostPath:
+            path: /var/lib/kubelet/pod-resources
+        - name: zxporter-nodemon-dcgm-metrics
+          configMap:
+            name: zxporter-nodemon-dcgm-metrics
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+              - matchExpressions:
+                  - key: nvidia.com/gpu.present
+                    operator: In
+                    values:
+                      - "true"
+      tolerations:
+        - effect: NoExecute
+          operator: Exists
+        - effect: NoSchedule
+          operator: Exists
+        - effect: PreferNoSchedule
+          operator: Exists
+      containers:
+        - name: zxporter-nodemon
+          securityContext:
+            readOnlyRootFilesystem: true
+            runAsNonRoot: true
+          image: "docker.io/devzeroinc/zxporter-nodemon:latest"
+          imagePullPolicy: IfNotPresent
+          ports:
+            - name: http
+              containerPort: 6061
+              protocol: TCP
+          livenessProbe:
+            httpGet:
+              path: /healthz
+              port: http
+          readinessProbe:
+            httpGet:
+              path: /healthz
+              port: http
+          envFrom:
+            - configMapRef:
+                name: zxporter-nodemon-zxporter-nodemon
+          env:
+            - name: "NODE_NAME"
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.nodeName
+            - name: "RUNTIME_METRICS_ENABLED"
+              value: "false"
+            - name: "DCGM_HOST"
+              value: "localhost"
+          resources:
+            limits:
+              memory: 256Mi
+            requests:
+              cpu: 60m
+              memory: 256Mi
+        - name: dcgm-exporter
+          securityContext:
+            capabilities:
+              add:
+                - SYS_ADMIN
+              drop:
+                - NET_RAW
+            runAsNonRoot: false
+            runAsUser: 0
+          image: "nvcr.io/nvidia/k8s/dcgm-exporter:4.5.2-4.8.1-ubuntu22.04"
+          imagePullPolicy: IfNotPresent
+          command: ["/bin/bash", "-c"]
+          args:
+            - hostname $NODE_NAME; for ((;;)) { r=$(dcgm-exporter -f /etc/dcgm-exporter/counters.csv); echo "dcgm-exporter could not run"; sleep 60 ; }
+          ports:
+            - name: "metrics"
+              containerPort: 9400
+          env:
+            - name: "DCGM_EXPORTER_KUBERNETES"
+              value: "true"
+            - name: "DCGM_EXPORTER_LISTEN"
+              value: ":9400"
+            - name: "DCGM_EXPORTER_INTERVAL"
+              value: "5000"
+            - name: "NODE_NAME"
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.nodeName
+          volumeMounts:
+            - name: "pod-gpu-resources"
+              readOnly: true
+              mountPath: "/var/lib/kubelet/pod-resources"
+            - name: zxporter-nodemon-dcgm-metrics
+              mountPath: "/etc/dcgm-exporter"

--- a/dist/backend-install-lowpriv.yaml
+++ b/dist/backend-install-lowpriv.yaml
@@ -769,10 +769,10 @@ metadata:
   name: zxporter-nodemon
   namespace: {{.zxporter_namespace}}
   labels:
-    helm.sh/chart: zxporter-nodemon-0.0.97
+    helm.sh/chart: zxporter-nodemon-0.0.98
     app.kubernetes.io/name: zxporter-nodemon
     app.kubernetes.io/instance: zxporter-nodemon
-    app.kubernetes.io/version: "0.0.97"
+    app.kubernetes.io/version: "0.0.98"
     app.kubernetes.io/managed-by: Helm
 ---
 # Source: zxporter-nodemon/templates/dcgm-exporter-configmap.yaml
@@ -845,10 +845,10 @@ kind: ClusterRole
 metadata:
   name: zxporter-nodemon
   labels:
-    helm.sh/chart: zxporter-nodemon-0.0.97
+    helm.sh/chart: zxporter-nodemon-0.0.98
     app.kubernetes.io/name: zxporter-nodemon
     app.kubernetes.io/instance: zxporter-nodemon
-    app.kubernetes.io/version: "0.0.97"
+    app.kubernetes.io/version: "0.0.98"
     app.kubernetes.io/managed-by: Helm
 rules:
   - apiGroups:
@@ -895,10 +895,10 @@ kind: ClusterRoleBinding
 metadata:
   name: zxporter-nodemon
   labels:
-    helm.sh/chart: zxporter-nodemon-0.0.97
+    helm.sh/chart: zxporter-nodemon-0.0.98
     app.kubernetes.io/name: zxporter-nodemon
     app.kubernetes.io/instance: zxporter-nodemon
-    app.kubernetes.io/version: "0.0.97"
+    app.kubernetes.io/version: "0.0.98"
     app.kubernetes.io/managed-by: Helm
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -916,10 +916,10 @@ metadata:
   name: zxporter-nodemon
   namespace: {{.zxporter_namespace}}
   labels:
-    helm.sh/chart: zxporter-nodemon-0.0.97
+    helm.sh/chart: zxporter-nodemon-0.0.98
     app.kubernetes.io/name: zxporter-nodemon
     app.kubernetes.io/instance: zxporter-nodemon
-    app.kubernetes.io/version: "0.0.97"
+    app.kubernetes.io/version: "0.0.98"
     app.kubernetes.io/managed-by: Helm
   annotations:
     ignore-check.kube-linter.io/privileged-container: "This daemon set needs to run DCGM Exporter as privileged to access the GPU metrics."
@@ -1041,10 +1041,10 @@ metadata:
   name: zxporter-nodemon-gpu
   namespace: {{.zxporter_namespace}}
   labels:
-    helm.sh/chart: zxporter-nodemon-0.0.97
+    helm.sh/chart: zxporter-nodemon-0.0.98
     app.kubernetes.io/name: zxporter-nodemon
     app.kubernetes.io/instance: zxporter-nodemon-gpu
-    app.kubernetes.io/version: "0.0.97"
+    app.kubernetes.io/version: "0.0.98"
     app.kubernetes.io/managed-by: Helm
   annotations:
     ignore-check.kube-linter.io/privileged-container: "This daemon set needs to run DCGM Exporter as privileged to access the GPU metrics."

--- a/dist/install-gcp-lowpriv.yaml
+++ b/dist/install-gcp-lowpriv.yaml
@@ -769,10 +769,10 @@ metadata:
   name: zxporter-nodemon
   namespace: devzero-system
   labels:
-    helm.sh/chart: zxporter-nodemon-0.0.97
+    helm.sh/chart: zxporter-nodemon-0.0.98
     app.kubernetes.io/name: zxporter-nodemon
     app.kubernetes.io/instance: zxporter-nodemon
-    app.kubernetes.io/version: "0.0.97"
+    app.kubernetes.io/version: "0.0.98"
     app.kubernetes.io/managed-by: Helm
 ---
 # Source: zxporter-nodemon/templates/dcgm-exporter-configmap.yaml
@@ -845,10 +845,10 @@ kind: ClusterRole
 metadata:
   name: zxporter-nodemon
   labels:
-    helm.sh/chart: zxporter-nodemon-0.0.97
+    helm.sh/chart: zxporter-nodemon-0.0.98
     app.kubernetes.io/name: zxporter-nodemon
     app.kubernetes.io/instance: zxporter-nodemon
-    app.kubernetes.io/version: "0.0.97"
+    app.kubernetes.io/version: "0.0.98"
     app.kubernetes.io/managed-by: Helm
 rules:
 - apiGroups:
@@ -895,10 +895,10 @@ kind: ClusterRoleBinding
 metadata:
   name: zxporter-nodemon
   labels:
-    helm.sh/chart: zxporter-nodemon-0.0.97
+    helm.sh/chart: zxporter-nodemon-0.0.98
     app.kubernetes.io/name: zxporter-nodemon
     app.kubernetes.io/instance: zxporter-nodemon
-    app.kubernetes.io/version: "0.0.97"
+    app.kubernetes.io/version: "0.0.98"
     app.kubernetes.io/managed-by: Helm
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -916,10 +916,10 @@ metadata:
   name: zxporter-nodemon
   namespace: devzero-system
   labels:
-    helm.sh/chart: zxporter-nodemon-0.0.97
+    helm.sh/chart: zxporter-nodemon-0.0.98
     app.kubernetes.io/name: zxporter-nodemon
     app.kubernetes.io/instance: zxporter-nodemon
-    app.kubernetes.io/version: "0.0.97"
+    app.kubernetes.io/version: "0.0.98"
     app.kubernetes.io/managed-by: Helm
   annotations:
     ignore-check.kube-linter.io/privileged-container: "This daemon set needs to run DCGM Exporter as privileged to access the GPU metrics."
@@ -1051,10 +1051,10 @@ metadata:
   name: zxporter-nodemon-gpu
   namespace: devzero-system
   labels:
-    helm.sh/chart: zxporter-nodemon-0.0.97
+    helm.sh/chart: zxporter-nodemon-0.0.98
     app.kubernetes.io/name: zxporter-nodemon
     app.kubernetes.io/instance: zxporter-nodemon-gpu
-    app.kubernetes.io/version: "0.0.97"
+    app.kubernetes.io/version: "0.0.98"
     app.kubernetes.io/managed-by: Helm
   annotations:
     ignore-check.kube-linter.io/privileged-container: "This daemon set needs to run DCGM Exporter as privileged to access the GPU metrics."

--- a/dist/install-gcp-lowpriv.yaml
+++ b/dist/install-gcp-lowpriv.yaml
@@ -1,0 +1,1181 @@
+# ZXPorter installer bundle
+apiVersion: v1
+kind: Namespace
+metadata:
+  labels:
+    control-plane: controller-manager
+    app.kubernetes.io/name: devzero-system
+  name: devzero-system
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  labels:
+    app.kubernetes.io/managed-by: kustomize
+    app.kubernetes.io/name: devzero-zxporter
+    control-plane: controller-manager
+  name: devzero-system
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  labels:
+    app.kubernetes.io/managed-by: kustomize
+    app.kubernetes.io/name: devzero-zxporter
+  name: devzero-zxporter-controller-manager
+  namespace: devzero-system
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  labels:
+    app.kubernetes.io/managed-by: kustomize
+    app.kubernetes.io/name: devzero-zxporter
+  name: devzero-zxporter-leader-election-role
+  namespace: devzero-system
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  - deployments
+  - serviceaccounts
+  - services
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - patch
+  - delete
+- apiGroups:
+  - apps
+  resources:
+  - deployments
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - patch
+  - delete
+- apiGroups:
+  - coordination.k8s.io
+  resources:
+  - leases
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - patch
+  - delete
+- apiGroups:
+  - ""
+  resources:
+  - events
+  verbs:
+  - create
+  - patch
+- apiGroups:
+  - rbac.authorization.k8s.io
+  resources:
+  - rolebindings
+  - roles
+  - clusterrolebindings
+  - clusterroles
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    app.kubernetes.io/managed-by: kustomize
+    app.kubernetes.io/name: devzero-zxporter
+  name: devzero-zxporter-collectionpolicy-editor-role
+rules:
+- apiGroups:
+  - devzero.io
+  resources:
+  - collectionpolicies
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - devzero.io
+  resources:
+  - collectionpolicies/status
+  verbs:
+  - get
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    app.kubernetes.io/managed-by: kustomize
+    app.kubernetes.io/name: devzero-zxporter
+  name: devzero-zxporter-collectionpolicy-viewer-role
+rules:
+- apiGroups:
+  - devzero.io
+  resources:
+  - collectionpolicies
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - devzero.io
+  resources:
+  - collectionpolicies/status
+  verbs:
+  - get
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: devzero-zxporter-manager-role
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  verbs:
+  - get
+  - list
+  - update
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - endpoints
+  - events
+  - limitranges
+  - namespaces
+  - nodes
+  - persistentvolumeclaims
+  - persistentvolumes
+  - pods
+  - replicationcontrollers
+  - resourcequotas
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - nodes/metrics
+  - nodes/proxy
+  - nodes/status
+  - pods/status
+  verbs:
+  - get
+- apiGroups:
+  - ""
+  resources:
+  - secrets
+  verbs:
+  - create
+- apiGroups:
+  - ""
+  resourceNames:
+  - devzero-zxporter-token
+  resources:
+  - secrets
+  verbs:
+  - get
+  - patch
+  - update
+- apiGroups:
+  - ""
+  resources:
+  - serviceaccounts
+  - services
+  verbs:
+  - create
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - apiextensions.k8s.io
+  resources:
+  - customresourcedefinitions
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - apiregistration.k8s.io
+  resources:
+  - apiservices
+  verbs:
+  - create
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - apps
+  resources:
+  - daemonsets
+  - replicasets
+  - statefulsets
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - apps
+  resources:
+  - deployments
+  verbs:
+  - create
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - argoproj.io
+  resources:
+  - rollouts
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - autoscaling
+  resources:
+  - horizontalpodautoscalers
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - autoscaling.k8s.io
+  resources:
+  - verticalpodautoscalers
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - batch
+  resources:
+  - cronjobs
+  - jobs
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - batch.volcano.sh
+  resources:
+  - jobs
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - dakr.devzero.io
+  resources:
+  - workloadrecommendations
+  - workloadrules
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - datadoghq.com
+  resources:
+  - extendeddaemonsetreplicasets
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - devzero.io
+  resources:
+  - collectionpolicies
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - devzero.io
+  resources:
+  - collectionpolicies/finalizers
+  verbs:
+  - update
+- apiGroups:
+  - devzero.io
+  resources:
+  - collectionpolicies/status
+  verbs:
+  - get
+  - patch
+  - update
+- apiGroups:
+  - devzero.karpenter.sh
+  resources:
+  - karpentersettings
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - karpenter.azure.com
+  resources:
+  - aksnodeclasses
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - karpenter.k8s.aws
+  resources:
+  - awsnodetemplates
+  - ec2nodeclasses
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - karpenter.k8s.gcp
+  resources:
+  - gcenodeclasses
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - karpenter.k8s.oracle
+  resources:
+  - ocinodeclasses
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - karpenter.sh
+  resources:
+  - machines
+  - nodeclaims
+  - nodeoverlays
+  - nodepools
+  - provisioners
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - keda.sh
+  resources:
+  - clustertriggerauthentications
+  - scaledjobs
+  - scaledobjects
+  - triggerauthentications
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - kubeflow.org
+  resources:
+  - notebooks
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - metrics.k8s.io
+  resources:
+  - nodes
+  - pods
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - networking.k8s.io
+  resources:
+  - ingressclasses
+  - ingresses
+  - networkpolicies
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - policy
+  resources:
+  - poddisruptionbudgets
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - postgresql.cnpg.io
+  resources:
+  - clusters
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - rbac.authorization.k8s.io
+  resources:
+  - clusterrolebindings
+  - clusterroles
+  - rolebindings
+  verbs:
+  - create
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - rbac.authorization.k8s.io
+  resources:
+  - roles
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - sparkoperator.k8s.io
+  resources:
+  - scheduledsparkapplications
+  - sparkapplications
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - storage.k8s.io
+  resources:
+  - csidrivers
+  - csinodes
+  - csistoragecapacities
+  - storageclasses
+  - volumeattachments
+  verbs:
+  - get
+  - list
+  - watch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: devzero-zxporter-metrics-auth-role
+rules:
+- apiGroups:
+  - authentication.k8s.io
+  resources:
+  - tokenreviews
+  verbs:
+  - create
+- apiGroups:
+  - authorization.k8s.io
+  resources:
+  - subjectaccessreviews
+  verbs:
+  - create
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: devzero-zxporter-metrics-reader
+rules:
+- nonResourceURLs:
+  - /metrics
+  verbs:
+  - get
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  labels:
+    app.kubernetes.io/managed-by: kustomize
+    app.kubernetes.io/name: devzero-zxporter
+  name: devzero-zxporter-leader-election-rolebinding
+  namespace: devzero-system
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: devzero-zxporter-leader-election-role
+subjects:
+- kind: ServiceAccount
+  name: devzero-zxporter-controller-manager
+  namespace: devzero-system
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  labels:
+    app.kubernetes.io/managed-by: kustomize
+    app.kubernetes.io/name: devzero-zxporter
+  name: devzero-zxporter-manager-rolebinding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: devzero-zxporter-manager-role
+subjects:
+- kind: ServiceAccount
+  name: devzero-zxporter-controller-manager
+  namespace: devzero-system
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: devzero-zxporter-metrics-auth-rolebinding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: devzero-zxporter-metrics-auth-role
+subjects:
+- kind: ServiceAccount
+  name: devzero-zxporter-controller-manager
+  namespace: devzero-system
+---
+apiVersion: v1
+data:
+  BUFFER_SIZE: ""
+  CLUSTER_TOKEN: ""
+  COLLECTION_FREQUENCY: ""
+  DAKR_URL: https://dakr.devzero.io
+  DISABLED_COLLECTORS: ""
+  EXCLUDED_CLUSTERROLEBINDINGS: ""
+  EXCLUDED_CLUSTERROLES: ""
+  EXCLUDED_CRDGROUPS: ""
+  EXCLUDED_CRDS: ""
+  EXCLUDED_CRONJOBS: ""
+  EXCLUDED_DAEMONSETS: ""
+  EXCLUDED_DEPLOYMENTS: ""
+  EXCLUDED_ENDPOINTS: ""
+  EXCLUDED_EVENTS: ""
+  EXCLUDED_HPAS: ""
+  EXCLUDED_INGRESSCLASSES: ""
+  EXCLUDED_INGRESSES: ""
+  EXCLUDED_JOBS: ""
+  EXCLUDED_LIMITRANGES: ""
+  EXCLUDED_NAMESPACES: ""
+  EXCLUDED_NETWORKPOLICIES: ""
+  EXCLUDED_NODES: ""
+  EXCLUDED_PDBS: ""
+  EXCLUDED_PODS: ""
+  EXCLUDED_PSPS: ""
+  EXCLUDED_PVCS: ""
+  EXCLUDED_PVS: ""
+  EXCLUDED_REPLICATIONCONTROLLERS: ""
+  EXCLUDED_RESOURCEQUOTAS: ""
+  EXCLUDED_ROLEBINDINGS: ""
+  EXCLUDED_ROLES: ""
+  EXCLUDED_SERVICEACCOUNTS: ""
+  EXCLUDED_SERVICES: ""
+  EXCLUDED_STATEFULSETS: ""
+  EXCLUDED_STORAGECLASSES: ""
+  EXCLUDED_VPAS: ""
+  K8S_PROVIDER: '{{ .k8s_provider }}'
+  KUBE_CONTEXT_NAME: '{{ .kube_context_name }}'
+  MASK_SECRET_DATA: ""
+  NODE_METRICS_INTERVAL: ""
+  TARGET_NAMESPACES: ""
+  TOKEN_CONFIGMAP_NAME: devzero-zxporter-env-config
+  TOKEN_CREDENTIALS_SECRET_NAME: devzero-zxporter-credentials
+  TOKEN_RUNTIME_SECRET_NAME: devzero-zxporter-token
+  TOKEN_SECRET_NAME: devzero-zxporter-token
+  USE_SECRET_FOR_TOKEN: "true"
+  WATCHED_CRDS: ""
+kind: ConfigMap
+metadata:
+  name: devzero-zxporter-env-config
+  namespace: devzero-system
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: devzero-zxporter-token
+  namespace: devzero-system
+stringData:
+  CLUSTER_TOKEN: '{{ .cluster_token }}'
+type: Opaque
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app.kubernetes.io/managed-by: kustomize
+    app.kubernetes.io/name: devzero-zxporter
+    control-plane: controller-manager
+  name: devzero-zxporter-controller-manager-metrics-service
+  namespace: devzero-system
+spec:
+  ports:
+  - name: https
+    port: 8443
+    protocol: TCP
+    targetPort: 8443
+  selector:
+    control-plane: controller-manager
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app.kubernetes.io/name: devzero-zxporter
+    control-plane: controller-manager
+  name: devzero-zxporter-controller-manager-mpa
+  namespace: devzero-system
+spec:
+  ports:
+  - name: mpa-grpc
+    port: 50051
+    protocol: TCP
+    targetPort: mpa-grpc
+  selector:
+    control-plane: controller-manager
+  type: ClusterIP
+---
+apiVersion: scheduling.k8s.io/v1
+description: This priority class is for critical zxporter infrastructure components.
+globalDefault: false
+kind: PriorityClass
+metadata:
+  name: devzero-zxporter-devzero-zxporter-critical
+preemptionPolicy: PreemptLowerPriority
+value: 1000000000
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app.kubernetes.io/managed-by: kustomize
+    app.kubernetes.io/name: devzero-zxporter
+    control-plane: controller-manager
+  name: devzero-zxporter-controller-manager
+  namespace: devzero-system
+spec:
+  replicas: 2
+  selector:
+    matchLabels:
+      control-plane: controller-manager
+  template:
+    metadata:
+      annotations:
+        kubectl.kubernetes.io/default-container: manager
+      labels:
+        app.kubernetes.io/instance: zxporter
+        app.kubernetes.io/name: zxporter
+        control-plane: controller-manager
+    spec:
+      containers:
+      - args:
+        - --metrics-bind-address=:8443
+        - --leader-elect
+        - --mpa-server-port=50051
+        - --health-probe-bind-address=:8081
+        env:
+        - name: POD_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        - name: CLUSTER_TOKEN
+          valueFrom:
+            secretKeyRef:
+              key: CLUSTER_TOKEN
+              name: devzero-zxporter-token
+              optional: true
+        image: ttl.sh/zxporter:latest
+        livenessProbe:
+          httpGet:
+            path: /healthz
+            port: 8081
+          initialDelaySeconds: 15
+          periodSeconds: 20
+        name: manager
+        ports:
+        - containerPort: 50051
+          name: mpa-grpc
+          protocol: TCP
+        readinessProbe:
+          httpGet:
+            path: /readyz
+            port: 8081
+          initialDelaySeconds: 5
+          periodSeconds: 10
+        resources:
+          requests:
+            cpu: 200m
+            memory: 2Gi
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
+        volumeMounts:
+        - mountPath: /etc/zxporter/config
+          name: config-volume
+          readOnly: true
+      priorityClassName: devzero-zxporter-devzero-zxporter-critical
+      securityContext:
+        runAsNonRoot: true
+      serviceAccountName: devzero-zxporter-controller-manager
+      terminationGracePeriodSeconds: 10
+      volumes:
+      - configMap:
+          name: devzero-zxporter-env-config
+        name: config-volume
+---
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: devzero-zxporter-devzero-zxporter-pdb
+  namespace: devzero-system
+spec:
+  minAvailable: 1
+  selector:
+    matchLabels:
+      control-plane: controller-manager
+---
+# Source: zxporter-nodemon/templates/rbac.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: zxporter-nodemon
+  namespace: devzero-system
+  labels:
+    helm.sh/chart: zxporter-nodemon-0.0.97
+    app.kubernetes.io/name: zxporter-nodemon
+    app.kubernetes.io/instance: zxporter-nodemon
+    app.kubernetes.io/version: "0.0.97"
+    app.kubernetes.io/managed-by: Helm
+---
+# Source: zxporter-nodemon/templates/dcgm-exporter-configmap.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: zxporter-nodemon-dcgm-metrics
+  namespace: devzero-system
+data:
+  counters.csv: |
+    # Temperature and power usage,,
+    DCGM_FI_DEV_GPU_TEMP, gauge, Current temperature readings for the device in degrees C.
+    DCGM_FI_DEV_MEMORY_TEMP, gauge, Memory temperature for the device.
+    DCGM_FI_DEV_POWER_USAGE, gauge, Power usage for the device in Watts.
+
+    # Utilization,,
+    # DCGM_FI_DEV_GPU_UTIL provides overall GPU utilization which is useful for scenarios
+    # like fractional GPU sharing (e.g., EKS time-slicing, MIG) where profiling metrics may not be available.
+    DCGM_FI_DEV_GPU_UTIL, gauge, GPU utilization (in %).
+    # DCGM_FI_PROF_SM_ACTIVE, gauge, The ratio of cycles an SM has at least 1 warp assigned
+    # DCGM_FI_PROF_SM_OCCUPANCY, gauge, The fraction of resident warps on a multiprocessor
+    # DCGM_FI_PROF_GR_ENGINE_ACTIVE, gauge, Ratio of time the graphics engine is active (in %).
+    # DCGM_FI_PROF_DRAM_ACTIVE, gauge, The ratio of cycles the device memory interface is active sending or receiving data.
+
+    # Memory usage,,
+    DCGM_FI_DEV_FB_FREE, gauge, Framebuffer memory free (in MiB).
+    DCGM_FI_DEV_FB_USED, gauge, Framebuffer memory used (in MiB).
+    DCGM_FI_DEV_FB_TOTAL, gauge, Total Frame Buffer of the GPU in MB.
+    DCGM_FI_DEV_MEM_COPY_UTIL, gauge, Utilization of the memory copy engine.
+
+    # PCIE,,
+    # DCGM_FI_PROF_PCIE_TX_BYTES, gauge, Total number of bytes transmitted through PCIe TX
+    # DCGM_FI_PROF_PCIE_RX_BYTES, gauge, Total number of bytes received through PCIe RX
+    DCGM_FI_DEV_PCIE_LINK_GEN, gauge, PCIe Current Link Generation.
+    DCGM_FI_DEV_PCIE_LINK_WIDTH, gauge, PCIe Current Link Width.
+
+    # Pipelines,,
+    # DCGM_FI_PROF_PIPE_INT_ACTIVE, gauge, Ratio of cycles the integer pipe is active.
+    # DCGM_FI_PROF_PIPE_FP16_ACTIVE, gauge, Ratio of cycles the fp16 pipe is active.
+    # DCGM_FI_PROF_PIPE_FP32_ACTIVE, gauge, Ratio of cycles the fp32 pipe is active.
+    # DCGM_FI_PROF_PIPE_FP64_ACTIVE, gauge, Ratio of cycles the fp64 pipe is active.
+    # DCGM_FI_PROF_PIPE_TENSOR_ACTIVE, gauge, The ratio of cycles the tensor (HMMA) pipe is active (off the peak sustained elapsed cycles)
+
+    # Health,,
+    # DCGM_FI_DEV_CLOCKS_EVENT_REASONS is not supported by DCGM 3.3.7
+    # DCGM_FI_DEV_CLOCKS_EVENT_REASONS, gauge, Current clock event reasons (bitmask of DCGM_CLOCKS_EVENT_REASON_*)
+    DCGM_FI_DEV_XID_ERRORS, gauge, The value is the specific XID error
+    DCGM_FI_DEV_POWER_VIOLATION, gauge, Power Violation time in ns.
+    DCGM_FI_DEV_THERMAL_VIOLATION, gauge, Thermal Violation time in ns.
+
+    # NVLink,,
+    # DCGM_FI_PROF_NVLINK_TX_BYTES, gauge, The number of bytes of active NvLink tx (transmit) data including both header and payload.
+    # DCGM_FI_PROF_NVLINK_RX_BYTES, gauge, The number of bytes of active NvLink rx (read) data including both header and payload.
+
+    # Clocks,,
+    DCGM_FI_DEV_SM_CLOCK, gauge, SM clock frequency (in MHz).
+    DCGM_FI_DEV_MEM_CLOCK, gauge, Memory clock frequency (in MHz).
+---
+# Source: zxporter-nodemon/templates/nodemon-configmap.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: zxporter-nodemon-zxporter-nodemon
+  namespace: devzero-system
+data:
+---
+# Source: zxporter-nodemon/templates/rbac.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: zxporter-nodemon
+  labels:
+    helm.sh/chart: zxporter-nodemon-0.0.97
+    app.kubernetes.io/name: zxporter-nodemon
+    app.kubernetes.io/instance: zxporter-nodemon
+    app.kubernetes.io/version: "0.0.97"
+    app.kubernetes.io/managed-by: Helm
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  verbs:
+  - get
+  - list
+- apiGroups:
+    - apps
+  resources:
+    - replicasets
+    - deployments
+    - statefulsets
+    - daemonsets
+  verbs:
+    - get
+- apiGroups:
+    - batch
+  resources:
+    - jobs
+    - cronjobs
+  verbs:
+    - get
+- apiGroups:
+    - argoproj.io
+  resources:
+    - rollouts
+  verbs:
+    - get
+- apiGroups:
+    - ""
+  resources:
+    - nodes/proxy
+    - nodes/metrics
+    - nodes/stats
+  verbs:
+    - get
+---
+# Source: zxporter-nodemon/templates/rbac.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: zxporter-nodemon
+  labels:
+    helm.sh/chart: zxporter-nodemon-0.0.97
+    app.kubernetes.io/name: zxporter-nodemon
+    app.kubernetes.io/instance: zxporter-nodemon
+    app.kubernetes.io/version: "0.0.97"
+    app.kubernetes.io/managed-by: Helm
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: zxporter-nodemon
+subjects:
+- kind: ServiceAccount
+  name: zxporter-nodemon
+  namespace: devzero-system
+---
+# Source: zxporter-nodemon/templates/daemonset.yaml
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: zxporter-nodemon
+  namespace: devzero-system
+  labels:
+    helm.sh/chart: zxporter-nodemon-0.0.97
+    app.kubernetes.io/name: zxporter-nodemon
+    app.kubernetes.io/instance: zxporter-nodemon
+    app.kubernetes.io/version: "0.0.97"
+    app.kubernetes.io/managed-by: Helm
+  annotations:
+    ignore-check.kube-linter.io/privileged-container: "This daemon set needs to run DCGM Exporter as privileged to access the GPU metrics."
+    ignore-check.kube-linter.io/run-as-non-root: "This daemon set needs to run DCGM Exporter as root to access the GPU metrics."
+    ignore-check.kube-linter.io/privilege-escalation-container: "This daemon set needs escalate privileges for DCGM Exporter."
+    ignore-check.kube-linter.io/no-read-only-root-fs: "This daemon set needs to run DCGM Exporter with read-only root filesystem."
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: zxporter-nodemon
+      app.kubernetes.io/instance: zxporter-nodemon
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: zxporter-nodemon
+        app.kubernetes.io/instance: zxporter-nodemon
+    spec:
+      priorityClassName: devzero-zxporter-devzero-zxporter-critical
+      serviceAccountName: zxporter-nodemon
+      volumes:
+        - name: "pod-gpu-resources"
+          hostPath:
+            path: /var/lib/kubelet/pod-resources
+        - name: zxporter-nodemon-dcgm-metrics
+          configMap:
+            name: zxporter-nodemon-dcgm-metrics
+        - name: "nvidia-install-dir-host"
+          hostPath:
+            path: /home/kubernetes/bin/nvidia
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: nvidia.com/gpu.present
+                operator: NotIn
+                values:
+                - "true"
+      tolerations:
+        - effect: NoExecute
+          operator: Exists
+        - effect: NoSchedule
+          operator: Exists
+        - effect: PreferNoSchedule
+          operator: Exists
+      containers:
+        - name: zxporter-nodemon
+          securityContext:
+            readOnlyRootFilesystem: true
+            runAsNonRoot: true
+          image: "ttl.sh/zxporter-nodemon:latest"
+          imagePullPolicy: IfNotPresent
+          ports:
+            - name: http
+              containerPort: 6061
+              protocol: TCP
+          livenessProbe:
+            httpGet:
+              path: /healthz
+              port: http
+          readinessProbe:
+            httpGet:
+              path: /healthz
+              port: http
+          envFrom:
+            - configMapRef:
+                name: zxporter-nodemon-zxporter-nodemon
+          env:
+            - name: "NODE_NAME"
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.nodeName
+            - name: "RUNTIME_METRICS_ENABLED"
+              value: "false"
+            - name: "DCGM_HOST"
+              value: "localhost"
+          resources:
+            limits:
+              memory: 256Mi
+            requests:
+              cpu: 60m
+              memory: 256Mi
+        - name: dcgm-exporter
+          securityContext:
+            capabilities:
+              add:
+                - SYS_ADMIN
+              drop:
+                - NET_RAW
+            runAsNonRoot: false
+            runAsUser: 0
+            privileged: true
+          image: "nvcr.io/nvidia/k8s/dcgm-exporter:4.5.2-4.8.1-ubuntu22.04"
+          imagePullPolicy: IfNotPresent
+          command: [ "/bin/bash", "-c" ]
+          args:
+            - hostname $NODE_NAME; for ((;;)) { r=$(dcgm-exporter -f /etc/dcgm-exporter/counters.csv); echo "dcgm-exporter could not run"; sleep 60 ; }
+          ports:
+            - name: "metrics"
+              containerPort: 9400
+          env:
+            - name: "DCGM_EXPORTER_KUBERNETES"
+              value: "true"
+            - name: "DCGM_EXPORTER_LISTEN"
+              value: ":9400"
+            - name: "DCGM_EXPORTER_INTERVAL"
+              value: "5000"
+            - name: "NODE_NAME"
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.nodeName
+            - name: "LD_LIBRARY_PATH"
+              value: "/usr/local/nvidia/lib64"
+            - name: "DCGM_EXPORTER_KUBERNETES_GPU_ID_TYPE"
+              value: "device-name"
+          volumeMounts:
+            - name: "pod-gpu-resources"
+              readOnly: true
+              mountPath: "/var/lib/kubelet/pod-resources"
+            - name: "nvidia-install-dir-host"
+              mountPath: /usr/local/nvidia
+            - name: zxporter-nodemon-dcgm-metrics
+              mountPath: "/etc/dcgm-exporter"
+---
+# Source: zxporter-nodemon/templates/daemonset.yaml
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: zxporter-nodemon-gpu
+  namespace: devzero-system
+  labels:
+    helm.sh/chart: zxporter-nodemon-0.0.97
+    app.kubernetes.io/name: zxporter-nodemon
+    app.kubernetes.io/instance: zxporter-nodemon-gpu
+    app.kubernetes.io/version: "0.0.97"
+    app.kubernetes.io/managed-by: Helm
+  annotations:
+    ignore-check.kube-linter.io/privileged-container: "This daemon set needs to run DCGM Exporter as privileged to access the GPU metrics."
+    ignore-check.kube-linter.io/run-as-non-root: "This daemon set needs to run DCGM Exporter as root to access the GPU metrics."
+    ignore-check.kube-linter.io/privilege-escalation-container: "This daemon set needs escalate privileges for DCGM Exporter."
+    ignore-check.kube-linter.io/no-read-only-root-fs: "This daemon set needs to run DCGM Exporter with read-only root filesystem."
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: zxporter-nodemon
+      app.kubernetes.io/instance: zxporter-nodemon-gpu
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: zxporter-nodemon
+        app.kubernetes.io/instance: zxporter-nodemon-gpu
+    spec:
+      priorityClassName: devzero-zxporter-devzero-zxporter-critical
+      runtimeClassName: "nvidia"
+      serviceAccountName: zxporter-nodemon
+      volumes:
+        - name: "pod-gpu-resources"
+          hostPath:
+            path: /var/lib/kubelet/pod-resources
+        - name: zxporter-nodemon-dcgm-metrics
+          configMap:
+            name: zxporter-nodemon-dcgm-metrics
+        - name: "nvidia-install-dir-host"
+          hostPath:
+            path: /home/kubernetes/bin/nvidia
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: nvidia.com/gpu.present
+                operator: In
+                values:
+                - "true"
+      tolerations:
+        - effect: NoExecute
+          operator: Exists
+        - effect: NoSchedule
+          operator: Exists
+        - effect: PreferNoSchedule
+          operator: Exists
+      containers:
+        - name: zxporter-nodemon
+          securityContext:
+            readOnlyRootFilesystem: true
+            runAsNonRoot: true
+          image: "ttl.sh/zxporter-nodemon:latest"
+          imagePullPolicy: IfNotPresent
+          ports:
+            - name: http
+              containerPort: 6061
+              protocol: TCP
+          livenessProbe:
+            httpGet:
+              path: /healthz
+              port: http
+          readinessProbe:
+            httpGet:
+              path: /healthz
+              port: http
+          envFrom:
+            - configMapRef:
+                name: zxporter-nodemon-zxporter-nodemon
+          env:
+            - name: "NODE_NAME"
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.nodeName
+            - name: "RUNTIME_METRICS_ENABLED"
+              value: "false"
+            - name: "DCGM_HOST"
+              value: "localhost"
+          resources:
+            limits:
+              memory: 256Mi
+            requests:
+              cpu: 60m
+              memory: 256Mi
+        - name: dcgm-exporter
+          securityContext:
+            capabilities:
+              add:
+                - SYS_ADMIN
+              drop:
+                - NET_RAW
+            runAsNonRoot: false
+            runAsUser: 0
+            privileged: true
+          image: "nvcr.io/nvidia/k8s/dcgm-exporter:4.5.2-4.8.1-ubuntu22.04"
+          imagePullPolicy: IfNotPresent
+          command: [ "/bin/bash", "-c" ]
+          args:
+            - hostname $NODE_NAME; for ((;;)) { r=$(dcgm-exporter -f /etc/dcgm-exporter/counters.csv); echo "dcgm-exporter could not run"; sleep 60 ; }
+          ports:
+            - name: "metrics"
+              containerPort: 9400
+          env:
+            - name: "DCGM_EXPORTER_KUBERNETES"
+              value: "true"
+            - name: "DCGM_EXPORTER_LISTEN"
+              value: ":9400"
+            - name: "DCGM_EXPORTER_INTERVAL"
+              value: "5000"
+            - name: "NODE_NAME"
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.nodeName
+            - name: "LD_LIBRARY_PATH"
+              value: "/usr/local/nvidia/lib64"
+            - name: "DCGM_EXPORTER_KUBERNETES_GPU_ID_TYPE"
+              value: "device-name"
+          volumeMounts:
+            - name: "pod-gpu-resources"
+              readOnly: true
+              mountPath: "/var/lib/kubelet/pod-resources"
+            - name: "nvidia-install-dir-host"
+              mountPath: /usr/local/nvidia
+            - name: zxporter-nodemon-dcgm-metrics
+              mountPath: "/etc/dcgm-exporter"

--- a/dist/install-lowpriv.yaml
+++ b/dist/install-lowpriv.yaml
@@ -769,10 +769,10 @@ metadata:
   name: zxporter-nodemon
   namespace: devzero-system
   labels:
-    helm.sh/chart: zxporter-nodemon-0.0.97
+    helm.sh/chart: zxporter-nodemon-0.0.98
     app.kubernetes.io/name: zxporter-nodemon
     app.kubernetes.io/instance: zxporter-nodemon
-    app.kubernetes.io/version: "0.0.97"
+    app.kubernetes.io/version: "0.0.98"
     app.kubernetes.io/managed-by: Helm
 ---
 # Source: zxporter-nodemon/templates/dcgm-exporter-configmap.yaml
@@ -845,10 +845,10 @@ kind: ClusterRole
 metadata:
   name: zxporter-nodemon
   labels:
-    helm.sh/chart: zxporter-nodemon-0.0.97
+    helm.sh/chart: zxporter-nodemon-0.0.98
     app.kubernetes.io/name: zxporter-nodemon
     app.kubernetes.io/instance: zxporter-nodemon
-    app.kubernetes.io/version: "0.0.97"
+    app.kubernetes.io/version: "0.0.98"
     app.kubernetes.io/managed-by: Helm
 rules:
 - apiGroups:
@@ -895,10 +895,10 @@ kind: ClusterRoleBinding
 metadata:
   name: zxporter-nodemon
   labels:
-    helm.sh/chart: zxporter-nodemon-0.0.97
+    helm.sh/chart: zxporter-nodemon-0.0.98
     app.kubernetes.io/name: zxporter-nodemon
     app.kubernetes.io/instance: zxporter-nodemon
-    app.kubernetes.io/version: "0.0.97"
+    app.kubernetes.io/version: "0.0.98"
     app.kubernetes.io/managed-by: Helm
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -916,10 +916,10 @@ metadata:
   name: zxporter-nodemon
   namespace: devzero-system
   labels:
-    helm.sh/chart: zxporter-nodemon-0.0.97
+    helm.sh/chart: zxporter-nodemon-0.0.98
     app.kubernetes.io/name: zxporter-nodemon
     app.kubernetes.io/instance: zxporter-nodemon
-    app.kubernetes.io/version: "0.0.97"
+    app.kubernetes.io/version: "0.0.98"
     app.kubernetes.io/managed-by: Helm
   annotations:
     ignore-check.kube-linter.io/privileged-container: "This daemon set needs to run DCGM Exporter as privileged to access the GPU metrics."
@@ -1041,10 +1041,10 @@ metadata:
   name: zxporter-nodemon-gpu
   namespace: devzero-system
   labels:
-    helm.sh/chart: zxporter-nodemon-0.0.97
+    helm.sh/chart: zxporter-nodemon-0.0.98
     app.kubernetes.io/name: zxporter-nodemon
     app.kubernetes.io/instance: zxporter-nodemon-gpu
-    app.kubernetes.io/version: "0.0.97"
+    app.kubernetes.io/version: "0.0.98"
     app.kubernetes.io/managed-by: Helm
   annotations:
     ignore-check.kube-linter.io/privileged-container: "This daemon set needs to run DCGM Exporter as privileged to access the GPU metrics."

--- a/dist/install-lowpriv.yaml
+++ b/dist/install-lowpriv.yaml
@@ -1,0 +1,1161 @@
+# ZXPorter installer bundle
+apiVersion: v1
+kind: Namespace
+metadata:
+  labels:
+    control-plane: controller-manager
+    app.kubernetes.io/name: devzero-system
+  name: devzero-system
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  labels:
+    app.kubernetes.io/managed-by: kustomize
+    app.kubernetes.io/name: devzero-zxporter
+    control-plane: controller-manager
+  name: devzero-system
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  labels:
+    app.kubernetes.io/managed-by: kustomize
+    app.kubernetes.io/name: devzero-zxporter
+  name: devzero-zxporter-controller-manager
+  namespace: devzero-system
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  labels:
+    app.kubernetes.io/managed-by: kustomize
+    app.kubernetes.io/name: devzero-zxporter
+  name: devzero-zxporter-leader-election-role
+  namespace: devzero-system
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  - deployments
+  - serviceaccounts
+  - services
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - patch
+  - delete
+- apiGroups:
+  - apps
+  resources:
+  - deployments
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - patch
+  - delete
+- apiGroups:
+  - coordination.k8s.io
+  resources:
+  - leases
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - patch
+  - delete
+- apiGroups:
+  - ""
+  resources:
+  - events
+  verbs:
+  - create
+  - patch
+- apiGroups:
+  - rbac.authorization.k8s.io
+  resources:
+  - rolebindings
+  - roles
+  - clusterrolebindings
+  - clusterroles
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    app.kubernetes.io/managed-by: kustomize
+    app.kubernetes.io/name: devzero-zxporter
+  name: devzero-zxporter-collectionpolicy-editor-role
+rules:
+- apiGroups:
+  - devzero.io
+  resources:
+  - collectionpolicies
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - devzero.io
+  resources:
+  - collectionpolicies/status
+  verbs:
+  - get
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    app.kubernetes.io/managed-by: kustomize
+    app.kubernetes.io/name: devzero-zxporter
+  name: devzero-zxporter-collectionpolicy-viewer-role
+rules:
+- apiGroups:
+  - devzero.io
+  resources:
+  - collectionpolicies
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - devzero.io
+  resources:
+  - collectionpolicies/status
+  verbs:
+  - get
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: devzero-zxporter-manager-role
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  verbs:
+  - get
+  - list
+  - update
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - endpoints
+  - events
+  - limitranges
+  - namespaces
+  - nodes
+  - persistentvolumeclaims
+  - persistentvolumes
+  - pods
+  - replicationcontrollers
+  - resourcequotas
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - nodes/metrics
+  - nodes/proxy
+  - nodes/status
+  - pods/status
+  verbs:
+  - get
+- apiGroups:
+  - ""
+  resources:
+  - secrets
+  verbs:
+  - create
+- apiGroups:
+  - ""
+  resourceNames:
+  - devzero-zxporter-token
+  resources:
+  - secrets
+  verbs:
+  - get
+  - patch
+  - update
+- apiGroups:
+  - ""
+  resources:
+  - serviceaccounts
+  - services
+  verbs:
+  - create
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - apiextensions.k8s.io
+  resources:
+  - customresourcedefinitions
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - apiregistration.k8s.io
+  resources:
+  - apiservices
+  verbs:
+  - create
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - apps
+  resources:
+  - daemonsets
+  - replicasets
+  - statefulsets
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - apps
+  resources:
+  - deployments
+  verbs:
+  - create
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - argoproj.io
+  resources:
+  - rollouts
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - autoscaling
+  resources:
+  - horizontalpodautoscalers
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - autoscaling.k8s.io
+  resources:
+  - verticalpodautoscalers
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - batch
+  resources:
+  - cronjobs
+  - jobs
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - batch.volcano.sh
+  resources:
+  - jobs
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - dakr.devzero.io
+  resources:
+  - workloadrecommendations
+  - workloadrules
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - datadoghq.com
+  resources:
+  - extendeddaemonsetreplicasets
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - devzero.io
+  resources:
+  - collectionpolicies
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - devzero.io
+  resources:
+  - collectionpolicies/finalizers
+  verbs:
+  - update
+- apiGroups:
+  - devzero.io
+  resources:
+  - collectionpolicies/status
+  verbs:
+  - get
+  - patch
+  - update
+- apiGroups:
+  - devzero.karpenter.sh
+  resources:
+  - karpentersettings
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - karpenter.azure.com
+  resources:
+  - aksnodeclasses
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - karpenter.k8s.aws
+  resources:
+  - awsnodetemplates
+  - ec2nodeclasses
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - karpenter.k8s.gcp
+  resources:
+  - gcenodeclasses
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - karpenter.k8s.oracle
+  resources:
+  - ocinodeclasses
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - karpenter.sh
+  resources:
+  - machines
+  - nodeclaims
+  - nodeoverlays
+  - nodepools
+  - provisioners
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - keda.sh
+  resources:
+  - clustertriggerauthentications
+  - scaledjobs
+  - scaledobjects
+  - triggerauthentications
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - kubeflow.org
+  resources:
+  - notebooks
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - metrics.k8s.io
+  resources:
+  - nodes
+  - pods
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - networking.k8s.io
+  resources:
+  - ingressclasses
+  - ingresses
+  - networkpolicies
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - policy
+  resources:
+  - poddisruptionbudgets
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - postgresql.cnpg.io
+  resources:
+  - clusters
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - rbac.authorization.k8s.io
+  resources:
+  - clusterrolebindings
+  - clusterroles
+  - rolebindings
+  verbs:
+  - create
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - rbac.authorization.k8s.io
+  resources:
+  - roles
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - sparkoperator.k8s.io
+  resources:
+  - scheduledsparkapplications
+  - sparkapplications
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - storage.k8s.io
+  resources:
+  - csidrivers
+  - csinodes
+  - csistoragecapacities
+  - storageclasses
+  - volumeattachments
+  verbs:
+  - get
+  - list
+  - watch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: devzero-zxporter-metrics-auth-role
+rules:
+- apiGroups:
+  - authentication.k8s.io
+  resources:
+  - tokenreviews
+  verbs:
+  - create
+- apiGroups:
+  - authorization.k8s.io
+  resources:
+  - subjectaccessreviews
+  verbs:
+  - create
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: devzero-zxporter-metrics-reader
+rules:
+- nonResourceURLs:
+  - /metrics
+  verbs:
+  - get
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  labels:
+    app.kubernetes.io/managed-by: kustomize
+    app.kubernetes.io/name: devzero-zxporter
+  name: devzero-zxporter-leader-election-rolebinding
+  namespace: devzero-system
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: devzero-zxporter-leader-election-role
+subjects:
+- kind: ServiceAccount
+  name: devzero-zxporter-controller-manager
+  namespace: devzero-system
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  labels:
+    app.kubernetes.io/managed-by: kustomize
+    app.kubernetes.io/name: devzero-zxporter
+  name: devzero-zxporter-manager-rolebinding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: devzero-zxporter-manager-role
+subjects:
+- kind: ServiceAccount
+  name: devzero-zxporter-controller-manager
+  namespace: devzero-system
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: devzero-zxporter-metrics-auth-rolebinding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: devzero-zxporter-metrics-auth-role
+subjects:
+- kind: ServiceAccount
+  name: devzero-zxporter-controller-manager
+  namespace: devzero-system
+---
+apiVersion: v1
+data:
+  BUFFER_SIZE: ""
+  CLUSTER_TOKEN: ""
+  COLLECTION_FREQUENCY: ""
+  DAKR_URL: https://dakr.devzero.io
+  DISABLED_COLLECTORS: ""
+  EXCLUDED_CLUSTERROLEBINDINGS: ""
+  EXCLUDED_CLUSTERROLES: ""
+  EXCLUDED_CRDGROUPS: ""
+  EXCLUDED_CRDS: ""
+  EXCLUDED_CRONJOBS: ""
+  EXCLUDED_DAEMONSETS: ""
+  EXCLUDED_DEPLOYMENTS: ""
+  EXCLUDED_ENDPOINTS: ""
+  EXCLUDED_EVENTS: ""
+  EXCLUDED_HPAS: ""
+  EXCLUDED_INGRESSCLASSES: ""
+  EXCLUDED_INGRESSES: ""
+  EXCLUDED_JOBS: ""
+  EXCLUDED_LIMITRANGES: ""
+  EXCLUDED_NAMESPACES: ""
+  EXCLUDED_NETWORKPOLICIES: ""
+  EXCLUDED_NODES: ""
+  EXCLUDED_PDBS: ""
+  EXCLUDED_PODS: ""
+  EXCLUDED_PSPS: ""
+  EXCLUDED_PVCS: ""
+  EXCLUDED_PVS: ""
+  EXCLUDED_REPLICATIONCONTROLLERS: ""
+  EXCLUDED_RESOURCEQUOTAS: ""
+  EXCLUDED_ROLEBINDINGS: ""
+  EXCLUDED_ROLES: ""
+  EXCLUDED_SERVICEACCOUNTS: ""
+  EXCLUDED_SERVICES: ""
+  EXCLUDED_STATEFULSETS: ""
+  EXCLUDED_STORAGECLASSES: ""
+  EXCLUDED_VPAS: ""
+  K8S_PROVIDER: '{{ .k8s_provider }}'
+  KUBE_CONTEXT_NAME: '{{ .kube_context_name }}'
+  MASK_SECRET_DATA: ""
+  NODE_METRICS_INTERVAL: ""
+  TARGET_NAMESPACES: ""
+  TOKEN_CONFIGMAP_NAME: devzero-zxporter-env-config
+  TOKEN_CREDENTIALS_SECRET_NAME: devzero-zxporter-credentials
+  TOKEN_RUNTIME_SECRET_NAME: devzero-zxporter-token
+  TOKEN_SECRET_NAME: devzero-zxporter-token
+  USE_SECRET_FOR_TOKEN: "true"
+  WATCHED_CRDS: ""
+kind: ConfigMap
+metadata:
+  name: devzero-zxporter-env-config
+  namespace: devzero-system
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: devzero-zxporter-token
+  namespace: devzero-system
+stringData:
+  CLUSTER_TOKEN: '{{ .cluster_token }}'
+type: Opaque
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app.kubernetes.io/managed-by: kustomize
+    app.kubernetes.io/name: devzero-zxporter
+    control-plane: controller-manager
+  name: devzero-zxporter-controller-manager-metrics-service
+  namespace: devzero-system
+spec:
+  ports:
+  - name: https
+    port: 8443
+    protocol: TCP
+    targetPort: 8443
+  selector:
+    control-plane: controller-manager
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app.kubernetes.io/name: devzero-zxporter
+    control-plane: controller-manager
+  name: devzero-zxporter-controller-manager-mpa
+  namespace: devzero-system
+spec:
+  ports:
+  - name: mpa-grpc
+    port: 50051
+    protocol: TCP
+    targetPort: mpa-grpc
+  selector:
+    control-plane: controller-manager
+  type: ClusterIP
+---
+apiVersion: scheduling.k8s.io/v1
+description: This priority class is for critical zxporter infrastructure components.
+globalDefault: false
+kind: PriorityClass
+metadata:
+  name: devzero-zxporter-devzero-zxporter-critical
+preemptionPolicy: PreemptLowerPriority
+value: 1000000000
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app.kubernetes.io/managed-by: kustomize
+    app.kubernetes.io/name: devzero-zxporter
+    control-plane: controller-manager
+  name: devzero-zxporter-controller-manager
+  namespace: devzero-system
+spec:
+  replicas: 2
+  selector:
+    matchLabels:
+      control-plane: controller-manager
+  template:
+    metadata:
+      annotations:
+        kubectl.kubernetes.io/default-container: manager
+      labels:
+        app.kubernetes.io/instance: zxporter
+        app.kubernetes.io/name: zxporter
+        control-plane: controller-manager
+    spec:
+      containers:
+      - args:
+        - --metrics-bind-address=:8443
+        - --leader-elect
+        - --mpa-server-port=50051
+        - --health-probe-bind-address=:8081
+        env:
+        - name: POD_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        - name: CLUSTER_TOKEN
+          valueFrom:
+            secretKeyRef:
+              key: CLUSTER_TOKEN
+              name: devzero-zxporter-token
+              optional: true
+        image: ttl.sh/zxporter:latest
+        livenessProbe:
+          httpGet:
+            path: /healthz
+            port: 8081
+          initialDelaySeconds: 15
+          periodSeconds: 20
+        name: manager
+        ports:
+        - containerPort: 50051
+          name: mpa-grpc
+          protocol: TCP
+        readinessProbe:
+          httpGet:
+            path: /readyz
+            port: 8081
+          initialDelaySeconds: 5
+          periodSeconds: 10
+        resources:
+          requests:
+            cpu: 200m
+            memory: 2Gi
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
+        volumeMounts:
+        - mountPath: /etc/zxporter/config
+          name: config-volume
+          readOnly: true
+      priorityClassName: devzero-zxporter-devzero-zxporter-critical
+      securityContext:
+        runAsNonRoot: true
+      serviceAccountName: devzero-zxporter-controller-manager
+      terminationGracePeriodSeconds: 10
+      volumes:
+      - configMap:
+          name: devzero-zxporter-env-config
+        name: config-volume
+---
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: devzero-zxporter-devzero-zxporter-pdb
+  namespace: devzero-system
+spec:
+  minAvailable: 1
+  selector:
+    matchLabels:
+      control-plane: controller-manager
+---
+# Source: zxporter-nodemon/templates/rbac.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: zxporter-nodemon
+  namespace: devzero-system
+  labels:
+    helm.sh/chart: zxporter-nodemon-0.0.97
+    app.kubernetes.io/name: zxporter-nodemon
+    app.kubernetes.io/instance: zxporter-nodemon
+    app.kubernetes.io/version: "0.0.97"
+    app.kubernetes.io/managed-by: Helm
+---
+# Source: zxporter-nodemon/templates/dcgm-exporter-configmap.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: zxporter-nodemon-dcgm-metrics
+  namespace: devzero-system
+data:
+  counters.csv: |
+    # Temperature and power usage,,
+    DCGM_FI_DEV_GPU_TEMP, gauge, Current temperature readings for the device in degrees C.
+    DCGM_FI_DEV_MEMORY_TEMP, gauge, Memory temperature for the device.
+    DCGM_FI_DEV_POWER_USAGE, gauge, Power usage for the device in Watts.
+
+    # Utilization,,
+    # DCGM_FI_DEV_GPU_UTIL provides overall GPU utilization which is useful for scenarios
+    # like fractional GPU sharing (e.g., EKS time-slicing, MIG) where profiling metrics may not be available.
+    DCGM_FI_DEV_GPU_UTIL, gauge, GPU utilization (in %).
+    # DCGM_FI_PROF_SM_ACTIVE, gauge, The ratio of cycles an SM has at least 1 warp assigned
+    # DCGM_FI_PROF_SM_OCCUPANCY, gauge, The fraction of resident warps on a multiprocessor
+    # DCGM_FI_PROF_GR_ENGINE_ACTIVE, gauge, Ratio of time the graphics engine is active (in %).
+    # DCGM_FI_PROF_DRAM_ACTIVE, gauge, The ratio of cycles the device memory interface is active sending or receiving data.
+
+    # Memory usage,,
+    DCGM_FI_DEV_FB_FREE, gauge, Framebuffer memory free (in MiB).
+    DCGM_FI_DEV_FB_USED, gauge, Framebuffer memory used (in MiB).
+    DCGM_FI_DEV_FB_TOTAL, gauge, Total Frame Buffer of the GPU in MB.
+    DCGM_FI_DEV_MEM_COPY_UTIL, gauge, Utilization of the memory copy engine.
+
+    # PCIE,,
+    # DCGM_FI_PROF_PCIE_TX_BYTES, gauge, Total number of bytes transmitted through PCIe TX
+    # DCGM_FI_PROF_PCIE_RX_BYTES, gauge, Total number of bytes received through PCIe RX
+    DCGM_FI_DEV_PCIE_LINK_GEN, gauge, PCIe Current Link Generation.
+    DCGM_FI_DEV_PCIE_LINK_WIDTH, gauge, PCIe Current Link Width.
+
+    # Pipelines,,
+    # DCGM_FI_PROF_PIPE_INT_ACTIVE, gauge, Ratio of cycles the integer pipe is active.
+    # DCGM_FI_PROF_PIPE_FP16_ACTIVE, gauge, Ratio of cycles the fp16 pipe is active.
+    # DCGM_FI_PROF_PIPE_FP32_ACTIVE, gauge, Ratio of cycles the fp32 pipe is active.
+    # DCGM_FI_PROF_PIPE_FP64_ACTIVE, gauge, Ratio of cycles the fp64 pipe is active.
+    # DCGM_FI_PROF_PIPE_TENSOR_ACTIVE, gauge, The ratio of cycles the tensor (HMMA) pipe is active (off the peak sustained elapsed cycles)
+
+    # Health,,
+    # DCGM_FI_DEV_CLOCKS_EVENT_REASONS is not supported by DCGM 3.3.7
+    # DCGM_FI_DEV_CLOCKS_EVENT_REASONS, gauge, Current clock event reasons (bitmask of DCGM_CLOCKS_EVENT_REASON_*)
+    DCGM_FI_DEV_XID_ERRORS, gauge, The value is the specific XID error
+    DCGM_FI_DEV_POWER_VIOLATION, gauge, Power Violation time in ns.
+    DCGM_FI_DEV_THERMAL_VIOLATION, gauge, Thermal Violation time in ns.
+
+    # NVLink,,
+    # DCGM_FI_PROF_NVLINK_TX_BYTES, gauge, The number of bytes of active NvLink tx (transmit) data including both header and payload.
+    # DCGM_FI_PROF_NVLINK_RX_BYTES, gauge, The number of bytes of active NvLink rx (read) data including both header and payload.
+
+    # Clocks,,
+    DCGM_FI_DEV_SM_CLOCK, gauge, SM clock frequency (in MHz).
+    DCGM_FI_DEV_MEM_CLOCK, gauge, Memory clock frequency (in MHz).
+---
+# Source: zxporter-nodemon/templates/nodemon-configmap.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: zxporter-nodemon-zxporter-nodemon
+  namespace: devzero-system
+data:
+---
+# Source: zxporter-nodemon/templates/rbac.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: zxporter-nodemon
+  labels:
+    helm.sh/chart: zxporter-nodemon-0.0.97
+    app.kubernetes.io/name: zxporter-nodemon
+    app.kubernetes.io/instance: zxporter-nodemon
+    app.kubernetes.io/version: "0.0.97"
+    app.kubernetes.io/managed-by: Helm
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  verbs:
+  - get
+  - list
+- apiGroups:
+    - apps
+  resources:
+    - replicasets
+    - deployments
+    - statefulsets
+    - daemonsets
+  verbs:
+    - get
+- apiGroups:
+    - batch
+  resources:
+    - jobs
+    - cronjobs
+  verbs:
+    - get
+- apiGroups:
+    - argoproj.io
+  resources:
+    - rollouts
+  verbs:
+    - get
+- apiGroups:
+    - ""
+  resources:
+    - nodes/proxy
+    - nodes/metrics
+    - nodes/stats
+  verbs:
+    - get
+---
+# Source: zxporter-nodemon/templates/rbac.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: zxporter-nodemon
+  labels:
+    helm.sh/chart: zxporter-nodemon-0.0.97
+    app.kubernetes.io/name: zxporter-nodemon
+    app.kubernetes.io/instance: zxporter-nodemon
+    app.kubernetes.io/version: "0.0.97"
+    app.kubernetes.io/managed-by: Helm
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: zxporter-nodemon
+subjects:
+- kind: ServiceAccount
+  name: zxporter-nodemon
+  namespace: devzero-system
+---
+# Source: zxporter-nodemon/templates/daemonset.yaml
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: zxporter-nodemon
+  namespace: devzero-system
+  labels:
+    helm.sh/chart: zxporter-nodemon-0.0.97
+    app.kubernetes.io/name: zxporter-nodemon
+    app.kubernetes.io/instance: zxporter-nodemon
+    app.kubernetes.io/version: "0.0.97"
+    app.kubernetes.io/managed-by: Helm
+  annotations:
+    ignore-check.kube-linter.io/privileged-container: "This daemon set needs to run DCGM Exporter as privileged to access the GPU metrics."
+    ignore-check.kube-linter.io/run-as-non-root: "This daemon set needs to run DCGM Exporter as root to access the GPU metrics."
+    ignore-check.kube-linter.io/privilege-escalation-container: "This daemon set needs escalate privileges for DCGM Exporter."
+    ignore-check.kube-linter.io/no-read-only-root-fs: "This daemon set needs to run DCGM Exporter with read-only root filesystem."
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: zxporter-nodemon
+      app.kubernetes.io/instance: zxporter-nodemon
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: zxporter-nodemon
+        app.kubernetes.io/instance: zxporter-nodemon
+    spec:
+      priorityClassName: devzero-zxporter-devzero-zxporter-critical
+      serviceAccountName: zxporter-nodemon
+      volumes:
+        - name: "pod-gpu-resources"
+          hostPath:
+            path: /var/lib/kubelet/pod-resources
+        - name: zxporter-nodemon-dcgm-metrics
+          configMap:
+            name: zxporter-nodemon-dcgm-metrics
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: nvidia.com/gpu.present
+                operator: NotIn
+                values:
+                - "true"
+      tolerations:
+        - effect: NoExecute
+          operator: Exists
+        - effect: NoSchedule
+          operator: Exists
+        - effect: PreferNoSchedule
+          operator: Exists
+      containers:
+        - name: zxporter-nodemon
+          securityContext:
+            readOnlyRootFilesystem: true
+            runAsNonRoot: true
+          image: "ttl.sh/zxporter-nodemon:latest"
+          imagePullPolicy: IfNotPresent
+          ports:
+            - name: http
+              containerPort: 6061
+              protocol: TCP
+          livenessProbe:
+            httpGet:
+              path: /healthz
+              port: http
+          readinessProbe:
+            httpGet:
+              path: /healthz
+              port: http
+          envFrom:
+            - configMapRef:
+                name: zxporter-nodemon-zxporter-nodemon
+          env:
+            - name: "NODE_NAME"
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.nodeName
+            - name: "RUNTIME_METRICS_ENABLED"
+              value: "false"
+            - name: "DCGM_HOST"
+              value: "localhost"
+          resources:
+            limits:
+              memory: 256Mi
+            requests:
+              cpu: 60m
+              memory: 256Mi
+        - name: dcgm-exporter
+          securityContext:
+            capabilities:
+              add:
+                - SYS_ADMIN
+              drop:
+                - NET_RAW
+            runAsNonRoot: false
+            runAsUser: 0
+          image: "nvcr.io/nvidia/k8s/dcgm-exporter:4.5.2-4.8.1-ubuntu22.04"
+          imagePullPolicy: IfNotPresent
+          command: [ "/bin/bash", "-c" ]
+          args:
+            - hostname $NODE_NAME; for ((;;)) { r=$(dcgm-exporter -f /etc/dcgm-exporter/counters.csv); echo "dcgm-exporter could not run"; sleep 60 ; }
+          ports:
+            - name: "metrics"
+              containerPort: 9400
+          env:
+            - name: "DCGM_EXPORTER_KUBERNETES"
+              value: "true"
+            - name: "DCGM_EXPORTER_LISTEN"
+              value: ":9400"
+            - name: "DCGM_EXPORTER_INTERVAL"
+              value: "5000"
+            - name: "NODE_NAME"
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.nodeName
+          volumeMounts:
+            - name: "pod-gpu-resources"
+              readOnly: true
+              mountPath: "/var/lib/kubelet/pod-resources"
+            - name: zxporter-nodemon-dcgm-metrics
+              mountPath: "/etc/dcgm-exporter"
+---
+# Source: zxporter-nodemon/templates/daemonset.yaml
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: zxporter-nodemon-gpu
+  namespace: devzero-system
+  labels:
+    helm.sh/chart: zxporter-nodemon-0.0.97
+    app.kubernetes.io/name: zxporter-nodemon
+    app.kubernetes.io/instance: zxporter-nodemon-gpu
+    app.kubernetes.io/version: "0.0.97"
+    app.kubernetes.io/managed-by: Helm
+  annotations:
+    ignore-check.kube-linter.io/privileged-container: "This daemon set needs to run DCGM Exporter as privileged to access the GPU metrics."
+    ignore-check.kube-linter.io/run-as-non-root: "This daemon set needs to run DCGM Exporter as root to access the GPU metrics."
+    ignore-check.kube-linter.io/privilege-escalation-container: "This daemon set needs escalate privileges for DCGM Exporter."
+    ignore-check.kube-linter.io/no-read-only-root-fs: "This daemon set needs to run DCGM Exporter with read-only root filesystem."
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: zxporter-nodemon
+      app.kubernetes.io/instance: zxporter-nodemon-gpu
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: zxporter-nodemon
+        app.kubernetes.io/instance: zxporter-nodemon-gpu
+    spec:
+      priorityClassName: devzero-zxporter-devzero-zxporter-critical
+      runtimeClassName: "nvidia"
+      serviceAccountName: zxporter-nodemon
+      volumes:
+        - name: "pod-gpu-resources"
+          hostPath:
+            path: /var/lib/kubelet/pod-resources
+        - name: zxporter-nodemon-dcgm-metrics
+          configMap:
+            name: zxporter-nodemon-dcgm-metrics
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: nvidia.com/gpu.present
+                operator: In
+                values:
+                - "true"
+      tolerations:
+        - effect: NoExecute
+          operator: Exists
+        - effect: NoSchedule
+          operator: Exists
+        - effect: PreferNoSchedule
+          operator: Exists
+      containers:
+        - name: zxporter-nodemon
+          securityContext:
+            readOnlyRootFilesystem: true
+            runAsNonRoot: true
+          image: "ttl.sh/zxporter-nodemon:latest"
+          imagePullPolicy: IfNotPresent
+          ports:
+            - name: http
+              containerPort: 6061
+              protocol: TCP
+          livenessProbe:
+            httpGet:
+              path: /healthz
+              port: http
+          readinessProbe:
+            httpGet:
+              path: /healthz
+              port: http
+          envFrom:
+            - configMapRef:
+                name: zxporter-nodemon-zxporter-nodemon
+          env:
+            - name: "NODE_NAME"
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.nodeName
+            - name: "RUNTIME_METRICS_ENABLED"
+              value: "false"
+            - name: "DCGM_HOST"
+              value: "localhost"
+          resources:
+            limits:
+              memory: 256Mi
+            requests:
+              cpu: 60m
+              memory: 256Mi
+        - name: dcgm-exporter
+          securityContext:
+            capabilities:
+              add:
+                - SYS_ADMIN
+              drop:
+                - NET_RAW
+            runAsNonRoot: false
+            runAsUser: 0
+          image: "nvcr.io/nvidia/k8s/dcgm-exporter:4.5.2-4.8.1-ubuntu22.04"
+          imagePullPolicy: IfNotPresent
+          command: [ "/bin/bash", "-c" ]
+          args:
+            - hostname $NODE_NAME; for ((;;)) { r=$(dcgm-exporter -f /etc/dcgm-exporter/counters.csv); echo "dcgm-exporter could not run"; sleep 60 ; }
+          ports:
+            - name: "metrics"
+              containerPort: 9400
+          env:
+            - name: "DCGM_EXPORTER_KUBERNETES"
+              value: "true"
+            - name: "DCGM_EXPORTER_LISTEN"
+              value: ":9400"
+            - name: "DCGM_EXPORTER_INTERVAL"
+              value: "5000"
+            - name: "NODE_NAME"
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.nodeName
+          volumeMounts:
+            - name: "pod-gpu-resources"
+              readOnly: true
+              mountPath: "/var/lib/kubelet/pod-resources"
+            - name: zxporter-nodemon-dcgm-metrics
+              mountPath: "/etc/dcgm-exporter"

--- a/dist/installer_updater-gcp-lowpriv.yaml
+++ b/dist/installer_updater-gcp-lowpriv.yaml
@@ -1,0 +1,1118 @@
+# ZXPorter installer bundle
+apiVersion: v1
+kind: Namespace
+metadata:
+  labels:
+    control-plane: controller-manager
+    app.kubernetes.io/name: '{{.zxporter_namespace}}'
+  name: '{{.zxporter_namespace}}'
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  labels:
+    app.kubernetes.io/managed-by: kustomize
+    app.kubernetes.io/name: devzero-zxporter
+    control-plane: controller-manager
+  name: '{{.zxporter_namespace}}'
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  labels:
+    app.kubernetes.io/managed-by: kustomize
+    app.kubernetes.io/name: devzero-zxporter
+  name: devzero-zxporter-controller-manager
+  namespace: '{{.zxporter_namespace}}'
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  labels:
+    app.kubernetes.io/managed-by: kustomize
+    app.kubernetes.io/name: devzero-zxporter
+  name: devzero-zxporter-leader-election-role
+  namespace: '{{.zxporter_namespace}}'
+rules:
+  - apiGroups:
+      - ""
+    resources:
+      - configmaps
+      - deployments
+      - serviceaccounts
+      - services
+    verbs:
+      - get
+      - list
+      - watch
+      - create
+      - update
+      - patch
+      - delete
+  - apiGroups:
+      - apps
+    resources:
+      - deployments
+    verbs:
+      - get
+      - list
+      - watch
+      - create
+      - update
+      - patch
+      - delete
+  - apiGroups:
+      - coordination.k8s.io
+    resources:
+      - leases
+    verbs:
+      - get
+      - list
+      - watch
+      - create
+      - update
+      - patch
+      - delete
+  - apiGroups:
+      - ""
+    resources:
+      - events
+    verbs:
+      - create
+      - patch
+  - apiGroups:
+      - rbac.authorization.k8s.io
+    resources:
+      - rolebindings
+      - roles
+      - clusterrolebindings
+      - clusterroles
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    app.kubernetes.io/managed-by: kustomize
+    app.kubernetes.io/name: devzero-zxporter
+  name: devzero-zxporter-collectionpolicy-editor-role
+rules:
+  - apiGroups:
+      - devzero.io
+    resources:
+      - collectionpolicies
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - devzero.io
+    resources:
+      - collectionpolicies/status
+    verbs:
+      - get
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    app.kubernetes.io/managed-by: kustomize
+    app.kubernetes.io/name: devzero-zxporter
+  name: devzero-zxporter-collectionpolicy-viewer-role
+rules:
+  - apiGroups:
+      - devzero.io
+    resources:
+      - collectionpolicies
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - devzero.io
+    resources:
+      - collectionpolicies/status
+    verbs:
+      - get
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: devzero-zxporter-manager-role
+rules:
+  - apiGroups:
+      - ""
+    resources:
+      - configmaps
+    verbs:
+      - get
+      - list
+      - update
+      - watch
+  - apiGroups:
+      - ""
+    resources:
+      - endpoints
+      - events
+      - limitranges
+      - namespaces
+      - nodes
+      - persistentvolumeclaims
+      - persistentvolumes
+      - pods
+      - replicationcontrollers
+      - resourcequotas
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - ""
+    resources:
+      - nodes/metrics
+      - nodes/proxy
+      - nodes/status
+      - pods/status
+    verbs:
+      - get
+  - apiGroups:
+      - ""
+    resources:
+      - secrets
+    verbs:
+      - create
+  - apiGroups:
+      - ""
+    resourceNames:
+      - devzero-zxporter-token
+    resources:
+      - secrets
+    verbs:
+      - get
+      - patch
+      - update
+  - apiGroups:
+      - ""
+    resources:
+      - serviceaccounts
+      - services
+    verbs:
+      - create
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - apiextensions.k8s.io
+    resources:
+      - customresourcedefinitions
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - apiregistration.k8s.io
+    resources:
+      - apiservices
+    verbs:
+      - create
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - apps
+    resources:
+      - daemonsets
+      - replicasets
+      - statefulsets
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - apps
+    resources:
+      - deployments
+    verbs:
+      - create
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - argoproj.io
+    resources:
+      - rollouts
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - autoscaling
+    resources:
+      - horizontalpodautoscalers
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - autoscaling.k8s.io
+    resources:
+      - verticalpodautoscalers
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - batch
+    resources:
+      - cronjobs
+      - jobs
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - batch.volcano.sh
+    resources:
+      - jobs
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - dakr.devzero.io
+    resources:
+      - workloadrecommendations
+      - workloadrules
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - datadoghq.com
+    resources:
+      - extendeddaemonsetreplicasets
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - devzero.io
+    resources:
+      - collectionpolicies
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - devzero.io
+    resources:
+      - collectionpolicies/finalizers
+    verbs:
+      - update
+  - apiGroups:
+      - devzero.io
+    resources:
+      - collectionpolicies/status
+    verbs:
+      - get
+      - patch
+      - update
+  - apiGroups:
+      - devzero.karpenter.sh
+    resources:
+      - karpentersettings
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - karpenter.azure.com
+    resources:
+      - aksnodeclasses
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - karpenter.k8s.aws
+    resources:
+      - awsnodetemplates
+      - ec2nodeclasses
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - karpenter.k8s.gcp
+    resources:
+      - gcenodeclasses
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - karpenter.k8s.oracle
+    resources:
+      - ocinodeclasses
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - karpenter.sh
+    resources:
+      - machines
+      - nodeclaims
+      - nodeoverlays
+      - nodepools
+      - provisioners
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - keda.sh
+    resources:
+      - clustertriggerauthentications
+      - scaledjobs
+      - scaledobjects
+      - triggerauthentications
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - kubeflow.org
+    resources:
+      - notebooks
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - metrics.k8s.io
+    resources:
+      - nodes
+      - pods
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - networking.k8s.io
+    resources:
+      - ingressclasses
+      - ingresses
+      - networkpolicies
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - policy
+    resources:
+      - poddisruptionbudgets
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - postgresql.cnpg.io
+    resources:
+      - clusters
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - rbac.authorization.k8s.io
+    resources:
+      - clusterrolebindings
+      - clusterroles
+      - rolebindings
+    verbs:
+      - create
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - rbac.authorization.k8s.io
+    resources:
+      - roles
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - sparkoperator.k8s.io
+    resources:
+      - scheduledsparkapplications
+      - sparkapplications
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - storage.k8s.io
+    resources:
+      - csidrivers
+      - csinodes
+      - csistoragecapacities
+      - storageclasses
+      - volumeattachments
+    verbs:
+      - get
+      - list
+      - watch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: devzero-zxporter-metrics-auth-role
+rules:
+  - apiGroups:
+      - authentication.k8s.io
+    resources:
+      - tokenreviews
+    verbs:
+      - create
+  - apiGroups:
+      - authorization.k8s.io
+    resources:
+      - subjectaccessreviews
+    verbs:
+      - create
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: devzero-zxporter-metrics-reader
+rules:
+  - nonResourceURLs:
+      - /metrics
+    verbs:
+      - get
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  labels:
+    app.kubernetes.io/managed-by: kustomize
+    app.kubernetes.io/name: devzero-zxporter
+  name: devzero-zxporter-leader-election-rolebinding
+  namespace: '{{.zxporter_namespace}}'
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: devzero-zxporter-leader-election-role
+subjects:
+  - kind: ServiceAccount
+    name: devzero-zxporter-controller-manager
+    namespace: '{{.zxporter_namespace}}'
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  labels:
+    app.kubernetes.io/managed-by: kustomize
+    app.kubernetes.io/name: devzero-zxporter
+  name: devzero-zxporter-manager-rolebinding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: devzero-zxporter-manager-role
+subjects:
+  - kind: ServiceAccount
+    name: devzero-zxporter-controller-manager
+    namespace: '{{.zxporter_namespace}}'
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: devzero-zxporter-metrics-auth-rolebinding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: devzero-zxporter-metrics-auth-role
+subjects:
+  - kind: ServiceAccount
+    name: devzero-zxporter-controller-manager
+    namespace: '{{.zxporter_namespace}}'
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app.kubernetes.io/managed-by: kustomize
+    app.kubernetes.io/name: devzero-zxporter
+    control-plane: controller-manager
+  name: devzero-zxporter-controller-manager-metrics-service
+  namespace: '{{.zxporter_namespace}}'
+spec:
+  ports:
+    - name: https
+      port: 8443
+      protocol: TCP
+      targetPort: 8443
+  selector:
+    control-plane: controller-manager
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app.kubernetes.io/name: devzero-zxporter
+    control-plane: controller-manager
+  name: devzero-zxporter-controller-manager-mpa
+  namespace: '{{.zxporter_namespace}}'
+spec:
+  ports:
+    - name: mpa-grpc
+      port: 50051
+      protocol: TCP
+      targetPort: mpa-grpc
+  selector:
+    control-plane: controller-manager
+  type: ClusterIP
+---
+apiVersion: scheduling.k8s.io/v1
+description: This priority class is for critical zxporter infrastructure components.
+globalDefault: false
+kind: PriorityClass
+metadata:
+  name: devzero-zxporter-devzero-zxporter-critical
+preemptionPolicy: PreemptLowerPriority
+value: 1000000000
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app.kubernetes.io/managed-by: kustomize
+    app.kubernetes.io/name: devzero-zxporter
+    control-plane: controller-manager
+  name: devzero-zxporter-controller-manager
+  namespace: '{{.zxporter_namespace}}'
+spec:
+  replicas: 2
+  selector:
+    matchLabels:
+      control-plane: controller-manager
+  template:
+    metadata:
+      annotations:
+        kubectl.kubernetes.io/default-container: manager
+      labels:
+        app.kubernetes.io/instance: zxporter
+        app.kubernetes.io/name: zxporter
+        control-plane: controller-manager
+    spec:
+      containers:
+        - args:
+            - --metrics-bind-address=:8443
+            - --leader-elect
+            - --mpa-server-port=50051
+            - --health-probe-bind-address=:8081
+          env:
+            - name: POD_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+            - name: CLUSTER_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  key: CLUSTER_TOKEN
+                  name: devzero-zxporter-token
+                  optional: true
+          image: docker.io/devzeroinc/zxporter:latest
+          livenessProbe:
+            httpGet:
+              path: /healthz
+              port: 8081
+            initialDelaySeconds: 15
+            periodSeconds: 20
+          name: manager
+          ports:
+            - containerPort: 50051
+              name: mpa-grpc
+              protocol: TCP
+          readinessProbe:
+            httpGet:
+              path: /readyz
+              port: 8081
+            initialDelaySeconds: 5
+            periodSeconds: 10
+          resources:
+            requests:
+              cpu: 200m
+              memory: 2Gi
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
+          volumeMounts:
+            - mountPath: /etc/zxporter/config
+              name: config-volume
+              readOnly: true
+      priorityClassName: devzero-zxporter-devzero-zxporter-critical
+      securityContext:
+        runAsNonRoot: true
+      serviceAccountName: devzero-zxporter-controller-manager
+      terminationGracePeriodSeconds: 10
+      volumes:
+        - configMap:
+            name: devzero-zxporter-env-config
+          name: config-volume
+---
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: devzero-zxporter-devzero-zxporter-pdb
+  namespace: '{{.zxporter_namespace}}'
+spec:
+  minAvailable: 1
+  selector:
+    matchLabels:
+      control-plane: controller-manager
+---
+# Source: zxporter-nodemon/templates/rbac.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: zxporter-nodemon
+  namespace: '{{.zxporter_namespace}}'
+  labels:
+    helm.sh/chart: zxporter-nodemon-0.0.97
+    app.kubernetes.io/name: zxporter-nodemon
+    app.kubernetes.io/instance: zxporter-nodemon
+    app.kubernetes.io/version: "0.0.97"
+    app.kubernetes.io/managed-by: Helm
+---
+# Source: zxporter-nodemon/templates/dcgm-exporter-configmap.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: zxporter-nodemon-dcgm-metrics
+  namespace: '{{.zxporter_namespace}}'
+data:
+  counters.csv: |
+    # Temperature and power usage,,
+    DCGM_FI_DEV_GPU_TEMP, gauge, Current temperature readings for the device in degrees C.
+    DCGM_FI_DEV_MEMORY_TEMP, gauge, Memory temperature for the device.
+    DCGM_FI_DEV_POWER_USAGE, gauge, Power usage for the device in Watts.
+
+    # Utilization,,
+    # DCGM_FI_DEV_GPU_UTIL provides overall GPU utilization which is useful for scenarios
+    # like fractional GPU sharing (e.g., EKS time-slicing, MIG) where profiling metrics may not be available.
+    DCGM_FI_DEV_GPU_UTIL, gauge, GPU utilization (in %).
+    # DCGM_FI_PROF_SM_ACTIVE, gauge, The ratio of cycles an SM has at least 1 warp assigned
+    # DCGM_FI_PROF_SM_OCCUPANCY, gauge, The fraction of resident warps on a multiprocessor
+    # DCGM_FI_PROF_GR_ENGINE_ACTIVE, gauge, Ratio of time the graphics engine is active (in %).
+    # DCGM_FI_PROF_DRAM_ACTIVE, gauge, The ratio of cycles the device memory interface is active sending or receiving data.
+
+    # Memory usage,,
+    DCGM_FI_DEV_FB_FREE, gauge, Framebuffer memory free (in MiB).
+    DCGM_FI_DEV_FB_USED, gauge, Framebuffer memory used (in MiB).
+    DCGM_FI_DEV_FB_TOTAL, gauge, Total Frame Buffer of the GPU in MB.
+    DCGM_FI_DEV_MEM_COPY_UTIL, gauge, Utilization of the memory copy engine.
+
+    # PCIE,,
+    # DCGM_FI_PROF_PCIE_TX_BYTES, gauge, Total number of bytes transmitted through PCIe TX
+    # DCGM_FI_PROF_PCIE_RX_BYTES, gauge, Total number of bytes received through PCIe RX
+    DCGM_FI_DEV_PCIE_LINK_GEN, gauge, PCIe Current Link Generation.
+    DCGM_FI_DEV_PCIE_LINK_WIDTH, gauge, PCIe Current Link Width.
+
+    # Pipelines,,
+    # DCGM_FI_PROF_PIPE_INT_ACTIVE, gauge, Ratio of cycles the integer pipe is active.
+    # DCGM_FI_PROF_PIPE_FP16_ACTIVE, gauge, Ratio of cycles the fp16 pipe is active.
+    # DCGM_FI_PROF_PIPE_FP32_ACTIVE, gauge, Ratio of cycles the fp32 pipe is active.
+    # DCGM_FI_PROF_PIPE_FP64_ACTIVE, gauge, Ratio of cycles the fp64 pipe is active.
+    # DCGM_FI_PROF_PIPE_TENSOR_ACTIVE, gauge, The ratio of cycles the tensor (HMMA) pipe is active (off the peak sustained elapsed cycles)
+
+    # Health,,
+    # DCGM_FI_DEV_CLOCKS_EVENT_REASONS is not supported by DCGM 3.3.7
+    # DCGM_FI_DEV_CLOCKS_EVENT_REASONS, gauge, Current clock event reasons (bitmask of DCGM_CLOCKS_EVENT_REASON_*)
+    DCGM_FI_DEV_XID_ERRORS, gauge, The value is the specific XID error
+    DCGM_FI_DEV_POWER_VIOLATION, gauge, Power Violation time in ns.
+    DCGM_FI_DEV_THERMAL_VIOLATION, gauge, Thermal Violation time in ns.
+
+    # NVLink,,
+    # DCGM_FI_PROF_NVLINK_TX_BYTES, gauge, The number of bytes of active NvLink tx (transmit) data including both header and payload.
+    # DCGM_FI_PROF_NVLINK_RX_BYTES, gauge, The number of bytes of active NvLink rx (read) data including both header and payload.
+
+    # Clocks,,
+    DCGM_FI_DEV_SM_CLOCK, gauge, SM clock frequency (in MHz).
+    DCGM_FI_DEV_MEM_CLOCK, gauge, Memory clock frequency (in MHz).
+---
+# Source: zxporter-nodemon/templates/nodemon-configmap.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: zxporter-nodemon-zxporter-nodemon
+  namespace: '{{.zxporter_namespace}}'
+data:
+---
+# Source: zxporter-nodemon/templates/rbac.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: zxporter-nodemon
+  labels:
+    helm.sh/chart: zxporter-nodemon-0.0.97
+    app.kubernetes.io/name: zxporter-nodemon
+    app.kubernetes.io/instance: zxporter-nodemon
+    app.kubernetes.io/version: "0.0.97"
+    app.kubernetes.io/managed-by: Helm
+rules:
+  - apiGroups:
+      - ""
+    resources:
+      - pods
+    verbs:
+      - get
+      - list
+  - apiGroups:
+      - apps
+    resources:
+      - replicasets
+      - deployments
+      - statefulsets
+      - daemonsets
+    verbs:
+      - get
+  - apiGroups:
+      - batch
+    resources:
+      - jobs
+      - cronjobs
+    verbs:
+      - get
+  - apiGroups:
+      - argoproj.io
+    resources:
+      - rollouts
+    verbs:
+      - get
+  - apiGroups:
+      - ""
+    resources:
+      - nodes/proxy
+      - nodes/metrics
+      - nodes/stats
+    verbs:
+      - get
+---
+# Source: zxporter-nodemon/templates/rbac.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: zxporter-nodemon
+  labels:
+    helm.sh/chart: zxporter-nodemon-0.0.97
+    app.kubernetes.io/name: zxporter-nodemon
+    app.kubernetes.io/instance: zxporter-nodemon
+    app.kubernetes.io/version: "0.0.97"
+    app.kubernetes.io/managed-by: Helm
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: zxporter-nodemon
+subjects:
+  - kind: ServiceAccount
+    name: zxporter-nodemon
+    namespace: '{{.zxporter_namespace}}'
+---
+# Source: zxporter-nodemon/templates/daemonset.yaml
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: zxporter-nodemon
+  namespace: '{{.zxporter_namespace}}'
+  labels:
+    helm.sh/chart: zxporter-nodemon-0.0.97
+    app.kubernetes.io/name: zxporter-nodemon
+    app.kubernetes.io/instance: zxporter-nodemon
+    app.kubernetes.io/version: "0.0.97"
+    app.kubernetes.io/managed-by: Helm
+  annotations:
+    ignore-check.kube-linter.io/privileged-container: "This daemon set needs to run DCGM Exporter as privileged to access the GPU metrics."
+    ignore-check.kube-linter.io/run-as-non-root: "This daemon set needs to run DCGM Exporter as root to access the GPU metrics."
+    ignore-check.kube-linter.io/privilege-escalation-container: "This daemon set needs escalate privileges for DCGM Exporter."
+    ignore-check.kube-linter.io/no-read-only-root-fs: "This daemon set needs to run DCGM Exporter with read-only root filesystem."
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: zxporter-nodemon
+      app.kubernetes.io/instance: zxporter-nodemon
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: zxporter-nodemon
+        app.kubernetes.io/instance: zxporter-nodemon
+    spec:
+      priorityClassName: devzero-zxporter-devzero-zxporter-critical
+      serviceAccountName: zxporter-nodemon
+      volumes:
+        - name: "pod-gpu-resources"
+          hostPath:
+            path: /var/lib/kubelet/pod-resources
+        - name: zxporter-nodemon-dcgm-metrics
+          configMap:
+            name: zxporter-nodemon-dcgm-metrics
+        - name: "nvidia-install-dir-host"
+          hostPath:
+            path: /home/kubernetes/bin/nvidia
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+              - matchExpressions:
+                  - key: nvidia.com/gpu.present
+                    operator: NotIn
+                    values:
+                      - "true"
+      tolerations:
+        - effect: NoExecute
+          operator: Exists
+        - effect: NoSchedule
+          operator: Exists
+        - effect: PreferNoSchedule
+          operator: Exists
+      containers:
+        - name: zxporter-nodemon
+          securityContext:
+            readOnlyRootFilesystem: true
+            runAsNonRoot: true
+          image: "docker.io/devzeroinc/zxporter-nodemon:latest"
+          imagePullPolicy: IfNotPresent
+          ports:
+            - name: http
+              containerPort: 6061
+              protocol: TCP
+          livenessProbe:
+            httpGet:
+              path: /healthz
+              port: http
+          readinessProbe:
+            httpGet:
+              path: /healthz
+              port: http
+          envFrom:
+            - configMapRef:
+                name: zxporter-nodemon-zxporter-nodemon
+          env:
+            - name: "NODE_NAME"
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.nodeName
+            - name: "RUNTIME_METRICS_ENABLED"
+              value: "false"
+            - name: "DCGM_HOST"
+              value: "localhost"
+          resources:
+            limits:
+              memory: 256Mi
+            requests:
+              cpu: 60m
+              memory: 256Mi
+        - name: dcgm-exporter
+          securityContext:
+            capabilities:
+              add:
+                - SYS_ADMIN
+              drop:
+                - NET_RAW
+            runAsNonRoot: false
+            runAsUser: 0
+            privileged: true
+          image: "nvcr.io/nvidia/k8s/dcgm-exporter:4.5.2-4.8.1-ubuntu22.04"
+          imagePullPolicy: IfNotPresent
+          command: ["/bin/bash", "-c"]
+          args:
+            - hostname $NODE_NAME; for ((;;)) { r=$(dcgm-exporter -f /etc/dcgm-exporter/counters.csv); echo "dcgm-exporter could not run"; sleep 60 ; }
+          ports:
+            - name: "metrics"
+              containerPort: 9400
+          env:
+            - name: "DCGM_EXPORTER_KUBERNETES"
+              value: "true"
+            - name: "DCGM_EXPORTER_LISTEN"
+              value: ":9400"
+            - name: "DCGM_EXPORTER_INTERVAL"
+              value: "5000"
+            - name: "NODE_NAME"
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.nodeName
+            - name: "LD_LIBRARY_PATH"
+              value: "/usr/local/nvidia/lib64"
+            - name: "DCGM_EXPORTER_KUBERNETES_GPU_ID_TYPE"
+              value: "device-name"
+          volumeMounts:
+            - name: "pod-gpu-resources"
+              readOnly: true
+              mountPath: "/var/lib/kubelet/pod-resources"
+            - name: "nvidia-install-dir-host"
+              mountPath: /usr/local/nvidia
+            - name: zxporter-nodemon-dcgm-metrics
+              mountPath: "/etc/dcgm-exporter"
+---
+# Source: zxporter-nodemon/templates/daemonset.yaml
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: zxporter-nodemon-gpu
+  namespace: '{{.zxporter_namespace}}'
+  labels:
+    helm.sh/chart: zxporter-nodemon-0.0.97
+    app.kubernetes.io/name: zxporter-nodemon
+    app.kubernetes.io/instance: zxporter-nodemon-gpu
+    app.kubernetes.io/version: "0.0.97"
+    app.kubernetes.io/managed-by: Helm
+  annotations:
+    ignore-check.kube-linter.io/privileged-container: "This daemon set needs to run DCGM Exporter as privileged to access the GPU metrics."
+    ignore-check.kube-linter.io/run-as-non-root: "This daemon set needs to run DCGM Exporter as root to access the GPU metrics."
+    ignore-check.kube-linter.io/privilege-escalation-container: "This daemon set needs escalate privileges for DCGM Exporter."
+    ignore-check.kube-linter.io/no-read-only-root-fs: "This daemon set needs to run DCGM Exporter with read-only root filesystem."
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: zxporter-nodemon
+      app.kubernetes.io/instance: zxporter-nodemon-gpu
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: zxporter-nodemon
+        app.kubernetes.io/instance: zxporter-nodemon-gpu
+    spec:
+      priorityClassName: devzero-zxporter-devzero-zxporter-critical
+      runtimeClassName: "nvidia"
+      serviceAccountName: zxporter-nodemon
+      volumes:
+        - name: "pod-gpu-resources"
+          hostPath:
+            path: /var/lib/kubelet/pod-resources
+        - name: zxporter-nodemon-dcgm-metrics
+          configMap:
+            name: zxporter-nodemon-dcgm-metrics
+        - name: "nvidia-install-dir-host"
+          hostPath:
+            path: /home/kubernetes/bin/nvidia
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+              - matchExpressions:
+                  - key: nvidia.com/gpu.present
+                    operator: In
+                    values:
+                      - "true"
+      tolerations:
+        - effect: NoExecute
+          operator: Exists
+        - effect: NoSchedule
+          operator: Exists
+        - effect: PreferNoSchedule
+          operator: Exists
+      containers:
+        - name: zxporter-nodemon
+          securityContext:
+            readOnlyRootFilesystem: true
+            runAsNonRoot: true
+          image: "docker.io/devzeroinc/zxporter-nodemon:latest"
+          imagePullPolicy: IfNotPresent
+          ports:
+            - name: http
+              containerPort: 6061
+              protocol: TCP
+          livenessProbe:
+            httpGet:
+              path: /healthz
+              port: http
+          readinessProbe:
+            httpGet:
+              path: /healthz
+              port: http
+          envFrom:
+            - configMapRef:
+                name: zxporter-nodemon-zxporter-nodemon
+          env:
+            - name: "NODE_NAME"
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.nodeName
+            - name: "RUNTIME_METRICS_ENABLED"
+              value: "false"
+            - name: "DCGM_HOST"
+              value: "localhost"
+          resources:
+            limits:
+              memory: 256Mi
+            requests:
+              cpu: 60m
+              memory: 256Mi
+        - name: dcgm-exporter
+          securityContext:
+            capabilities:
+              add:
+                - SYS_ADMIN
+              drop:
+                - NET_RAW
+            runAsNonRoot: false
+            runAsUser: 0
+            privileged: true
+          image: "nvcr.io/nvidia/k8s/dcgm-exporter:4.5.2-4.8.1-ubuntu22.04"
+          imagePullPolicy: IfNotPresent
+          command: ["/bin/bash", "-c"]
+          args:
+            - hostname $NODE_NAME; for ((;;)) { r=$(dcgm-exporter -f /etc/dcgm-exporter/counters.csv); echo "dcgm-exporter could not run"; sleep 60 ; }
+          ports:
+            - name: "metrics"
+              containerPort: 9400
+          env:
+            - name: "DCGM_EXPORTER_KUBERNETES"
+              value: "true"
+            - name: "DCGM_EXPORTER_LISTEN"
+              value: ":9400"
+            - name: "DCGM_EXPORTER_INTERVAL"
+              value: "5000"
+            - name: "NODE_NAME"
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.nodeName
+            - name: "LD_LIBRARY_PATH"
+              value: "/usr/local/nvidia/lib64"
+            - name: "DCGM_EXPORTER_KUBERNETES_GPU_ID_TYPE"
+              value: "device-name"
+          volumeMounts:
+            - name: "pod-gpu-resources"
+              readOnly: true
+              mountPath: "/var/lib/kubelet/pod-resources"
+            - name: "nvidia-install-dir-host"
+              mountPath: /usr/local/nvidia
+            - name: zxporter-nodemon-dcgm-metrics
+              mountPath: "/etc/dcgm-exporter"

--- a/dist/installer_updater-gcp-lowpriv.yaml
+++ b/dist/installer_updater-gcp-lowpriv.yaml
@@ -706,10 +706,10 @@ metadata:
   name: zxporter-nodemon
   namespace: '{{.zxporter_namespace}}'
   labels:
-    helm.sh/chart: zxporter-nodemon-0.0.97
+    helm.sh/chart: zxporter-nodemon-0.0.98
     app.kubernetes.io/name: zxporter-nodemon
     app.kubernetes.io/instance: zxporter-nodemon
-    app.kubernetes.io/version: "0.0.97"
+    app.kubernetes.io/version: "0.0.98"
     app.kubernetes.io/managed-by: Helm
 ---
 # Source: zxporter-nodemon/templates/dcgm-exporter-configmap.yaml
@@ -782,10 +782,10 @@ kind: ClusterRole
 metadata:
   name: zxporter-nodemon
   labels:
-    helm.sh/chart: zxporter-nodemon-0.0.97
+    helm.sh/chart: zxporter-nodemon-0.0.98
     app.kubernetes.io/name: zxporter-nodemon
     app.kubernetes.io/instance: zxporter-nodemon
-    app.kubernetes.io/version: "0.0.97"
+    app.kubernetes.io/version: "0.0.98"
     app.kubernetes.io/managed-by: Helm
 rules:
   - apiGroups:
@@ -832,10 +832,10 @@ kind: ClusterRoleBinding
 metadata:
   name: zxporter-nodemon
   labels:
-    helm.sh/chart: zxporter-nodemon-0.0.97
+    helm.sh/chart: zxporter-nodemon-0.0.98
     app.kubernetes.io/name: zxporter-nodemon
     app.kubernetes.io/instance: zxporter-nodemon
-    app.kubernetes.io/version: "0.0.97"
+    app.kubernetes.io/version: "0.0.98"
     app.kubernetes.io/managed-by: Helm
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -853,10 +853,10 @@ metadata:
   name: zxporter-nodemon
   namespace: '{{.zxporter_namespace}}'
   labels:
-    helm.sh/chart: zxporter-nodemon-0.0.97
+    helm.sh/chart: zxporter-nodemon-0.0.98
     app.kubernetes.io/name: zxporter-nodemon
     app.kubernetes.io/instance: zxporter-nodemon
-    app.kubernetes.io/version: "0.0.97"
+    app.kubernetes.io/version: "0.0.98"
     app.kubernetes.io/managed-by: Helm
   annotations:
     ignore-check.kube-linter.io/privileged-container: "This daemon set needs to run DCGM Exporter as privileged to access the GPU metrics."
@@ -988,10 +988,10 @@ metadata:
   name: zxporter-nodemon-gpu
   namespace: '{{.zxporter_namespace}}'
   labels:
-    helm.sh/chart: zxporter-nodemon-0.0.97
+    helm.sh/chart: zxporter-nodemon-0.0.98
     app.kubernetes.io/name: zxporter-nodemon
     app.kubernetes.io/instance: zxporter-nodemon-gpu
-    app.kubernetes.io/version: "0.0.97"
+    app.kubernetes.io/version: "0.0.98"
     app.kubernetes.io/managed-by: Helm
   annotations:
     ignore-check.kube-linter.io/privileged-container: "This daemon set needs to run DCGM Exporter as privileged to access the GPU metrics."

--- a/dist/installer_updater-lowpriv.yaml
+++ b/dist/installer_updater-lowpriv.yaml
@@ -706,10 +706,10 @@ metadata:
   name: zxporter-nodemon
   namespace: '{{.zxporter_namespace}}'
   labels:
-    helm.sh/chart: zxporter-nodemon-0.0.97
+    helm.sh/chart: zxporter-nodemon-0.0.98
     app.kubernetes.io/name: zxporter-nodemon
     app.kubernetes.io/instance: zxporter-nodemon
-    app.kubernetes.io/version: "0.0.97"
+    app.kubernetes.io/version: "0.0.98"
     app.kubernetes.io/managed-by: Helm
 ---
 # Source: zxporter-nodemon/templates/dcgm-exporter-configmap.yaml
@@ -782,10 +782,10 @@ kind: ClusterRole
 metadata:
   name: zxporter-nodemon
   labels:
-    helm.sh/chart: zxporter-nodemon-0.0.97
+    helm.sh/chart: zxporter-nodemon-0.0.98
     app.kubernetes.io/name: zxporter-nodemon
     app.kubernetes.io/instance: zxporter-nodemon
-    app.kubernetes.io/version: "0.0.97"
+    app.kubernetes.io/version: "0.0.98"
     app.kubernetes.io/managed-by: Helm
 rules:
   - apiGroups:
@@ -832,10 +832,10 @@ kind: ClusterRoleBinding
 metadata:
   name: zxporter-nodemon
   labels:
-    helm.sh/chart: zxporter-nodemon-0.0.97
+    helm.sh/chart: zxporter-nodemon-0.0.98
     app.kubernetes.io/name: zxporter-nodemon
     app.kubernetes.io/instance: zxporter-nodemon
-    app.kubernetes.io/version: "0.0.97"
+    app.kubernetes.io/version: "0.0.98"
     app.kubernetes.io/managed-by: Helm
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -853,10 +853,10 @@ metadata:
   name: zxporter-nodemon
   namespace: '{{.zxporter_namespace}}'
   labels:
-    helm.sh/chart: zxporter-nodemon-0.0.97
+    helm.sh/chart: zxporter-nodemon-0.0.98
     app.kubernetes.io/name: zxporter-nodemon
     app.kubernetes.io/instance: zxporter-nodemon
-    app.kubernetes.io/version: "0.0.97"
+    app.kubernetes.io/version: "0.0.98"
     app.kubernetes.io/managed-by: Helm
   annotations:
     ignore-check.kube-linter.io/privileged-container: "This daemon set needs to run DCGM Exporter as privileged to access the GPU metrics."
@@ -978,10 +978,10 @@ metadata:
   name: zxporter-nodemon-gpu
   namespace: '{{.zxporter_namespace}}'
   labels:
-    helm.sh/chart: zxporter-nodemon-0.0.97
+    helm.sh/chart: zxporter-nodemon-0.0.98
     app.kubernetes.io/name: zxporter-nodemon
     app.kubernetes.io/instance: zxporter-nodemon-gpu
-    app.kubernetes.io/version: "0.0.97"
+    app.kubernetes.io/version: "0.0.98"
     app.kubernetes.io/managed-by: Helm
   annotations:
     ignore-check.kube-linter.io/privileged-container: "This daemon set needs to run DCGM Exporter as privileged to access the GPU metrics."

--- a/dist/installer_updater-lowpriv.yaml
+++ b/dist/installer_updater-lowpriv.yaml
@@ -1,0 +1,1098 @@
+# ZXPorter installer bundle
+apiVersion: v1
+kind: Namespace
+metadata:
+  labels:
+    control-plane: controller-manager
+    app.kubernetes.io/name: '{{.zxporter_namespace}}'
+  name: '{{.zxporter_namespace}}'
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  labels:
+    app.kubernetes.io/managed-by: kustomize
+    app.kubernetes.io/name: devzero-zxporter
+    control-plane: controller-manager
+  name: '{{.zxporter_namespace}}'
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  labels:
+    app.kubernetes.io/managed-by: kustomize
+    app.kubernetes.io/name: devzero-zxporter
+  name: devzero-zxporter-controller-manager
+  namespace: '{{.zxporter_namespace}}'
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  labels:
+    app.kubernetes.io/managed-by: kustomize
+    app.kubernetes.io/name: devzero-zxporter
+  name: devzero-zxporter-leader-election-role
+  namespace: '{{.zxporter_namespace}}'
+rules:
+  - apiGroups:
+      - ""
+    resources:
+      - configmaps
+      - deployments
+      - serviceaccounts
+      - services
+    verbs:
+      - get
+      - list
+      - watch
+      - create
+      - update
+      - patch
+      - delete
+  - apiGroups:
+      - apps
+    resources:
+      - deployments
+    verbs:
+      - get
+      - list
+      - watch
+      - create
+      - update
+      - patch
+      - delete
+  - apiGroups:
+      - coordination.k8s.io
+    resources:
+      - leases
+    verbs:
+      - get
+      - list
+      - watch
+      - create
+      - update
+      - patch
+      - delete
+  - apiGroups:
+      - ""
+    resources:
+      - events
+    verbs:
+      - create
+      - patch
+  - apiGroups:
+      - rbac.authorization.k8s.io
+    resources:
+      - rolebindings
+      - roles
+      - clusterrolebindings
+      - clusterroles
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    app.kubernetes.io/managed-by: kustomize
+    app.kubernetes.io/name: devzero-zxporter
+  name: devzero-zxporter-collectionpolicy-editor-role
+rules:
+  - apiGroups:
+      - devzero.io
+    resources:
+      - collectionpolicies
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - devzero.io
+    resources:
+      - collectionpolicies/status
+    verbs:
+      - get
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    app.kubernetes.io/managed-by: kustomize
+    app.kubernetes.io/name: devzero-zxporter
+  name: devzero-zxporter-collectionpolicy-viewer-role
+rules:
+  - apiGroups:
+      - devzero.io
+    resources:
+      - collectionpolicies
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - devzero.io
+    resources:
+      - collectionpolicies/status
+    verbs:
+      - get
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: devzero-zxporter-manager-role
+rules:
+  - apiGroups:
+      - ""
+    resources:
+      - configmaps
+    verbs:
+      - get
+      - list
+      - update
+      - watch
+  - apiGroups:
+      - ""
+    resources:
+      - endpoints
+      - events
+      - limitranges
+      - namespaces
+      - nodes
+      - persistentvolumeclaims
+      - persistentvolumes
+      - pods
+      - replicationcontrollers
+      - resourcequotas
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - ""
+    resources:
+      - nodes/metrics
+      - nodes/proxy
+      - nodes/status
+      - pods/status
+    verbs:
+      - get
+  - apiGroups:
+      - ""
+    resources:
+      - secrets
+    verbs:
+      - create
+  - apiGroups:
+      - ""
+    resourceNames:
+      - devzero-zxporter-token
+    resources:
+      - secrets
+    verbs:
+      - get
+      - patch
+      - update
+  - apiGroups:
+      - ""
+    resources:
+      - serviceaccounts
+      - services
+    verbs:
+      - create
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - apiextensions.k8s.io
+    resources:
+      - customresourcedefinitions
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - apiregistration.k8s.io
+    resources:
+      - apiservices
+    verbs:
+      - create
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - apps
+    resources:
+      - daemonsets
+      - replicasets
+      - statefulsets
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - apps
+    resources:
+      - deployments
+    verbs:
+      - create
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - argoproj.io
+    resources:
+      - rollouts
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - autoscaling
+    resources:
+      - horizontalpodautoscalers
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - autoscaling.k8s.io
+    resources:
+      - verticalpodautoscalers
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - batch
+    resources:
+      - cronjobs
+      - jobs
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - batch.volcano.sh
+    resources:
+      - jobs
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - dakr.devzero.io
+    resources:
+      - workloadrecommendations
+      - workloadrules
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - datadoghq.com
+    resources:
+      - extendeddaemonsetreplicasets
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - devzero.io
+    resources:
+      - collectionpolicies
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - devzero.io
+    resources:
+      - collectionpolicies/finalizers
+    verbs:
+      - update
+  - apiGroups:
+      - devzero.io
+    resources:
+      - collectionpolicies/status
+    verbs:
+      - get
+      - patch
+      - update
+  - apiGroups:
+      - devzero.karpenter.sh
+    resources:
+      - karpentersettings
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - karpenter.azure.com
+    resources:
+      - aksnodeclasses
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - karpenter.k8s.aws
+    resources:
+      - awsnodetemplates
+      - ec2nodeclasses
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - karpenter.k8s.gcp
+    resources:
+      - gcenodeclasses
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - karpenter.k8s.oracle
+    resources:
+      - ocinodeclasses
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - karpenter.sh
+    resources:
+      - machines
+      - nodeclaims
+      - nodeoverlays
+      - nodepools
+      - provisioners
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - keda.sh
+    resources:
+      - clustertriggerauthentications
+      - scaledjobs
+      - scaledobjects
+      - triggerauthentications
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - kubeflow.org
+    resources:
+      - notebooks
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - metrics.k8s.io
+    resources:
+      - nodes
+      - pods
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - networking.k8s.io
+    resources:
+      - ingressclasses
+      - ingresses
+      - networkpolicies
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - policy
+    resources:
+      - poddisruptionbudgets
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - postgresql.cnpg.io
+    resources:
+      - clusters
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - rbac.authorization.k8s.io
+    resources:
+      - clusterrolebindings
+      - clusterroles
+      - rolebindings
+    verbs:
+      - create
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - rbac.authorization.k8s.io
+    resources:
+      - roles
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - sparkoperator.k8s.io
+    resources:
+      - scheduledsparkapplications
+      - sparkapplications
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - storage.k8s.io
+    resources:
+      - csidrivers
+      - csinodes
+      - csistoragecapacities
+      - storageclasses
+      - volumeattachments
+    verbs:
+      - get
+      - list
+      - watch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: devzero-zxporter-metrics-auth-role
+rules:
+  - apiGroups:
+      - authentication.k8s.io
+    resources:
+      - tokenreviews
+    verbs:
+      - create
+  - apiGroups:
+      - authorization.k8s.io
+    resources:
+      - subjectaccessreviews
+    verbs:
+      - create
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: devzero-zxporter-metrics-reader
+rules:
+  - nonResourceURLs:
+      - /metrics
+    verbs:
+      - get
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  labels:
+    app.kubernetes.io/managed-by: kustomize
+    app.kubernetes.io/name: devzero-zxporter
+  name: devzero-zxporter-leader-election-rolebinding
+  namespace: '{{.zxporter_namespace}}'
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: devzero-zxporter-leader-election-role
+subjects:
+  - kind: ServiceAccount
+    name: devzero-zxporter-controller-manager
+    namespace: '{{.zxporter_namespace}}'
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  labels:
+    app.kubernetes.io/managed-by: kustomize
+    app.kubernetes.io/name: devzero-zxporter
+  name: devzero-zxporter-manager-rolebinding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: devzero-zxporter-manager-role
+subjects:
+  - kind: ServiceAccount
+    name: devzero-zxporter-controller-manager
+    namespace: '{{.zxporter_namespace}}'
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: devzero-zxporter-metrics-auth-rolebinding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: devzero-zxporter-metrics-auth-role
+subjects:
+  - kind: ServiceAccount
+    name: devzero-zxporter-controller-manager
+    namespace: '{{.zxporter_namespace}}'
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app.kubernetes.io/managed-by: kustomize
+    app.kubernetes.io/name: devzero-zxporter
+    control-plane: controller-manager
+  name: devzero-zxporter-controller-manager-metrics-service
+  namespace: '{{.zxporter_namespace}}'
+spec:
+  ports:
+    - name: https
+      port: 8443
+      protocol: TCP
+      targetPort: 8443
+  selector:
+    control-plane: controller-manager
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app.kubernetes.io/name: devzero-zxporter
+    control-plane: controller-manager
+  name: devzero-zxporter-controller-manager-mpa
+  namespace: '{{.zxporter_namespace}}'
+spec:
+  ports:
+    - name: mpa-grpc
+      port: 50051
+      protocol: TCP
+      targetPort: mpa-grpc
+  selector:
+    control-plane: controller-manager
+  type: ClusterIP
+---
+apiVersion: scheduling.k8s.io/v1
+description: This priority class is for critical zxporter infrastructure components.
+globalDefault: false
+kind: PriorityClass
+metadata:
+  name: devzero-zxporter-devzero-zxporter-critical
+preemptionPolicy: PreemptLowerPriority
+value: 1000000000
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app.kubernetes.io/managed-by: kustomize
+    app.kubernetes.io/name: devzero-zxporter
+    control-plane: controller-manager
+  name: devzero-zxporter-controller-manager
+  namespace: '{{.zxporter_namespace}}'
+spec:
+  replicas: 2
+  selector:
+    matchLabels:
+      control-plane: controller-manager
+  template:
+    metadata:
+      annotations:
+        kubectl.kubernetes.io/default-container: manager
+      labels:
+        app.kubernetes.io/instance: zxporter
+        app.kubernetes.io/name: zxporter
+        control-plane: controller-manager
+    spec:
+      containers:
+        - args:
+            - --metrics-bind-address=:8443
+            - --leader-elect
+            - --mpa-server-port=50051
+            - --health-probe-bind-address=:8081
+          env:
+            - name: POD_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+            - name: CLUSTER_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  key: CLUSTER_TOKEN
+                  name: devzero-zxporter-token
+                  optional: true
+          image: docker.io/devzeroinc/zxporter:latest
+          livenessProbe:
+            httpGet:
+              path: /healthz
+              port: 8081
+            initialDelaySeconds: 15
+            periodSeconds: 20
+          name: manager
+          ports:
+            - containerPort: 50051
+              name: mpa-grpc
+              protocol: TCP
+          readinessProbe:
+            httpGet:
+              path: /readyz
+              port: 8081
+            initialDelaySeconds: 5
+            periodSeconds: 10
+          resources:
+            requests:
+              cpu: 200m
+              memory: 2Gi
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
+          volumeMounts:
+            - mountPath: /etc/zxporter/config
+              name: config-volume
+              readOnly: true
+      priorityClassName: devzero-zxporter-devzero-zxporter-critical
+      securityContext:
+        runAsNonRoot: true
+      serviceAccountName: devzero-zxporter-controller-manager
+      terminationGracePeriodSeconds: 10
+      volumes:
+        - configMap:
+            name: devzero-zxporter-env-config
+          name: config-volume
+---
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: devzero-zxporter-devzero-zxporter-pdb
+  namespace: '{{.zxporter_namespace}}'
+spec:
+  minAvailable: 1
+  selector:
+    matchLabels:
+      control-plane: controller-manager
+---
+# Source: zxporter-nodemon/templates/rbac.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: zxporter-nodemon
+  namespace: '{{.zxporter_namespace}}'
+  labels:
+    helm.sh/chart: zxporter-nodemon-0.0.97
+    app.kubernetes.io/name: zxporter-nodemon
+    app.kubernetes.io/instance: zxporter-nodemon
+    app.kubernetes.io/version: "0.0.97"
+    app.kubernetes.io/managed-by: Helm
+---
+# Source: zxporter-nodemon/templates/dcgm-exporter-configmap.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: zxporter-nodemon-dcgm-metrics
+  namespace: '{{.zxporter_namespace}}'
+data:
+  counters.csv: |
+    # Temperature and power usage,,
+    DCGM_FI_DEV_GPU_TEMP, gauge, Current temperature readings for the device in degrees C.
+    DCGM_FI_DEV_MEMORY_TEMP, gauge, Memory temperature for the device.
+    DCGM_FI_DEV_POWER_USAGE, gauge, Power usage for the device in Watts.
+
+    # Utilization,,
+    # DCGM_FI_DEV_GPU_UTIL provides overall GPU utilization which is useful for scenarios
+    # like fractional GPU sharing (e.g., EKS time-slicing, MIG) where profiling metrics may not be available.
+    DCGM_FI_DEV_GPU_UTIL, gauge, GPU utilization (in %).
+    # DCGM_FI_PROF_SM_ACTIVE, gauge, The ratio of cycles an SM has at least 1 warp assigned
+    # DCGM_FI_PROF_SM_OCCUPANCY, gauge, The fraction of resident warps on a multiprocessor
+    # DCGM_FI_PROF_GR_ENGINE_ACTIVE, gauge, Ratio of time the graphics engine is active (in %).
+    # DCGM_FI_PROF_DRAM_ACTIVE, gauge, The ratio of cycles the device memory interface is active sending or receiving data.
+
+    # Memory usage,,
+    DCGM_FI_DEV_FB_FREE, gauge, Framebuffer memory free (in MiB).
+    DCGM_FI_DEV_FB_USED, gauge, Framebuffer memory used (in MiB).
+    DCGM_FI_DEV_FB_TOTAL, gauge, Total Frame Buffer of the GPU in MB.
+    DCGM_FI_DEV_MEM_COPY_UTIL, gauge, Utilization of the memory copy engine.
+
+    # PCIE,,
+    # DCGM_FI_PROF_PCIE_TX_BYTES, gauge, Total number of bytes transmitted through PCIe TX
+    # DCGM_FI_PROF_PCIE_RX_BYTES, gauge, Total number of bytes received through PCIe RX
+    DCGM_FI_DEV_PCIE_LINK_GEN, gauge, PCIe Current Link Generation.
+    DCGM_FI_DEV_PCIE_LINK_WIDTH, gauge, PCIe Current Link Width.
+
+    # Pipelines,,
+    # DCGM_FI_PROF_PIPE_INT_ACTIVE, gauge, Ratio of cycles the integer pipe is active.
+    # DCGM_FI_PROF_PIPE_FP16_ACTIVE, gauge, Ratio of cycles the fp16 pipe is active.
+    # DCGM_FI_PROF_PIPE_FP32_ACTIVE, gauge, Ratio of cycles the fp32 pipe is active.
+    # DCGM_FI_PROF_PIPE_FP64_ACTIVE, gauge, Ratio of cycles the fp64 pipe is active.
+    # DCGM_FI_PROF_PIPE_TENSOR_ACTIVE, gauge, The ratio of cycles the tensor (HMMA) pipe is active (off the peak sustained elapsed cycles)
+
+    # Health,,
+    # DCGM_FI_DEV_CLOCKS_EVENT_REASONS is not supported by DCGM 3.3.7
+    # DCGM_FI_DEV_CLOCKS_EVENT_REASONS, gauge, Current clock event reasons (bitmask of DCGM_CLOCKS_EVENT_REASON_*)
+    DCGM_FI_DEV_XID_ERRORS, gauge, The value is the specific XID error
+    DCGM_FI_DEV_POWER_VIOLATION, gauge, Power Violation time in ns.
+    DCGM_FI_DEV_THERMAL_VIOLATION, gauge, Thermal Violation time in ns.
+
+    # NVLink,,
+    # DCGM_FI_PROF_NVLINK_TX_BYTES, gauge, The number of bytes of active NvLink tx (transmit) data including both header and payload.
+    # DCGM_FI_PROF_NVLINK_RX_BYTES, gauge, The number of bytes of active NvLink rx (read) data including both header and payload.
+
+    # Clocks,,
+    DCGM_FI_DEV_SM_CLOCK, gauge, SM clock frequency (in MHz).
+    DCGM_FI_DEV_MEM_CLOCK, gauge, Memory clock frequency (in MHz).
+---
+# Source: zxporter-nodemon/templates/nodemon-configmap.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: zxporter-nodemon-zxporter-nodemon
+  namespace: '{{.zxporter_namespace}}'
+data:
+---
+# Source: zxporter-nodemon/templates/rbac.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: zxporter-nodemon
+  labels:
+    helm.sh/chart: zxporter-nodemon-0.0.97
+    app.kubernetes.io/name: zxporter-nodemon
+    app.kubernetes.io/instance: zxporter-nodemon
+    app.kubernetes.io/version: "0.0.97"
+    app.kubernetes.io/managed-by: Helm
+rules:
+  - apiGroups:
+      - ""
+    resources:
+      - pods
+    verbs:
+      - get
+      - list
+  - apiGroups:
+      - apps
+    resources:
+      - replicasets
+      - deployments
+      - statefulsets
+      - daemonsets
+    verbs:
+      - get
+  - apiGroups:
+      - batch
+    resources:
+      - jobs
+      - cronjobs
+    verbs:
+      - get
+  - apiGroups:
+      - argoproj.io
+    resources:
+      - rollouts
+    verbs:
+      - get
+  - apiGroups:
+      - ""
+    resources:
+      - nodes/proxy
+      - nodes/metrics
+      - nodes/stats
+    verbs:
+      - get
+---
+# Source: zxporter-nodemon/templates/rbac.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: zxporter-nodemon
+  labels:
+    helm.sh/chart: zxporter-nodemon-0.0.97
+    app.kubernetes.io/name: zxporter-nodemon
+    app.kubernetes.io/instance: zxporter-nodemon
+    app.kubernetes.io/version: "0.0.97"
+    app.kubernetes.io/managed-by: Helm
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: zxporter-nodemon
+subjects:
+  - kind: ServiceAccount
+    name: zxporter-nodemon
+    namespace: '{{.zxporter_namespace}}'
+---
+# Source: zxporter-nodemon/templates/daemonset.yaml
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: zxporter-nodemon
+  namespace: '{{.zxporter_namespace}}'
+  labels:
+    helm.sh/chart: zxporter-nodemon-0.0.97
+    app.kubernetes.io/name: zxporter-nodemon
+    app.kubernetes.io/instance: zxporter-nodemon
+    app.kubernetes.io/version: "0.0.97"
+    app.kubernetes.io/managed-by: Helm
+  annotations:
+    ignore-check.kube-linter.io/privileged-container: "This daemon set needs to run DCGM Exporter as privileged to access the GPU metrics."
+    ignore-check.kube-linter.io/run-as-non-root: "This daemon set needs to run DCGM Exporter as root to access the GPU metrics."
+    ignore-check.kube-linter.io/privilege-escalation-container: "This daemon set needs escalate privileges for DCGM Exporter."
+    ignore-check.kube-linter.io/no-read-only-root-fs: "This daemon set needs to run DCGM Exporter with read-only root filesystem."
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: zxporter-nodemon
+      app.kubernetes.io/instance: zxporter-nodemon
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: zxporter-nodemon
+        app.kubernetes.io/instance: zxporter-nodemon
+    spec:
+      priorityClassName: devzero-zxporter-devzero-zxporter-critical
+      serviceAccountName: zxporter-nodemon
+      volumes:
+        - name: "pod-gpu-resources"
+          hostPath:
+            path: /var/lib/kubelet/pod-resources
+        - name: zxporter-nodemon-dcgm-metrics
+          configMap:
+            name: zxporter-nodemon-dcgm-metrics
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+              - matchExpressions:
+                  - key: nvidia.com/gpu.present
+                    operator: NotIn
+                    values:
+                      - "true"
+      tolerations:
+        - effect: NoExecute
+          operator: Exists
+        - effect: NoSchedule
+          operator: Exists
+        - effect: PreferNoSchedule
+          operator: Exists
+      containers:
+        - name: zxporter-nodemon
+          securityContext:
+            readOnlyRootFilesystem: true
+            runAsNonRoot: true
+          image: "docker.io/devzeroinc/zxporter-nodemon:latest"
+          imagePullPolicy: IfNotPresent
+          ports:
+            - name: http
+              containerPort: 6061
+              protocol: TCP
+          livenessProbe:
+            httpGet:
+              path: /healthz
+              port: http
+          readinessProbe:
+            httpGet:
+              path: /healthz
+              port: http
+          envFrom:
+            - configMapRef:
+                name: zxporter-nodemon-zxporter-nodemon
+          env:
+            - name: "NODE_NAME"
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.nodeName
+            - name: "RUNTIME_METRICS_ENABLED"
+              value: "false"
+            - name: "DCGM_HOST"
+              value: "localhost"
+          resources:
+            limits:
+              memory: 256Mi
+            requests:
+              cpu: 60m
+              memory: 256Mi
+        - name: dcgm-exporter
+          securityContext:
+            capabilities:
+              add:
+                - SYS_ADMIN
+              drop:
+                - NET_RAW
+            runAsNonRoot: false
+            runAsUser: 0
+          image: "nvcr.io/nvidia/k8s/dcgm-exporter:4.5.2-4.8.1-ubuntu22.04"
+          imagePullPolicy: IfNotPresent
+          command: ["/bin/bash", "-c"]
+          args:
+            - hostname $NODE_NAME; for ((;;)) { r=$(dcgm-exporter -f /etc/dcgm-exporter/counters.csv); echo "dcgm-exporter could not run"; sleep 60 ; }
+          ports:
+            - name: "metrics"
+              containerPort: 9400
+          env:
+            - name: "DCGM_EXPORTER_KUBERNETES"
+              value: "true"
+            - name: "DCGM_EXPORTER_LISTEN"
+              value: ":9400"
+            - name: "DCGM_EXPORTER_INTERVAL"
+              value: "5000"
+            - name: "NODE_NAME"
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.nodeName
+          volumeMounts:
+            - name: "pod-gpu-resources"
+              readOnly: true
+              mountPath: "/var/lib/kubelet/pod-resources"
+            - name: zxporter-nodemon-dcgm-metrics
+              mountPath: "/etc/dcgm-exporter"
+---
+# Source: zxporter-nodemon/templates/daemonset.yaml
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: zxporter-nodemon-gpu
+  namespace: '{{.zxporter_namespace}}'
+  labels:
+    helm.sh/chart: zxporter-nodemon-0.0.97
+    app.kubernetes.io/name: zxporter-nodemon
+    app.kubernetes.io/instance: zxporter-nodemon-gpu
+    app.kubernetes.io/version: "0.0.97"
+    app.kubernetes.io/managed-by: Helm
+  annotations:
+    ignore-check.kube-linter.io/privileged-container: "This daemon set needs to run DCGM Exporter as privileged to access the GPU metrics."
+    ignore-check.kube-linter.io/run-as-non-root: "This daemon set needs to run DCGM Exporter as root to access the GPU metrics."
+    ignore-check.kube-linter.io/privilege-escalation-container: "This daemon set needs escalate privileges for DCGM Exporter."
+    ignore-check.kube-linter.io/no-read-only-root-fs: "This daemon set needs to run DCGM Exporter with read-only root filesystem."
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: zxporter-nodemon
+      app.kubernetes.io/instance: zxporter-nodemon-gpu
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: zxporter-nodemon
+        app.kubernetes.io/instance: zxporter-nodemon-gpu
+    spec:
+      priorityClassName: devzero-zxporter-devzero-zxporter-critical
+      runtimeClassName: "nvidia"
+      serviceAccountName: zxporter-nodemon
+      volumes:
+        - name: "pod-gpu-resources"
+          hostPath:
+            path: /var/lib/kubelet/pod-resources
+        - name: zxporter-nodemon-dcgm-metrics
+          configMap:
+            name: zxporter-nodemon-dcgm-metrics
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+              - matchExpressions:
+                  - key: nvidia.com/gpu.present
+                    operator: In
+                    values:
+                      - "true"
+      tolerations:
+        - effect: NoExecute
+          operator: Exists
+        - effect: NoSchedule
+          operator: Exists
+        - effect: PreferNoSchedule
+          operator: Exists
+      containers:
+        - name: zxporter-nodemon
+          securityContext:
+            readOnlyRootFilesystem: true
+            runAsNonRoot: true
+          image: "docker.io/devzeroinc/zxporter-nodemon:latest"
+          imagePullPolicy: IfNotPresent
+          ports:
+            - name: http
+              containerPort: 6061
+              protocol: TCP
+          livenessProbe:
+            httpGet:
+              path: /healthz
+              port: http
+          readinessProbe:
+            httpGet:
+              path: /healthz
+              port: http
+          envFrom:
+            - configMapRef:
+                name: zxporter-nodemon-zxporter-nodemon
+          env:
+            - name: "NODE_NAME"
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.nodeName
+            - name: "RUNTIME_METRICS_ENABLED"
+              value: "false"
+            - name: "DCGM_HOST"
+              value: "localhost"
+          resources:
+            limits:
+              memory: 256Mi
+            requests:
+              cpu: 60m
+              memory: 256Mi
+        - name: dcgm-exporter
+          securityContext:
+            capabilities:
+              add:
+                - SYS_ADMIN
+              drop:
+                - NET_RAW
+            runAsNonRoot: false
+            runAsUser: 0
+          image: "nvcr.io/nvidia/k8s/dcgm-exporter:4.5.2-4.8.1-ubuntu22.04"
+          imagePullPolicy: IfNotPresent
+          command: ["/bin/bash", "-c"]
+          args:
+            - hostname $NODE_NAME; for ((;;)) { r=$(dcgm-exporter -f /etc/dcgm-exporter/counters.csv); echo "dcgm-exporter could not run"; sleep 60 ; }
+          ports:
+            - name: "metrics"
+              containerPort: 9400
+          env:
+            - name: "DCGM_EXPORTER_KUBERNETES"
+              value: "true"
+            - name: "DCGM_EXPORTER_LISTEN"
+              value: ":9400"
+            - name: "DCGM_EXPORTER_INTERVAL"
+              value: "5000"
+            - name: "NODE_NAME"
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.nodeName
+          volumeMounts:
+            - name: "pod-gpu-resources"
+              readOnly: true
+              mountPath: "/var/lib/kubelet/pod-resources"
+            - name: zxporter-nodemon-dcgm-metrics
+              mountPath: "/etc/dcgm-exporter"

--- a/dist/nodemon-gcp-lowpriv.yaml
+++ b/dist/nodemon-gcp-lowpriv.yaml
@@ -1,0 +1,418 @@
+---
+# Source: zxporter-nodemon/templates/rbac.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: zxporter-nodemon
+  namespace: devzero-system
+  labels:
+    helm.sh/chart: zxporter-nodemon-0.0.97
+    app.kubernetes.io/name: zxporter-nodemon
+    app.kubernetes.io/instance: zxporter-nodemon
+    app.kubernetes.io/version: "0.0.97"
+    app.kubernetes.io/managed-by: Helm
+---
+# Source: zxporter-nodemon/templates/dcgm-exporter-configmap.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: zxporter-nodemon-dcgm-metrics
+  namespace: devzero-system
+data:
+  counters.csv: |
+    # Temperature and power usage,,
+    DCGM_FI_DEV_GPU_TEMP, gauge, Current temperature readings for the device in degrees C.
+    DCGM_FI_DEV_MEMORY_TEMP, gauge, Memory temperature for the device.
+    DCGM_FI_DEV_POWER_USAGE, gauge, Power usage for the device in Watts.
+
+    # Utilization,,
+    # DCGM_FI_DEV_GPU_UTIL provides overall GPU utilization which is useful for scenarios
+    # like fractional GPU sharing (e.g., EKS time-slicing, MIG) where profiling metrics may not be available.
+    DCGM_FI_DEV_GPU_UTIL, gauge, GPU utilization (in %).
+    # DCGM_FI_PROF_SM_ACTIVE, gauge, The ratio of cycles an SM has at least 1 warp assigned
+    # DCGM_FI_PROF_SM_OCCUPANCY, gauge, The fraction of resident warps on a multiprocessor
+    # DCGM_FI_PROF_GR_ENGINE_ACTIVE, gauge, Ratio of time the graphics engine is active (in %).
+    # DCGM_FI_PROF_DRAM_ACTIVE, gauge, The ratio of cycles the device memory interface is active sending or receiving data.
+
+    # Memory usage,,
+    DCGM_FI_DEV_FB_FREE, gauge, Framebuffer memory free (in MiB).
+    DCGM_FI_DEV_FB_USED, gauge, Framebuffer memory used (in MiB).
+    DCGM_FI_DEV_FB_TOTAL, gauge, Total Frame Buffer of the GPU in MB.
+    DCGM_FI_DEV_MEM_COPY_UTIL, gauge, Utilization of the memory copy engine.
+
+    # PCIE,,
+    # DCGM_FI_PROF_PCIE_TX_BYTES, gauge, Total number of bytes transmitted through PCIe TX
+    # DCGM_FI_PROF_PCIE_RX_BYTES, gauge, Total number of bytes received through PCIe RX
+    DCGM_FI_DEV_PCIE_LINK_GEN, gauge, PCIe Current Link Generation.
+    DCGM_FI_DEV_PCIE_LINK_WIDTH, gauge, PCIe Current Link Width.
+
+    # Pipelines,,
+    # DCGM_FI_PROF_PIPE_INT_ACTIVE, gauge, Ratio of cycles the integer pipe is active.
+    # DCGM_FI_PROF_PIPE_FP16_ACTIVE, gauge, Ratio of cycles the fp16 pipe is active.
+    # DCGM_FI_PROF_PIPE_FP32_ACTIVE, gauge, Ratio of cycles the fp32 pipe is active.
+    # DCGM_FI_PROF_PIPE_FP64_ACTIVE, gauge, Ratio of cycles the fp64 pipe is active.
+    # DCGM_FI_PROF_PIPE_TENSOR_ACTIVE, gauge, The ratio of cycles the tensor (HMMA) pipe is active (off the peak sustained elapsed cycles)
+
+    # Health,,
+    # DCGM_FI_DEV_CLOCKS_EVENT_REASONS is not supported by DCGM 3.3.7
+    # DCGM_FI_DEV_CLOCKS_EVENT_REASONS, gauge, Current clock event reasons (bitmask of DCGM_CLOCKS_EVENT_REASON_*)
+    DCGM_FI_DEV_XID_ERRORS, gauge, The value is the specific XID error
+    DCGM_FI_DEV_POWER_VIOLATION, gauge, Power Violation time in ns.
+    DCGM_FI_DEV_THERMAL_VIOLATION, gauge, Thermal Violation time in ns.
+
+    # NVLink,,
+    # DCGM_FI_PROF_NVLINK_TX_BYTES, gauge, The number of bytes of active NvLink tx (transmit) data including both header and payload.
+    # DCGM_FI_PROF_NVLINK_RX_BYTES, gauge, The number of bytes of active NvLink rx (read) data including both header and payload.
+
+    # Clocks,,
+    DCGM_FI_DEV_SM_CLOCK, gauge, SM clock frequency (in MHz).
+    DCGM_FI_DEV_MEM_CLOCK, gauge, Memory clock frequency (in MHz).
+---
+# Source: zxporter-nodemon/templates/nodemon-configmap.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: zxporter-nodemon-zxporter-nodemon
+  namespace: devzero-system
+data:
+---
+# Source: zxporter-nodemon/templates/rbac.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: zxporter-nodemon
+  labels:
+    helm.sh/chart: zxporter-nodemon-0.0.97
+    app.kubernetes.io/name: zxporter-nodemon
+    app.kubernetes.io/instance: zxporter-nodemon
+    app.kubernetes.io/version: "0.0.97"
+    app.kubernetes.io/managed-by: Helm
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  verbs:
+  - get
+  - list
+- apiGroups:
+    - apps
+  resources:
+    - replicasets
+    - deployments
+    - statefulsets
+    - daemonsets
+  verbs:
+    - get
+- apiGroups:
+    - batch
+  resources:
+    - jobs
+    - cronjobs
+  verbs:
+    - get
+- apiGroups:
+    - argoproj.io
+  resources:
+    - rollouts
+  verbs:
+    - get
+- apiGroups:
+    - ""
+  resources:
+    - nodes/proxy
+    - nodes/metrics
+    - nodes/stats
+  verbs:
+    - get
+---
+# Source: zxporter-nodemon/templates/rbac.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: zxporter-nodemon
+  labels:
+    helm.sh/chart: zxporter-nodemon-0.0.97
+    app.kubernetes.io/name: zxporter-nodemon
+    app.kubernetes.io/instance: zxporter-nodemon
+    app.kubernetes.io/version: "0.0.97"
+    app.kubernetes.io/managed-by: Helm
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: zxporter-nodemon
+subjects:
+- kind: ServiceAccount
+  name: zxporter-nodemon
+  namespace: devzero-system
+---
+# Source: zxporter-nodemon/templates/daemonset.yaml
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: zxporter-nodemon
+  namespace: devzero-system
+  labels:
+    helm.sh/chart: zxporter-nodemon-0.0.97
+    app.kubernetes.io/name: zxporter-nodemon
+    app.kubernetes.io/instance: zxporter-nodemon
+    app.kubernetes.io/version: "0.0.97"
+    app.kubernetes.io/managed-by: Helm
+  annotations:
+    ignore-check.kube-linter.io/privileged-container: "This daemon set needs to run DCGM Exporter as privileged to access the GPU metrics."
+    ignore-check.kube-linter.io/run-as-non-root: "This daemon set needs to run DCGM Exporter as root to access the GPU metrics."
+    ignore-check.kube-linter.io/privilege-escalation-container: "This daemon set needs escalate privileges for DCGM Exporter."
+    ignore-check.kube-linter.io/no-read-only-root-fs: "This daemon set needs to run DCGM Exporter with read-only root filesystem."
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: zxporter-nodemon
+      app.kubernetes.io/instance: zxporter-nodemon
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: zxporter-nodemon
+        app.kubernetes.io/instance: zxporter-nodemon
+    spec:
+      priorityClassName: devzero-zxporter-devzero-zxporter-critical
+      serviceAccountName: zxporter-nodemon
+      volumes:
+        - name: "pod-gpu-resources"
+          hostPath:
+            path: /var/lib/kubelet/pod-resources
+        - name: zxporter-nodemon-dcgm-metrics
+          configMap:
+            name: zxporter-nodemon-dcgm-metrics
+        - name: "nvidia-install-dir-host"
+          hostPath:
+            path: /home/kubernetes/bin/nvidia
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: nvidia.com/gpu.present
+                operator: NotIn
+                values:
+                - "true"
+      tolerations:
+        - effect: NoExecute
+          operator: Exists
+        - effect: NoSchedule
+          operator: Exists
+        - effect: PreferNoSchedule
+          operator: Exists
+      containers:
+        - name: zxporter-nodemon
+          securityContext:
+            readOnlyRootFilesystem: true
+            runAsNonRoot: true
+          image: "ttl.sh/zxporter-nodemon:latest"
+          imagePullPolicy: IfNotPresent
+          ports:
+            - name: http
+              containerPort: 6061
+              protocol: TCP
+          livenessProbe:
+            httpGet:
+              path: /healthz
+              port: http
+          readinessProbe:
+            httpGet:
+              path: /healthz
+              port: http
+          envFrom:
+            - configMapRef:
+                name: zxporter-nodemon-zxporter-nodemon
+          env:
+            - name: "NODE_NAME"
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.nodeName
+            - name: "RUNTIME_METRICS_ENABLED"
+              value: "false"
+            - name: "DCGM_HOST"
+              value: "localhost"
+          resources:
+            limits:
+              memory: 256Mi
+            requests:
+              cpu: 60m
+              memory: 256Mi
+        - name: dcgm-exporter
+          securityContext:
+            capabilities:
+              add:
+                - SYS_ADMIN
+              drop:
+                - NET_RAW
+            runAsNonRoot: false
+            runAsUser: 0
+            privileged: true
+          image: "nvcr.io/nvidia/k8s/dcgm-exporter:4.5.2-4.8.1-ubuntu22.04"
+          imagePullPolicy: IfNotPresent
+          command: [ "/bin/bash", "-c" ]
+          args:
+            - hostname $NODE_NAME; for ((;;)) { r=$(dcgm-exporter -f /etc/dcgm-exporter/counters.csv); echo "dcgm-exporter could not run"; sleep 60 ; }
+          ports:
+            - name: "metrics"
+              containerPort: 9400
+          env:
+            - name: "DCGM_EXPORTER_KUBERNETES"
+              value: "true"
+            - name: "DCGM_EXPORTER_LISTEN"
+              value: ":9400"
+            - name: "DCGM_EXPORTER_INTERVAL"
+              value: "5000"
+            - name: "NODE_NAME"
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.nodeName
+            - name: "LD_LIBRARY_PATH"
+              value: "/usr/local/nvidia/lib64"
+            - name: "DCGM_EXPORTER_KUBERNETES_GPU_ID_TYPE"
+              value: "device-name"
+          volumeMounts:
+            - name: "pod-gpu-resources"
+              readOnly: true
+              mountPath: "/var/lib/kubelet/pod-resources"
+            - name: "nvidia-install-dir-host"
+              mountPath: /usr/local/nvidia
+            - name: zxporter-nodemon-dcgm-metrics
+              mountPath: "/etc/dcgm-exporter"
+---
+# Source: zxporter-nodemon/templates/daemonset.yaml
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: zxporter-nodemon-gpu
+  namespace: devzero-system
+  labels:
+    helm.sh/chart: zxporter-nodemon-0.0.97
+    app.kubernetes.io/name: zxporter-nodemon
+    app.kubernetes.io/instance: zxporter-nodemon-gpu
+    app.kubernetes.io/version: "0.0.97"
+    app.kubernetes.io/managed-by: Helm
+  annotations:
+    ignore-check.kube-linter.io/privileged-container: "This daemon set needs to run DCGM Exporter as privileged to access the GPU metrics."
+    ignore-check.kube-linter.io/run-as-non-root: "This daemon set needs to run DCGM Exporter as root to access the GPU metrics."
+    ignore-check.kube-linter.io/privilege-escalation-container: "This daemon set needs escalate privileges for DCGM Exporter."
+    ignore-check.kube-linter.io/no-read-only-root-fs: "This daemon set needs to run DCGM Exporter with read-only root filesystem."
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: zxporter-nodemon
+      app.kubernetes.io/instance: zxporter-nodemon-gpu
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: zxporter-nodemon
+        app.kubernetes.io/instance: zxporter-nodemon-gpu
+    spec:
+      priorityClassName: devzero-zxporter-devzero-zxporter-critical
+      runtimeClassName: "nvidia"
+      serviceAccountName: zxporter-nodemon
+      volumes:
+        - name: "pod-gpu-resources"
+          hostPath:
+            path: /var/lib/kubelet/pod-resources
+        - name: zxporter-nodemon-dcgm-metrics
+          configMap:
+            name: zxporter-nodemon-dcgm-metrics
+        - name: "nvidia-install-dir-host"
+          hostPath:
+            path: /home/kubernetes/bin/nvidia
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: nvidia.com/gpu.present
+                operator: In
+                values:
+                - "true"
+      tolerations:
+        - effect: NoExecute
+          operator: Exists
+        - effect: NoSchedule
+          operator: Exists
+        - effect: PreferNoSchedule
+          operator: Exists
+      containers:
+        - name: zxporter-nodemon
+          securityContext:
+            readOnlyRootFilesystem: true
+            runAsNonRoot: true
+          image: "ttl.sh/zxporter-nodemon:latest"
+          imagePullPolicy: IfNotPresent
+          ports:
+            - name: http
+              containerPort: 6061
+              protocol: TCP
+          livenessProbe:
+            httpGet:
+              path: /healthz
+              port: http
+          readinessProbe:
+            httpGet:
+              path: /healthz
+              port: http
+          envFrom:
+            - configMapRef:
+                name: zxporter-nodemon-zxporter-nodemon
+          env:
+            - name: "NODE_NAME"
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.nodeName
+            - name: "RUNTIME_METRICS_ENABLED"
+              value: "false"
+            - name: "DCGM_HOST"
+              value: "localhost"
+          resources:
+            limits:
+              memory: 256Mi
+            requests:
+              cpu: 60m
+              memory: 256Mi
+        - name: dcgm-exporter
+          securityContext:
+            capabilities:
+              add:
+                - SYS_ADMIN
+              drop:
+                - NET_RAW
+            runAsNonRoot: false
+            runAsUser: 0
+            privileged: true
+          image: "nvcr.io/nvidia/k8s/dcgm-exporter:4.5.2-4.8.1-ubuntu22.04"
+          imagePullPolicy: IfNotPresent
+          command: [ "/bin/bash", "-c" ]
+          args:
+            - hostname $NODE_NAME; for ((;;)) { r=$(dcgm-exporter -f /etc/dcgm-exporter/counters.csv); echo "dcgm-exporter could not run"; sleep 60 ; }
+          ports:
+            - name: "metrics"
+              containerPort: 9400
+          env:
+            - name: "DCGM_EXPORTER_KUBERNETES"
+              value: "true"
+            - name: "DCGM_EXPORTER_LISTEN"
+              value: ":9400"
+            - name: "DCGM_EXPORTER_INTERVAL"
+              value: "5000"
+            - name: "NODE_NAME"
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.nodeName
+            - name: "LD_LIBRARY_PATH"
+              value: "/usr/local/nvidia/lib64"
+            - name: "DCGM_EXPORTER_KUBERNETES_GPU_ID_TYPE"
+              value: "device-name"
+          volumeMounts:
+            - name: "pod-gpu-resources"
+              readOnly: true
+              mountPath: "/var/lib/kubelet/pod-resources"
+            - name: "nvidia-install-dir-host"
+              mountPath: /usr/local/nvidia
+            - name: zxporter-nodemon-dcgm-metrics
+              mountPath: "/etc/dcgm-exporter"

--- a/dist/nodemon-gcp-lowpriv.yaml
+++ b/dist/nodemon-gcp-lowpriv.yaml
@@ -6,10 +6,10 @@ metadata:
   name: zxporter-nodemon
   namespace: devzero-system
   labels:
-    helm.sh/chart: zxporter-nodemon-0.0.97
+    helm.sh/chart: zxporter-nodemon-0.0.98
     app.kubernetes.io/name: zxporter-nodemon
     app.kubernetes.io/instance: zxporter-nodemon
-    app.kubernetes.io/version: "0.0.97"
+    app.kubernetes.io/version: "0.0.98"
     app.kubernetes.io/managed-by: Helm
 ---
 # Source: zxporter-nodemon/templates/dcgm-exporter-configmap.yaml
@@ -82,10 +82,10 @@ kind: ClusterRole
 metadata:
   name: zxporter-nodemon
   labels:
-    helm.sh/chart: zxporter-nodemon-0.0.97
+    helm.sh/chart: zxporter-nodemon-0.0.98
     app.kubernetes.io/name: zxporter-nodemon
     app.kubernetes.io/instance: zxporter-nodemon
-    app.kubernetes.io/version: "0.0.97"
+    app.kubernetes.io/version: "0.0.98"
     app.kubernetes.io/managed-by: Helm
 rules:
 - apiGroups:
@@ -132,10 +132,10 @@ kind: ClusterRoleBinding
 metadata:
   name: zxporter-nodemon
   labels:
-    helm.sh/chart: zxporter-nodemon-0.0.97
+    helm.sh/chart: zxporter-nodemon-0.0.98
     app.kubernetes.io/name: zxporter-nodemon
     app.kubernetes.io/instance: zxporter-nodemon
-    app.kubernetes.io/version: "0.0.97"
+    app.kubernetes.io/version: "0.0.98"
     app.kubernetes.io/managed-by: Helm
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -153,10 +153,10 @@ metadata:
   name: zxporter-nodemon
   namespace: devzero-system
   labels:
-    helm.sh/chart: zxporter-nodemon-0.0.97
+    helm.sh/chart: zxporter-nodemon-0.0.98
     app.kubernetes.io/name: zxporter-nodemon
     app.kubernetes.io/instance: zxporter-nodemon
-    app.kubernetes.io/version: "0.0.97"
+    app.kubernetes.io/version: "0.0.98"
     app.kubernetes.io/managed-by: Helm
   annotations:
     ignore-check.kube-linter.io/privileged-container: "This daemon set needs to run DCGM Exporter as privileged to access the GPU metrics."
@@ -288,10 +288,10 @@ metadata:
   name: zxporter-nodemon-gpu
   namespace: devzero-system
   labels:
-    helm.sh/chart: zxporter-nodemon-0.0.97
+    helm.sh/chart: zxporter-nodemon-0.0.98
     app.kubernetes.io/name: zxporter-nodemon
     app.kubernetes.io/instance: zxporter-nodemon-gpu
-    app.kubernetes.io/version: "0.0.97"
+    app.kubernetes.io/version: "0.0.98"
     app.kubernetes.io/managed-by: Helm
   annotations:
     ignore-check.kube-linter.io/privileged-container: "This daemon set needs to run DCGM Exporter as privileged to access the GPU metrics."

--- a/dist/nodemon-lowpriv.yaml
+++ b/dist/nodemon-lowpriv.yaml
@@ -6,10 +6,10 @@ metadata:
   name: zxporter-nodemon
   namespace: devzero-system
   labels:
-    helm.sh/chart: zxporter-nodemon-0.0.97
+    helm.sh/chart: zxporter-nodemon-0.0.98
     app.kubernetes.io/name: zxporter-nodemon
     app.kubernetes.io/instance: zxporter-nodemon
-    app.kubernetes.io/version: "0.0.97"
+    app.kubernetes.io/version: "0.0.98"
     app.kubernetes.io/managed-by: Helm
 ---
 # Source: zxporter-nodemon/templates/dcgm-exporter-configmap.yaml
@@ -82,10 +82,10 @@ kind: ClusterRole
 metadata:
   name: zxporter-nodemon
   labels:
-    helm.sh/chart: zxporter-nodemon-0.0.97
+    helm.sh/chart: zxporter-nodemon-0.0.98
     app.kubernetes.io/name: zxporter-nodemon
     app.kubernetes.io/instance: zxporter-nodemon
-    app.kubernetes.io/version: "0.0.97"
+    app.kubernetes.io/version: "0.0.98"
     app.kubernetes.io/managed-by: Helm
 rules:
 - apiGroups:
@@ -132,10 +132,10 @@ kind: ClusterRoleBinding
 metadata:
   name: zxporter-nodemon
   labels:
-    helm.sh/chart: zxporter-nodemon-0.0.97
+    helm.sh/chart: zxporter-nodemon-0.0.98
     app.kubernetes.io/name: zxporter-nodemon
     app.kubernetes.io/instance: zxporter-nodemon
-    app.kubernetes.io/version: "0.0.97"
+    app.kubernetes.io/version: "0.0.98"
     app.kubernetes.io/managed-by: Helm
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -153,10 +153,10 @@ metadata:
   name: zxporter-nodemon
   namespace: devzero-system
   labels:
-    helm.sh/chart: zxporter-nodemon-0.0.97
+    helm.sh/chart: zxporter-nodemon-0.0.98
     app.kubernetes.io/name: zxporter-nodemon
     app.kubernetes.io/instance: zxporter-nodemon
-    app.kubernetes.io/version: "0.0.97"
+    app.kubernetes.io/version: "0.0.98"
     app.kubernetes.io/managed-by: Helm
   annotations:
     ignore-check.kube-linter.io/privileged-container: "This daemon set needs to run DCGM Exporter as privileged to access the GPU metrics."
@@ -278,10 +278,10 @@ metadata:
   name: zxporter-nodemon-gpu
   namespace: devzero-system
   labels:
-    helm.sh/chart: zxporter-nodemon-0.0.97
+    helm.sh/chart: zxporter-nodemon-0.0.98
     app.kubernetes.io/name: zxporter-nodemon
     app.kubernetes.io/instance: zxporter-nodemon-gpu
-    app.kubernetes.io/version: "0.0.97"
+    app.kubernetes.io/version: "0.0.98"
     app.kubernetes.io/managed-by: Helm
   annotations:
     ignore-check.kube-linter.io/privileged-container: "This daemon set needs to run DCGM Exporter as privileged to access the GPU metrics."

--- a/dist/nodemon-lowpriv.yaml
+++ b/dist/nodemon-lowpriv.yaml
@@ -1,0 +1,398 @@
+---
+# Source: zxporter-nodemon/templates/rbac.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: zxporter-nodemon
+  namespace: devzero-system
+  labels:
+    helm.sh/chart: zxporter-nodemon-0.0.97
+    app.kubernetes.io/name: zxporter-nodemon
+    app.kubernetes.io/instance: zxporter-nodemon
+    app.kubernetes.io/version: "0.0.97"
+    app.kubernetes.io/managed-by: Helm
+---
+# Source: zxporter-nodemon/templates/dcgm-exporter-configmap.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: zxporter-nodemon-dcgm-metrics
+  namespace: devzero-system
+data:
+  counters.csv: |
+    # Temperature and power usage,,
+    DCGM_FI_DEV_GPU_TEMP, gauge, Current temperature readings for the device in degrees C.
+    DCGM_FI_DEV_MEMORY_TEMP, gauge, Memory temperature for the device.
+    DCGM_FI_DEV_POWER_USAGE, gauge, Power usage for the device in Watts.
+
+    # Utilization,,
+    # DCGM_FI_DEV_GPU_UTIL provides overall GPU utilization which is useful for scenarios
+    # like fractional GPU sharing (e.g., EKS time-slicing, MIG) where profiling metrics may not be available.
+    DCGM_FI_DEV_GPU_UTIL, gauge, GPU utilization (in %).
+    # DCGM_FI_PROF_SM_ACTIVE, gauge, The ratio of cycles an SM has at least 1 warp assigned
+    # DCGM_FI_PROF_SM_OCCUPANCY, gauge, The fraction of resident warps on a multiprocessor
+    # DCGM_FI_PROF_GR_ENGINE_ACTIVE, gauge, Ratio of time the graphics engine is active (in %).
+    # DCGM_FI_PROF_DRAM_ACTIVE, gauge, The ratio of cycles the device memory interface is active sending or receiving data.
+
+    # Memory usage,,
+    DCGM_FI_DEV_FB_FREE, gauge, Framebuffer memory free (in MiB).
+    DCGM_FI_DEV_FB_USED, gauge, Framebuffer memory used (in MiB).
+    DCGM_FI_DEV_FB_TOTAL, gauge, Total Frame Buffer of the GPU in MB.
+    DCGM_FI_DEV_MEM_COPY_UTIL, gauge, Utilization of the memory copy engine.
+
+    # PCIE,,
+    # DCGM_FI_PROF_PCIE_TX_BYTES, gauge, Total number of bytes transmitted through PCIe TX
+    # DCGM_FI_PROF_PCIE_RX_BYTES, gauge, Total number of bytes received through PCIe RX
+    DCGM_FI_DEV_PCIE_LINK_GEN, gauge, PCIe Current Link Generation.
+    DCGM_FI_DEV_PCIE_LINK_WIDTH, gauge, PCIe Current Link Width.
+
+    # Pipelines,,
+    # DCGM_FI_PROF_PIPE_INT_ACTIVE, gauge, Ratio of cycles the integer pipe is active.
+    # DCGM_FI_PROF_PIPE_FP16_ACTIVE, gauge, Ratio of cycles the fp16 pipe is active.
+    # DCGM_FI_PROF_PIPE_FP32_ACTIVE, gauge, Ratio of cycles the fp32 pipe is active.
+    # DCGM_FI_PROF_PIPE_FP64_ACTIVE, gauge, Ratio of cycles the fp64 pipe is active.
+    # DCGM_FI_PROF_PIPE_TENSOR_ACTIVE, gauge, The ratio of cycles the tensor (HMMA) pipe is active (off the peak sustained elapsed cycles)
+
+    # Health,,
+    # DCGM_FI_DEV_CLOCKS_EVENT_REASONS is not supported by DCGM 3.3.7
+    # DCGM_FI_DEV_CLOCKS_EVENT_REASONS, gauge, Current clock event reasons (bitmask of DCGM_CLOCKS_EVENT_REASON_*)
+    DCGM_FI_DEV_XID_ERRORS, gauge, The value is the specific XID error
+    DCGM_FI_DEV_POWER_VIOLATION, gauge, Power Violation time in ns.
+    DCGM_FI_DEV_THERMAL_VIOLATION, gauge, Thermal Violation time in ns.
+
+    # NVLink,,
+    # DCGM_FI_PROF_NVLINK_TX_BYTES, gauge, The number of bytes of active NvLink tx (transmit) data including both header and payload.
+    # DCGM_FI_PROF_NVLINK_RX_BYTES, gauge, The number of bytes of active NvLink rx (read) data including both header and payload.
+
+    # Clocks,,
+    DCGM_FI_DEV_SM_CLOCK, gauge, SM clock frequency (in MHz).
+    DCGM_FI_DEV_MEM_CLOCK, gauge, Memory clock frequency (in MHz).
+---
+# Source: zxporter-nodemon/templates/nodemon-configmap.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: zxporter-nodemon-zxporter-nodemon
+  namespace: devzero-system
+data:
+---
+# Source: zxporter-nodemon/templates/rbac.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: zxporter-nodemon
+  labels:
+    helm.sh/chart: zxporter-nodemon-0.0.97
+    app.kubernetes.io/name: zxporter-nodemon
+    app.kubernetes.io/instance: zxporter-nodemon
+    app.kubernetes.io/version: "0.0.97"
+    app.kubernetes.io/managed-by: Helm
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  verbs:
+  - get
+  - list
+- apiGroups:
+    - apps
+  resources:
+    - replicasets
+    - deployments
+    - statefulsets
+    - daemonsets
+  verbs:
+    - get
+- apiGroups:
+    - batch
+  resources:
+    - jobs
+    - cronjobs
+  verbs:
+    - get
+- apiGroups:
+    - argoproj.io
+  resources:
+    - rollouts
+  verbs:
+    - get
+- apiGroups:
+    - ""
+  resources:
+    - nodes/proxy
+    - nodes/metrics
+    - nodes/stats
+  verbs:
+    - get
+---
+# Source: zxporter-nodemon/templates/rbac.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: zxporter-nodemon
+  labels:
+    helm.sh/chart: zxporter-nodemon-0.0.97
+    app.kubernetes.io/name: zxporter-nodemon
+    app.kubernetes.io/instance: zxporter-nodemon
+    app.kubernetes.io/version: "0.0.97"
+    app.kubernetes.io/managed-by: Helm
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: zxporter-nodemon
+subjects:
+- kind: ServiceAccount
+  name: zxporter-nodemon
+  namespace: devzero-system
+---
+# Source: zxporter-nodemon/templates/daemonset.yaml
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: zxporter-nodemon
+  namespace: devzero-system
+  labels:
+    helm.sh/chart: zxporter-nodemon-0.0.97
+    app.kubernetes.io/name: zxporter-nodemon
+    app.kubernetes.io/instance: zxporter-nodemon
+    app.kubernetes.io/version: "0.0.97"
+    app.kubernetes.io/managed-by: Helm
+  annotations:
+    ignore-check.kube-linter.io/privileged-container: "This daemon set needs to run DCGM Exporter as privileged to access the GPU metrics."
+    ignore-check.kube-linter.io/run-as-non-root: "This daemon set needs to run DCGM Exporter as root to access the GPU metrics."
+    ignore-check.kube-linter.io/privilege-escalation-container: "This daemon set needs escalate privileges for DCGM Exporter."
+    ignore-check.kube-linter.io/no-read-only-root-fs: "This daemon set needs to run DCGM Exporter with read-only root filesystem."
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: zxporter-nodemon
+      app.kubernetes.io/instance: zxporter-nodemon
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: zxporter-nodemon
+        app.kubernetes.io/instance: zxporter-nodemon
+    spec:
+      priorityClassName: devzero-zxporter-devzero-zxporter-critical
+      serviceAccountName: zxporter-nodemon
+      volumes:
+        - name: "pod-gpu-resources"
+          hostPath:
+            path: /var/lib/kubelet/pod-resources
+        - name: zxporter-nodemon-dcgm-metrics
+          configMap:
+            name: zxporter-nodemon-dcgm-metrics
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: nvidia.com/gpu.present
+                operator: NotIn
+                values:
+                - "true"
+      tolerations:
+        - effect: NoExecute
+          operator: Exists
+        - effect: NoSchedule
+          operator: Exists
+        - effect: PreferNoSchedule
+          operator: Exists
+      containers:
+        - name: zxporter-nodemon
+          securityContext:
+            readOnlyRootFilesystem: true
+            runAsNonRoot: true
+          image: "ttl.sh/zxporter-nodemon:latest"
+          imagePullPolicy: IfNotPresent
+          ports:
+            - name: http
+              containerPort: 6061
+              protocol: TCP
+          livenessProbe:
+            httpGet:
+              path: /healthz
+              port: http
+          readinessProbe:
+            httpGet:
+              path: /healthz
+              port: http
+          envFrom:
+            - configMapRef:
+                name: zxporter-nodemon-zxporter-nodemon
+          env:
+            - name: "NODE_NAME"
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.nodeName
+            - name: "RUNTIME_METRICS_ENABLED"
+              value: "false"
+            - name: "DCGM_HOST"
+              value: "localhost"
+          resources:
+            limits:
+              memory: 256Mi
+            requests:
+              cpu: 60m
+              memory: 256Mi
+        - name: dcgm-exporter
+          securityContext:
+            capabilities:
+              add:
+                - SYS_ADMIN
+              drop:
+                - NET_RAW
+            runAsNonRoot: false
+            runAsUser: 0
+          image: "nvcr.io/nvidia/k8s/dcgm-exporter:4.5.2-4.8.1-ubuntu22.04"
+          imagePullPolicy: IfNotPresent
+          command: [ "/bin/bash", "-c" ]
+          args:
+            - hostname $NODE_NAME; for ((;;)) { r=$(dcgm-exporter -f /etc/dcgm-exporter/counters.csv); echo "dcgm-exporter could not run"; sleep 60 ; }
+          ports:
+            - name: "metrics"
+              containerPort: 9400
+          env:
+            - name: "DCGM_EXPORTER_KUBERNETES"
+              value: "true"
+            - name: "DCGM_EXPORTER_LISTEN"
+              value: ":9400"
+            - name: "DCGM_EXPORTER_INTERVAL"
+              value: "5000"
+            - name: "NODE_NAME"
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.nodeName
+          volumeMounts:
+            - name: "pod-gpu-resources"
+              readOnly: true
+              mountPath: "/var/lib/kubelet/pod-resources"
+            - name: zxporter-nodemon-dcgm-metrics
+              mountPath: "/etc/dcgm-exporter"
+---
+# Source: zxporter-nodemon/templates/daemonset.yaml
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: zxporter-nodemon-gpu
+  namespace: devzero-system
+  labels:
+    helm.sh/chart: zxporter-nodemon-0.0.97
+    app.kubernetes.io/name: zxporter-nodemon
+    app.kubernetes.io/instance: zxporter-nodemon-gpu
+    app.kubernetes.io/version: "0.0.97"
+    app.kubernetes.io/managed-by: Helm
+  annotations:
+    ignore-check.kube-linter.io/privileged-container: "This daemon set needs to run DCGM Exporter as privileged to access the GPU metrics."
+    ignore-check.kube-linter.io/run-as-non-root: "This daemon set needs to run DCGM Exporter as root to access the GPU metrics."
+    ignore-check.kube-linter.io/privilege-escalation-container: "This daemon set needs escalate privileges for DCGM Exporter."
+    ignore-check.kube-linter.io/no-read-only-root-fs: "This daemon set needs to run DCGM Exporter with read-only root filesystem."
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: zxporter-nodemon
+      app.kubernetes.io/instance: zxporter-nodemon-gpu
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: zxporter-nodemon
+        app.kubernetes.io/instance: zxporter-nodemon-gpu
+    spec:
+      priorityClassName: devzero-zxporter-devzero-zxporter-critical
+      runtimeClassName: "nvidia"
+      serviceAccountName: zxporter-nodemon
+      volumes:
+        - name: "pod-gpu-resources"
+          hostPath:
+            path: /var/lib/kubelet/pod-resources
+        - name: zxporter-nodemon-dcgm-metrics
+          configMap:
+            name: zxporter-nodemon-dcgm-metrics
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: nvidia.com/gpu.present
+                operator: In
+                values:
+                - "true"
+      tolerations:
+        - effect: NoExecute
+          operator: Exists
+        - effect: NoSchedule
+          operator: Exists
+        - effect: PreferNoSchedule
+          operator: Exists
+      containers:
+        - name: zxporter-nodemon
+          securityContext:
+            readOnlyRootFilesystem: true
+            runAsNonRoot: true
+          image: "ttl.sh/zxporter-nodemon:latest"
+          imagePullPolicy: IfNotPresent
+          ports:
+            - name: http
+              containerPort: 6061
+              protocol: TCP
+          livenessProbe:
+            httpGet:
+              path: /healthz
+              port: http
+          readinessProbe:
+            httpGet:
+              path: /healthz
+              port: http
+          envFrom:
+            - configMapRef:
+                name: zxporter-nodemon-zxporter-nodemon
+          env:
+            - name: "NODE_NAME"
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.nodeName
+            - name: "RUNTIME_METRICS_ENABLED"
+              value: "false"
+            - name: "DCGM_HOST"
+              value: "localhost"
+          resources:
+            limits:
+              memory: 256Mi
+            requests:
+              cpu: 60m
+              memory: 256Mi
+        - name: dcgm-exporter
+          securityContext:
+            capabilities:
+              add:
+                - SYS_ADMIN
+              drop:
+                - NET_RAW
+            runAsNonRoot: false
+            runAsUser: 0
+          image: "nvcr.io/nvidia/k8s/dcgm-exporter:4.5.2-4.8.1-ubuntu22.04"
+          imagePullPolicy: IfNotPresent
+          command: [ "/bin/bash", "-c" ]
+          args:
+            - hostname $NODE_NAME; for ((;;)) { r=$(dcgm-exporter -f /etc/dcgm-exporter/counters.csv); echo "dcgm-exporter could not run"; sleep 60 ; }
+          ports:
+            - name: "metrics"
+              containerPort: 9400
+          env:
+            - name: "DCGM_EXPORTER_KUBERNETES"
+              value: "true"
+            - name: "DCGM_EXPORTER_LISTEN"
+              value: ":9400"
+            - name: "DCGM_EXPORTER_INTERVAL"
+              value: "5000"
+            - name: "NODE_NAME"
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.nodeName
+          volumeMounts:
+            - name: "pod-gpu-resources"
+              readOnly: true
+              mountPath: "/var/lib/kubelet/pod-resources"
+            - name: zxporter-nodemon-dcgm-metrics
+              mountPath: "/etc/dcgm-exporter"

--- a/internal/nodemon/server_test.go
+++ b/internal/nodemon/server_test.go
@@ -1,0 +1,55 @@
+package nodemon
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// stubHandler returns a fixed status so we only assert on route registration,
+// not handler internals (those are covered by the handler's own tests).
+func stubHandler(status int) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(status)
+	})
+}
+
+// TestNewServerMux_HighPrivilegeMode mirrors cmd/zxporter-nodemon/main.go's wiring
+// when RUNTIME_METRICS_ENABLED=true (the default, privileged install): the JVM and
+// combined runtime-metrics handlers are non-nil and must be reachable.
+func TestNewServerMux_HighPrivilegeMode(t *testing.T) {
+	mux := NewServerMux(stubHandler(http.StatusOK), stubHandler(http.StatusOK), stubHandler(http.StatusOK))
+
+	for _, path := range []string{"/container/metrics", "/container/jvm-metrics", "/container/runtime-metrics"} {
+		rec := httptest.NewRecorder()
+		mux.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, path, nil))
+		assert.Equalf(t, http.StatusOK, rec.Code, "expected %s to be registered in high-privilege mode", path)
+	}
+
+	rec := httptest.NewRecorder()
+	mux.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/healthz", nil))
+	assert.Equal(t, http.StatusOK, rec.Code)
+}
+
+// TestNewServerMux_LowPrivilegeMode mirrors main.go's wiring when
+// RUNTIME_METRICS_ENABLED=false (or unset) — the low-privilege install path with no
+// hostPID/root/SYS_PTRACE. JVM and runtime-metrics collection never start, so main.go
+// passes nil handlers for them; those routes must not be registered, while the
+// always-on endpoints (container metrics, healthz) keep working.
+func TestNewServerMux_LowPrivilegeMode(t *testing.T) {
+	mux := NewServerMux(stubHandler(http.StatusOK), nil, nil)
+
+	for _, path := range []string{"/container/jvm-metrics", "/container/runtime-metrics"} {
+		rec := httptest.NewRecorder()
+		mux.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, path, nil))
+		assert.Equalf(t, http.StatusNotFound, rec.Code, "expected %s to be absent in low-privilege mode", path)
+	}
+
+	for _, path := range []string{"/container/metrics", "/healthz"} {
+		rec := httptest.NewRecorder()
+		mux.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, path, nil))
+		assert.Equalf(t, http.StatusOK, rec.Code, "expected %s to still work in low-privilege mode", path)
+	}
+}

--- a/internal/nodemon/server_test.go
+++ b/internal/nodemon/server_test.go
@@ -8,11 +8,11 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-// stubHandler returns a fixed status so we only assert on route registration,
+// stubHandler always responds 200 OK, so we only assert on route registration,
 // not handler internals (those are covered by the handler's own tests).
-func stubHandler(status int) http.Handler {
+func stubHandler() http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		w.WriteHeader(status)
+		w.WriteHeader(http.StatusOK)
 	})
 }
 
@@ -20,7 +20,7 @@ func stubHandler(status int) http.Handler {
 // when RUNTIME_METRICS_ENABLED=true (the default, privileged install): the JVM and
 // combined runtime-metrics handlers are non-nil and must be reachable.
 func TestNewServerMux_HighPrivilegeMode(t *testing.T) {
-	mux := NewServerMux(stubHandler(http.StatusOK), stubHandler(http.StatusOK), stubHandler(http.StatusOK))
+	mux := NewServerMux(stubHandler(), stubHandler(), stubHandler())
 
 	for _, path := range []string{"/container/metrics", "/container/jvm-metrics", "/container/runtime-metrics"} {
 		rec := httptest.NewRecorder()
@@ -39,7 +39,7 @@ func TestNewServerMux_HighPrivilegeMode(t *testing.T) {
 // passes nil handlers for them; those routes must not be registered, while the
 // always-on endpoints (container metrics, healthz) keep working.
 func TestNewServerMux_LowPrivilegeMode(t *testing.T) {
-	mux := NewServerMux(stubHandler(http.StatusOK), nil, nil)
+	mux := NewServerMux(stubHandler(), nil, nil)
 
 	for _, path := range []string{"/container/jvm-metrics", "/container/runtime-metrics"} {
 		rec := httptest.NewRecorder()


### PR DESCRIPTION
## Summary

The nodemon Helm chart already supports opting out of process-introspection runtime metrics via `runtimeMetrics.enabled=false` — this drops `hostPID`, the root/`SYS_PTRACE` securityContext, `RUNTIME_METRICS_ENABLED`, and the RBAC `watch` verb (see `helm-chart/zxporter-nodemon/templates/daemonset.yaml` and `rbac.yaml`, added in #483/#437). But the static `dist/` bundles used by the plain `curl | kubectl apply` installer, and by dakr's backend-served installer manifests, always render with runtime metrics **on**, with no way to opt out short of hand-editing YAML.

This adds `-lowpriv` variants of every dist bundle, plus CI coverage so they can't silently drift from the chart they're generated from. (Previously split across #502/#503 — combined into one PR per review feedback.)

## What changed

- `Makefile`: added `DIST_*_LOWPRIV_BUNDLE` path vars, an extra `helm template --set runtimeMetrics.enabled=false` pass per provider in `build-installer`, and a second `$(MAKE) final-installer` invocation (with the lowpriv bundle vars overridden) to produce the backend/updater lowpriv variants — same pattern already used for the `-gcp` variant. Also fixed a latent bug where `final-installer`'s first `cp` was hardcoded to literal `dist/install.yaml` instead of `$(DIST_INSTALL_BUNDLE)`, so the target wasn't actually overridable for a base-bundle variant other than the default (no behavior change for existing default/-gcp builds, same path either way).
- New bundles: `nodemon-lowpriv.yaml` / `nodemon-gcp-lowpriv.yaml`, `install-lowpriv.yaml` / `install-gcp-lowpriv.yaml`, `backend-install-lowpriv.yaml` / `backend-install-gcp-lowpriv.yaml`, `installer_updater-lowpriv.yaml` / `installer_updater-gcp-lowpriv.yaml`.
- `runtime-metrics-kind-test.yml`: new "Static dist/ low-privilege bundle coverage" step asserting the **committed** lowpriv bundles have no `hostPID`/`SYS_PTRACE` and `RUNTIME_METRICS_ENABLED: "false"`, and that the privileged bundles still have them (proving the greps aren't vacuous). Deliberately a static-file check rather than a live deploy of the static bundle — the existing "Helm key parity" step already proves the template logic renders correctly with a freshly-built test image; a live deploy of the static bundle would pull its real published image tag, unnecessary flakiness for what's really just "did someone forget to run `make build-installer`."
- `build-installer-check.yml`: fixed a stale comment referencing a nonexistent `-nvidia-runtime` bundle naming scheme; its actual check logic needed no change (already runs `git status --porcelain dist/` over the whole directory).
- No Helm chart changes — this is purely a new dist-generation output off the toggle that already exists.

## Verification

Ran `make build-installer` locally (including a from-scratch regenerate after deleting `dist/` entirely) and diffed the output:
- `dist/nodemon-lowpriv.yaml` / `nodemon-gcp-lowpriv.yaml`: no `hostPID: true`, no `SYS_PTRACE`, `RUNTIME_METRICS_ENABLED: "false"`, nodemon ClusterRole's `pods` rule drops the `watch` verb.
- `dist/nodemon.yaml` / `nodemon-gcp.yaml` (existing, privileged): unchanged, still carry `hostPID: true` / `SYS_PTRACE` / `watch`.
- A single `make build-installer` invocation reproduces every checked-in bundle in `dist/` byte-for-byte from a clean checkout — no manual steps, no separately-maintained files.

## QA steps for reviewer

1. `make build-installer`
2. `grep -E 'hostPID: true|SYS_PTRACE' dist/nodemon-lowpriv.yaml dist/nodemon-gcp-lowpriv.yaml` → no matches
3. `grep -E 'hostPID: true|SYS_PTRACE' dist/nodemon.yaml dist/nodemon-gcp.yaml` → matches (unchanged privileged behavior)
4. `kubectl apply -f dist/nodemon-lowpriv.yaml` on a kind cluster → DaemonSet schedules and passes healthz without `hostPID`
5. `runtime-metrics-kind` CI job should show the new "Static dist/ low-privilege bundle coverage" step passing