### PR TITLE
chore(release): v0.1.3

### DIFF
--- a/dist/backend-install-gcp-lowpriv.yaml
+++ b/dist/backend-install-gcp-lowpriv.yaml
@@ -833,10 +833,10 @@ metadata:
   name: zxporter-nodemon
   namespace: {{.zxporter_namespace}}
   labels:
-    helm.sh/chart: zxporter-nodemon-0.1.2
+    helm.sh/chart: zxporter-nodemon-0.1.3
     app.kubernetes.io/name: zxporter-nodemon
     app.kubernetes.io/instance: zxporter-nodemon
-    app.kubernetes.io/version: "0.1.2"
+    app.kubernetes.io/version: "0.1.3"
     app.kubernetes.io/managed-by: Helm
 ---
 # Source: zxporter-nodemon/templates/dcgm-exporter-configmap.yaml
@@ -909,10 +909,10 @@ kind: ClusterRole
 metadata:
   name: zxporter-nodemon
   labels:
-    helm.sh/chart: zxporter-nodemon-0.1.2
+    helm.sh/chart: zxporter-nodemon-0.1.3
     app.kubernetes.io/name: zxporter-nodemon
     app.kubernetes.io/instance: zxporter-nodemon
-    app.kubernetes.io/version: "0.1.2"
+    app.kubernetes.io/version: "0.1.3"
     app.kubernetes.io/managed-by: Helm
 rules:
   - apiGroups:
@@ -959,10 +959,10 @@ kind: ClusterRoleBinding
 metadata:
   name: zxporter-nodemon
   labels:
-    helm.sh/chart: zxporter-nodemon-0.1.2
+    helm.sh/chart: zxporter-nodemon-0.1.3
     app.kubernetes.io/name: zxporter-nodemon
     app.kubernetes.io/instance: zxporter-nodemon
-    app.kubernetes.io/version: "0.1.2"
+    app.kubernetes.io/version: "0.1.3"
     app.kubernetes.io/managed-by: Helm
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -980,10 +980,10 @@ metadata:
   name: zxporter-nodemon
   namespace: {{.zxporter_namespace}}
   labels:
-    helm.sh/chart: zxporter-nodemon-0.1.2
+    helm.sh/chart: zxporter-nodemon-0.1.3
     app.kubernetes.io/name: zxporter-nodemon
     app.kubernetes.io/instance: zxporter-nodemon
-    app.kubernetes.io/version: "0.1.2"
+    app.kubernetes.io/version: "0.1.3"
     app.kubernetes.io/managed-by: Helm
   annotations:
     ignore-check.kube-linter.io/privileged-container: "This daemon set needs to run DCGM Exporter as privileged to access the GPU metrics."
@@ -1132,10 +1132,10 @@ metadata:
   name: zxporter-nodemon-gpu
   namespace: {{.zxporter_namespace}}
   labels:
-    helm.sh/chart: zxporter-nodemon-0.1.2
+    helm.sh/chart: zxporter-nodemon-0.1.3
     app.kubernetes.io/name: zxporter-nodemon
     app.kubernetes.io/instance: zxporter-nodemon-gpu
-    app.kubernetes.io/version: "0.1.2"
+    app.kubernetes.io/version: "0.1.3"
     app.kubernetes.io/managed-by: Helm
   annotations:
     ignore-check.kube-linter.io/privileged-container: "This daemon set needs to run DCGM Exporter as privileged to access the GPU metrics."

--- a/dist/backend-install-gcp.yaml
+++ b/dist/backend-install-gcp.yaml
@@ -833,10 +833,10 @@ metadata:
   name: zxporter-nodemon
   namespace: {{.zxporter_namespace}}
   labels:
-    helm.sh/chart: zxporter-nodemon-0.1.2
+    helm.sh/chart: zxporter-nodemon-0.1.3
     app.kubernetes.io/name: zxporter-nodemon
     app.kubernetes.io/instance: zxporter-nodemon
-    app.kubernetes.io/version: "0.1.2"
+    app.kubernetes.io/version: "0.1.3"
     app.kubernetes.io/managed-by: Helm
 ---
 # Source: zxporter-nodemon/templates/dcgm-exporter-configmap.yaml
@@ -909,10 +909,10 @@ kind: ClusterRole
 metadata:
   name: zxporter-nodemon
   labels:
-    helm.sh/chart: zxporter-nodemon-0.1.2
+    helm.sh/chart: zxporter-nodemon-0.1.3
     app.kubernetes.io/name: zxporter-nodemon
     app.kubernetes.io/instance: zxporter-nodemon
-    app.kubernetes.io/version: "0.1.2"
+    app.kubernetes.io/version: "0.1.3"
     app.kubernetes.io/managed-by: Helm
 rules:
   - apiGroups:
@@ -960,10 +960,10 @@ kind: ClusterRoleBinding
 metadata:
   name: zxporter-nodemon
   labels:
-    helm.sh/chart: zxporter-nodemon-0.1.2
+    helm.sh/chart: zxporter-nodemon-0.1.3
     app.kubernetes.io/name: zxporter-nodemon
     app.kubernetes.io/instance: zxporter-nodemon
-    app.kubernetes.io/version: "0.1.2"
+    app.kubernetes.io/version: "0.1.3"
     app.kubernetes.io/managed-by: Helm
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -981,10 +981,10 @@ metadata:
   name: zxporter-nodemon
   namespace: {{.zxporter_namespace}}
   labels:
-    helm.sh/chart: zxporter-nodemon-0.1.2
+    helm.sh/chart: zxporter-nodemon-0.1.3
     app.kubernetes.io/name: zxporter-nodemon
     app.kubernetes.io/instance: zxporter-nodemon
-    app.kubernetes.io/version: "0.1.2"
+    app.kubernetes.io/version: "0.1.3"
     app.kubernetes.io/managed-by: Helm
   annotations:
     ignore-check.kube-linter.io/privileged-container: "This daemon set needs to run DCGM Exporter as privileged to access the GPU metrics."
@@ -1138,10 +1138,10 @@ metadata:
   name: zxporter-nodemon-gpu
   namespace: {{.zxporter_namespace}}
   labels:
-    helm.sh/chart: zxporter-nodemon-0.1.2
+    helm.sh/chart: zxporter-nodemon-0.1.3
     app.kubernetes.io/name: zxporter-nodemon
     app.kubernetes.io/instance: zxporter-nodemon-gpu
-    app.kubernetes.io/version: "0.1.2"
+    app.kubernetes.io/version: "0.1.3"
     app.kubernetes.io/managed-by: Helm
   annotations:
     ignore-check.kube-linter.io/privileged-container: "This daemon set needs to run DCGM Exporter as privileged to access the GPU metrics."

--- a/dist/backend-install-lowpriv.yaml
+++ b/dist/backend-install-lowpriv.yaml
@@ -833,10 +833,10 @@ metadata:
   name: zxporter-nodemon
   namespace: {{.zxporter_namespace}}
   labels:
-    helm.sh/chart: zxporter-nodemon-0.1.2
+    helm.sh/chart: zxporter-nodemon-0.1.3
     app.kubernetes.io/name: zxporter-nodemon
     app.kubernetes.io/instance: zxporter-nodemon
-    app.kubernetes.io/version: "0.1.2"
+    app.kubernetes.io/version: "0.1.3"
     app.kubernetes.io/managed-by: Helm
 ---
 # Source: zxporter-nodemon/templates/dcgm-exporter-configmap.yaml
@@ -909,10 +909,10 @@ kind: ClusterRole
 metadata:
   name: zxporter-nodemon
   labels:
-    helm.sh/chart: zxporter-nodemon-0.1.2
+    helm.sh/chart: zxporter-nodemon-0.1.3
     app.kubernetes.io/name: zxporter-nodemon
     app.kubernetes.io/instance: zxporter-nodemon
-    app.kubernetes.io/version: "0.1.2"
+    app.kubernetes.io/version: "0.1.3"
     app.kubernetes.io/managed-by: Helm
 rules:
   - apiGroups:
@@ -959,10 +959,10 @@ kind: ClusterRoleBinding
 metadata:
   name: zxporter-nodemon
   labels:
-    helm.sh/chart: zxporter-nodemon-0.1.2
+    helm.sh/chart: zxporter-nodemon-0.1.3
     app.kubernetes.io/name: zxporter-nodemon
     app.kubernetes.io/instance: zxporter-nodemon
-    app.kubernetes.io/version: "0.1.2"
+    app.kubernetes.io/version: "0.1.3"
     app.kubernetes.io/managed-by: Helm
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -980,10 +980,10 @@ metadata:
   name: zxporter-nodemon
   namespace: {{.zxporter_namespace}}
   labels:
-    helm.sh/chart: zxporter-nodemon-0.1.2
+    helm.sh/chart: zxporter-nodemon-0.1.3
     app.kubernetes.io/name: zxporter-nodemon
     app.kubernetes.io/instance: zxporter-nodemon
-    app.kubernetes.io/version: "0.1.2"
+    app.kubernetes.io/version: "0.1.3"
     app.kubernetes.io/managed-by: Helm
   annotations:
     ignore-check.kube-linter.io/privileged-container: "This daemon set needs to run DCGM Exporter as privileged to access the GPU metrics."
@@ -1122,10 +1122,10 @@ metadata:
   name: zxporter-nodemon-gpu
   namespace: {{.zxporter_namespace}}
   labels:
-    helm.sh/chart: zxporter-nodemon-0.1.2
+    helm.sh/chart: zxporter-nodemon-0.1.3
     app.kubernetes.io/name: zxporter-nodemon
     app.kubernetes.io/instance: zxporter-nodemon-gpu
-    app.kubernetes.io/version: "0.1.2"
+    app.kubernetes.io/version: "0.1.3"
     app.kubernetes.io/managed-by: Helm
   annotations:
     ignore-check.kube-linter.io/privileged-container: "This daemon set needs to run DCGM Exporter as privileged to access the GPU metrics."

--- a/dist/backend-install.yaml
+++ b/dist/backend-install.yaml
@@ -833,10 +833,10 @@ metadata:
   name: zxporter-nodemon
   namespace: {{.zxporter_namespace}}
   labels:
-    helm.sh/chart: zxporter-nodemon-0.1.2
+    helm.sh/chart: zxporter-nodemon-0.1.3
     app.kubernetes.io/name: zxporter-nodemon
     app.kubernetes.io/instance: zxporter-nodemon
-    app.kubernetes.io/version: "0.1.2"
+    app.kubernetes.io/version: "0.1.3"
     app.kubernetes.io/managed-by: Helm
 ---
 # Source: zxporter-nodemon/templates/dcgm-exporter-configmap.yaml
@@ -909,10 +909,10 @@ kind: ClusterRole
 metadata:
   name: zxporter-nodemon
   labels:
-    helm.sh/chart: zxporter-nodemon-0.1.2
+    helm.sh/chart: zxporter-nodemon-0.1.3
     app.kubernetes.io/name: zxporter-nodemon
     app.kubernetes.io/instance: zxporter-nodemon
-    app.kubernetes.io/version: "0.1.2"
+    app.kubernetes.io/version: "0.1.3"
     app.kubernetes.io/managed-by: Helm
 rules:
   - apiGroups:
@@ -960,10 +960,10 @@ kind: ClusterRoleBinding
 metadata:
   name: zxporter-nodemon
   labels:
-    helm.sh/chart: zxporter-nodemon-0.1.2
+    helm.sh/chart: zxporter-nodemon-0.1.3
     app.kubernetes.io/name: zxporter-nodemon
     app.kubernetes.io/instance: zxporter-nodemon
-    app.kubernetes.io/version: "0.1.2"
+    app.kubernetes.io/version: "0.1.3"
     app.kubernetes.io/managed-by: Helm
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -981,10 +981,10 @@ metadata:
   name: zxporter-nodemon
   namespace: {{.zxporter_namespace}}
   labels:
-    helm.sh/chart: zxporter-nodemon-0.1.2
+    helm.sh/chart: zxporter-nodemon-0.1.3
     app.kubernetes.io/name: zxporter-nodemon
     app.kubernetes.io/instance: zxporter-nodemon
-    app.kubernetes.io/version: "0.1.2"
+    app.kubernetes.io/version: "0.1.3"
     app.kubernetes.io/managed-by: Helm
   annotations:
     ignore-check.kube-linter.io/privileged-container: "This daemon set needs to run DCGM Exporter as privileged to access the GPU metrics."
@@ -1128,10 +1128,10 @@ metadata:
   name: zxporter-nodemon-gpu
   namespace: {{.zxporter_namespace}}
   labels:
-    helm.sh/chart: zxporter-nodemon-0.1.2
+    helm.sh/chart: zxporter-nodemon-0.1.3
     app.kubernetes.io/name: zxporter-nodemon
     app.kubernetes.io/instance: zxporter-nodemon-gpu
-    app.kubernetes.io/version: "0.1.2"
+    app.kubernetes.io/version: "0.1.3"
     app.kubernetes.io/managed-by: Helm
   annotations:
     ignore-check.kube-linter.io/privileged-container: "This daemon set needs to run DCGM Exporter as privileged to access the GPU metrics."

--- a/dist/install-gcp-lowpriv.yaml
+++ b/dist/install-gcp-lowpriv.yaml
@@ -833,10 +833,10 @@ metadata:
   name: zxporter-nodemon
   namespace: devzero-system
   labels:
-    helm.sh/chart: zxporter-nodemon-0.1.2
+    helm.sh/chart: zxporter-nodemon-0.1.3
     app.kubernetes.io/name: zxporter-nodemon
     app.kubernetes.io/instance: zxporter-nodemon
-    app.kubernetes.io/version: "0.1.2"
+    app.kubernetes.io/version: "0.1.3"
     app.kubernetes.io/managed-by: Helm
 ---
 # Source: zxporter-nodemon/templates/dcgm-exporter-configmap.yaml
@@ -909,10 +909,10 @@ kind: ClusterRole
 metadata:
   name: zxporter-nodemon
   labels:
-    helm.sh/chart: zxporter-nodemon-0.1.2
+    helm.sh/chart: zxporter-nodemon-0.1.3
     app.kubernetes.io/name: zxporter-nodemon
     app.kubernetes.io/instance: zxporter-nodemon
-    app.kubernetes.io/version: "0.1.2"
+    app.kubernetes.io/version: "0.1.3"
     app.kubernetes.io/managed-by: Helm
 rules:
 - apiGroups:
@@ -959,10 +959,10 @@ kind: ClusterRoleBinding
 metadata:
   name: zxporter-nodemon
   labels:
-    helm.sh/chart: zxporter-nodemon-0.1.2
+    helm.sh/chart: zxporter-nodemon-0.1.3
     app.kubernetes.io/name: zxporter-nodemon
     app.kubernetes.io/instance: zxporter-nodemon
-    app.kubernetes.io/version: "0.1.2"
+    app.kubernetes.io/version: "0.1.3"
     app.kubernetes.io/managed-by: Helm
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -980,10 +980,10 @@ metadata:
   name: zxporter-nodemon
   namespace: devzero-system
   labels:
-    helm.sh/chart: zxporter-nodemon-0.1.2
+    helm.sh/chart: zxporter-nodemon-0.1.3
     app.kubernetes.io/name: zxporter-nodemon
     app.kubernetes.io/instance: zxporter-nodemon
-    app.kubernetes.io/version: "0.1.2"
+    app.kubernetes.io/version: "0.1.3"
     app.kubernetes.io/managed-by: Helm
   annotations:
     ignore-check.kube-linter.io/privileged-container: "This daemon set needs to run DCGM Exporter as privileged to access the GPU metrics."
@@ -1132,10 +1132,10 @@ metadata:
   name: zxporter-nodemon-gpu
   namespace: devzero-system
   labels:
-    helm.sh/chart: zxporter-nodemon-0.1.2
+    helm.sh/chart: zxporter-nodemon-0.1.3
     app.kubernetes.io/name: zxporter-nodemon
     app.kubernetes.io/instance: zxporter-nodemon-gpu
-    app.kubernetes.io/version: "0.1.2"
+    app.kubernetes.io/version: "0.1.3"
     app.kubernetes.io/managed-by: Helm
   annotations:
     ignore-check.kube-linter.io/privileged-container: "This daemon set needs to run DCGM Exporter as privileged to access the GPU metrics."

--- a/dist/install-gcp.yaml
+++ b/dist/install-gcp.yaml
@@ -833,10 +833,10 @@ metadata:
   name: zxporter-nodemon
   namespace: devzero-system
   labels:
-    helm.sh/chart: zxporter-nodemon-0.1.2
+    helm.sh/chart: zxporter-nodemon-0.1.3
     app.kubernetes.io/name: zxporter-nodemon
     app.kubernetes.io/instance: zxporter-nodemon
-    app.kubernetes.io/version: "0.1.2"
+    app.kubernetes.io/version: "0.1.3"
     app.kubernetes.io/managed-by: Helm
 ---
 # Source: zxporter-nodemon/templates/dcgm-exporter-configmap.yaml
@@ -909,10 +909,10 @@ kind: ClusterRole
 metadata:
   name: zxporter-nodemon
   labels:
-    helm.sh/chart: zxporter-nodemon-0.1.2
+    helm.sh/chart: zxporter-nodemon-0.1.3
     app.kubernetes.io/name: zxporter-nodemon
     app.kubernetes.io/instance: zxporter-nodemon
-    app.kubernetes.io/version: "0.1.2"
+    app.kubernetes.io/version: "0.1.3"
     app.kubernetes.io/managed-by: Helm
 rules:
 - apiGroups:
@@ -960,10 +960,10 @@ kind: ClusterRoleBinding
 metadata:
   name: zxporter-nodemon
   labels:
-    helm.sh/chart: zxporter-nodemon-0.1.2
+    helm.sh/chart: zxporter-nodemon-0.1.3
     app.kubernetes.io/name: zxporter-nodemon
     app.kubernetes.io/instance: zxporter-nodemon
-    app.kubernetes.io/version: "0.1.2"
+    app.kubernetes.io/version: "0.1.3"
     app.kubernetes.io/managed-by: Helm
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -981,10 +981,10 @@ metadata:
   name: zxporter-nodemon
   namespace: devzero-system
   labels:
-    helm.sh/chart: zxporter-nodemon-0.1.2
+    helm.sh/chart: zxporter-nodemon-0.1.3
     app.kubernetes.io/name: zxporter-nodemon
     app.kubernetes.io/instance: zxporter-nodemon
-    app.kubernetes.io/version: "0.1.2"
+    app.kubernetes.io/version: "0.1.3"
     app.kubernetes.io/managed-by: Helm
   annotations:
     ignore-check.kube-linter.io/privileged-container: "This daemon set needs to run DCGM Exporter as privileged to access the GPU metrics."
@@ -1138,10 +1138,10 @@ metadata:
   name: zxporter-nodemon-gpu
   namespace: devzero-system
   labels:
-    helm.sh/chart: zxporter-nodemon-0.1.2
+    helm.sh/chart: zxporter-nodemon-0.1.3
     app.kubernetes.io/name: zxporter-nodemon
     app.kubernetes.io/instance: zxporter-nodemon-gpu
-    app.kubernetes.io/version: "0.1.2"
+    app.kubernetes.io/version: "0.1.3"
     app.kubernetes.io/managed-by: Helm
   annotations:
     ignore-check.kube-linter.io/privileged-container: "This daemon set needs to run DCGM Exporter as privileged to access the GPU metrics."

--- a/dist/install-lowpriv.yaml
+++ b/dist/install-lowpriv.yaml
@@ -833,10 +833,10 @@ metadata:
   name: zxporter-nodemon
   namespace: devzero-system
   labels:
-    helm.sh/chart: zxporter-nodemon-0.1.2
+    helm.sh/chart: zxporter-nodemon-0.1.3
     app.kubernetes.io/name: zxporter-nodemon
     app.kubernetes.io/instance: zxporter-nodemon
-    app.kubernetes.io/version: "0.1.2"
+    app.kubernetes.io/version: "0.1.3"
     app.kubernetes.io/managed-by: Helm
 ---
 # Source: zxporter-nodemon/templates/dcgm-exporter-configmap.yaml
@@ -909,10 +909,10 @@ kind: ClusterRole
 metadata:
   name: zxporter-nodemon
   labels:
-    helm.sh/chart: zxporter-nodemon-0.1.2
+    helm.sh/chart: zxporter-nodemon-0.1.3
     app.kubernetes.io/name: zxporter-nodemon
     app.kubernetes.io/instance: zxporter-nodemon
-    app.kubernetes.io/version: "0.1.2"
+    app.kubernetes.io/version: "0.1.3"
     app.kubernetes.io/managed-by: Helm
 rules:
 - apiGroups:
@@ -959,10 +959,10 @@ kind: ClusterRoleBinding
 metadata:
   name: zxporter-nodemon
   labels:
-    helm.sh/chart: zxporter-nodemon-0.1.2
+    helm.sh/chart: zxporter-nodemon-0.1.3
     app.kubernetes.io/name: zxporter-nodemon
     app.kubernetes.io/instance: zxporter-nodemon
-    app.kubernetes.io/version: "0.1.2"
+    app.kubernetes.io/version: "0.1.3"
     app.kubernetes.io/managed-by: Helm
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -980,10 +980,10 @@ metadata:
   name: zxporter-nodemon
   namespace: devzero-system
   labels:
-    helm.sh/chart: zxporter-nodemon-0.1.2
+    helm.sh/chart: zxporter-nodemon-0.1.3
     app.kubernetes.io/name: zxporter-nodemon
     app.kubernetes.io/instance: zxporter-nodemon
-    app.kubernetes.io/version: "0.1.2"
+    app.kubernetes.io/version: "0.1.3"
     app.kubernetes.io/managed-by: Helm
   annotations:
     ignore-check.kube-linter.io/privileged-container: "This daemon set needs to run DCGM Exporter as privileged to access the GPU metrics."
@@ -1122,10 +1122,10 @@ metadata:
   name: zxporter-nodemon-gpu
   namespace: devzero-system
   labels:
-    helm.sh/chart: zxporter-nodemon-0.1.2
+    helm.sh/chart: zxporter-nodemon-0.1.3
     app.kubernetes.io/name: zxporter-nodemon
     app.kubernetes.io/instance: zxporter-nodemon-gpu
-    app.kubernetes.io/version: "0.1.2"
+    app.kubernetes.io/version: "0.1.3"
     app.kubernetes.io/managed-by: Helm
   annotations:
     ignore-check.kube-linter.io/privileged-container: "This daemon set needs to run DCGM Exporter as privileged to access the GPU metrics."

--- a/dist/install.yaml
+++ b/dist/install.yaml
@@ -833,10 +833,10 @@ metadata:
   name: zxporter-nodemon
   namespace: devzero-system
   labels:
-    helm.sh/chart: zxporter-nodemon-0.1.2
+    helm.sh/chart: zxporter-nodemon-0.1.3
     app.kubernetes.io/name: zxporter-nodemon
     app.kubernetes.io/instance: zxporter-nodemon
-    app.kubernetes.io/version: "0.1.2"
+    app.kubernetes.io/version: "0.1.3"
     app.kubernetes.io/managed-by: Helm
 ---
 # Source: zxporter-nodemon/templates/dcgm-exporter-configmap.yaml
@@ -909,10 +909,10 @@ kind: ClusterRole
 metadata:
   name: zxporter-nodemon
   labels:
-    helm.sh/chart: zxporter-nodemon-0.1.2
+    helm.sh/chart: zxporter-nodemon-0.1.3
     app.kubernetes.io/name: zxporter-nodemon
     app.kubernetes.io/instance: zxporter-nodemon
-    app.kubernetes.io/version: "0.1.2"
+    app.kubernetes.io/version: "0.1.3"
     app.kubernetes.io/managed-by: Helm
 rules:
 - apiGroups:
@@ -960,10 +960,10 @@ kind: ClusterRoleBinding
 metadata:
   name: zxporter-nodemon
   labels:
-    helm.sh/chart: zxporter-nodemon-0.1.2
+    helm.sh/chart: zxporter-nodemon-0.1.3
     app.kubernetes.io/name: zxporter-nodemon
     app.kubernetes.io/instance: zxporter-nodemon
-    app.kubernetes.io/version: "0.1.2"
+    app.kubernetes.io/version: "0.1.3"
     app.kubernetes.io/managed-by: Helm
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -981,10 +981,10 @@ metadata:
   name: zxporter-nodemon
   namespace: devzero-system
   labels:
-    helm.sh/chart: zxporter-nodemon-0.1.2
+    helm.sh/chart: zxporter-nodemon-0.1.3
     app.kubernetes.io/name: zxporter-nodemon
     app.kubernetes.io/instance: zxporter-nodemon
-    app.kubernetes.io/version: "0.1.2"
+    app.kubernetes.io/version: "0.1.3"
     app.kubernetes.io/managed-by: Helm
   annotations:
     ignore-check.kube-linter.io/privileged-container: "This daemon set needs to run DCGM Exporter as privileged to access the GPU metrics."
@@ -1128,10 +1128,10 @@ metadata:
   name: zxporter-nodemon-gpu
   namespace: devzero-system
   labels:
-    helm.sh/chart: zxporter-nodemon-0.1.2
+    helm.sh/chart: zxporter-nodemon-0.1.3
     app.kubernetes.io/name: zxporter-nodemon
     app.kubernetes.io/instance: zxporter-nodemon-gpu
-    app.kubernetes.io/version: "0.1.2"
+    app.kubernetes.io/version: "0.1.3"
     app.kubernetes.io/managed-by: Helm
   annotations:
     ignore-check.kube-linter.io/privileged-container: "This daemon set needs to run DCGM Exporter as privileged to access the GPU metrics."

--- a/dist/installer_updater-gcp-lowpriv.yaml
+++ b/dist/installer_updater-gcp-lowpriv.yaml
@@ -767,10 +767,10 @@ metadata:
   name: zxporter-nodemon
   namespace: '{{.zxporter_namespace}}'
   labels:
-    helm.sh/chart: zxporter-nodemon-0.1.2
+    helm.sh/chart: zxporter-nodemon-0.1.3
     app.kubernetes.io/name: zxporter-nodemon
     app.kubernetes.io/instance: zxporter-nodemon
-    app.kubernetes.io/version: "0.1.2"
+    app.kubernetes.io/version: "0.1.3"
     app.kubernetes.io/managed-by: Helm
 ---
 # Source: zxporter-nodemon/templates/dcgm-exporter-configmap.yaml
@@ -843,10 +843,10 @@ kind: ClusterRole
 metadata:
   name: zxporter-nodemon
   labels:
-    helm.sh/chart: zxporter-nodemon-0.1.2
+    helm.sh/chart: zxporter-nodemon-0.1.3
     app.kubernetes.io/name: zxporter-nodemon
     app.kubernetes.io/instance: zxporter-nodemon
-    app.kubernetes.io/version: "0.1.2"
+    app.kubernetes.io/version: "0.1.3"
     app.kubernetes.io/managed-by: Helm
 rules:
   - apiGroups:
@@ -893,10 +893,10 @@ kind: ClusterRoleBinding
 metadata:
   name: zxporter-nodemon
   labels:
-    helm.sh/chart: zxporter-nodemon-0.1.2
+    helm.sh/chart: zxporter-nodemon-0.1.3
     app.kubernetes.io/name: zxporter-nodemon
     app.kubernetes.io/instance: zxporter-nodemon
-    app.kubernetes.io/version: "0.1.2"
+    app.kubernetes.io/version: "0.1.3"
     app.kubernetes.io/managed-by: Helm
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -914,10 +914,10 @@ metadata:
   name: zxporter-nodemon
   namespace: '{{.zxporter_namespace}}'
   labels:
-    helm.sh/chart: zxporter-nodemon-0.1.2
+    helm.sh/chart: zxporter-nodemon-0.1.3
     app.kubernetes.io/name: zxporter-nodemon
     app.kubernetes.io/instance: zxporter-nodemon
-    app.kubernetes.io/version: "0.1.2"
+    app.kubernetes.io/version: "0.1.3"
     app.kubernetes.io/managed-by: Helm
   annotations:
     ignore-check.kube-linter.io/privileged-container: "This daemon set needs to run DCGM Exporter as privileged to access the GPU metrics."
@@ -1066,10 +1066,10 @@ metadata:
   name: zxporter-nodemon-gpu
   namespace: '{{.zxporter_namespace}}'
   labels:
-    helm.sh/chart: zxporter-nodemon-0.1.2
+    helm.sh/chart: zxporter-nodemon-0.1.3
     app.kubernetes.io/name: zxporter-nodemon
     app.kubernetes.io/instance: zxporter-nodemon-gpu
-    app.kubernetes.io/version: "0.1.2"
+    app.kubernetes.io/version: "0.1.3"
     app.kubernetes.io/managed-by: Helm
   annotations:
     ignore-check.kube-linter.io/privileged-container: "This daemon set needs to run DCGM Exporter as privileged to access the GPU metrics."

--- a/dist/installer_updater-gcp.yaml
+++ b/dist/installer_updater-gcp.yaml
@@ -767,10 +767,10 @@ metadata:
   name: zxporter-nodemon
   namespace: '{{.zxporter_namespace}}'
   labels:
-    helm.sh/chart: zxporter-nodemon-0.1.2
+    helm.sh/chart: zxporter-nodemon-0.1.3
     app.kubernetes.io/name: zxporter-nodemon
     app.kubernetes.io/instance: zxporter-nodemon
-    app.kubernetes.io/version: "0.1.2"
+    app.kubernetes.io/version: "0.1.3"
     app.kubernetes.io/managed-by: Helm
 ---
 # Source: zxporter-nodemon/templates/dcgm-exporter-configmap.yaml
@@ -843,10 +843,10 @@ kind: ClusterRole
 metadata:
   name: zxporter-nodemon
   labels:
-    helm.sh/chart: zxporter-nodemon-0.1.2
+    helm.sh/chart: zxporter-nodemon-0.1.3
     app.kubernetes.io/name: zxporter-nodemon
     app.kubernetes.io/instance: zxporter-nodemon
-    app.kubernetes.io/version: "0.1.2"
+    app.kubernetes.io/version: "0.1.3"
     app.kubernetes.io/managed-by: Helm
 rules:
   - apiGroups:
@@ -894,10 +894,10 @@ kind: ClusterRoleBinding
 metadata:
   name: zxporter-nodemon
   labels:
-    helm.sh/chart: zxporter-nodemon-0.1.2
+    helm.sh/chart: zxporter-nodemon-0.1.3
     app.kubernetes.io/name: zxporter-nodemon
     app.kubernetes.io/instance: zxporter-nodemon
-    app.kubernetes.io/version: "0.1.2"
+    app.kubernetes.io/version: "0.1.3"
     app.kubernetes.io/managed-by: Helm
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -915,10 +915,10 @@ metadata:
   name: zxporter-nodemon
   namespace: '{{.zxporter_namespace}}'
   labels:
-    helm.sh/chart: zxporter-nodemon-0.1.2
+    helm.sh/chart: zxporter-nodemon-0.1.3
     app.kubernetes.io/name: zxporter-nodemon
     app.kubernetes.io/instance: zxporter-nodemon
-    app.kubernetes.io/version: "0.1.2"
+    app.kubernetes.io/version: "0.1.3"
     app.kubernetes.io/managed-by: Helm
   annotations:
     ignore-check.kube-linter.io/privileged-container: "This daemon set needs to run DCGM Exporter as privileged to access the GPU metrics."
@@ -1072,10 +1072,10 @@ metadata:
   name: zxporter-nodemon-gpu
   namespace: '{{.zxporter_namespace}}'
   labels:
-    helm.sh/chart: zxporter-nodemon-0.1.2
+    helm.sh/chart: zxporter-nodemon-0.1.3
     app.kubernetes.io/name: zxporter-nodemon
     app.kubernetes.io/instance: zxporter-nodemon-gpu
-    app.kubernetes.io/version: "0.1.2"
+    app.kubernetes.io/version: "0.1.3"
     app.kubernetes.io/managed-by: Helm
   annotations:
     ignore-check.kube-linter.io/privileged-container: "This daemon set needs to run DCGM Exporter as privileged to access the GPU metrics."

--- a/dist/installer_updater-lowpriv.yaml
+++ b/dist/installer_updater-lowpriv.yaml
@@ -767,10 +767,10 @@ metadata:
   name: zxporter-nodemon
   namespace: '{{.zxporter_namespace}}'
   labels:
-    helm.sh/chart: zxporter-nodemon-0.1.2
+    helm.sh/chart: zxporter-nodemon-0.1.3
     app.kubernetes.io/name: zxporter-nodemon
     app.kubernetes.io/instance: zxporter-nodemon
-    app.kubernetes.io/version: "0.1.2"
+    app.kubernetes.io/version: "0.1.3"
     app.kubernetes.io/managed-by: Helm
 ---
 # Source: zxporter-nodemon/templates/dcgm-exporter-configmap.yaml
@@ -843,10 +843,10 @@ kind: ClusterRole
 metadata:
   name: zxporter-nodemon
   labels:
-    helm.sh/chart: zxporter-nodemon-0.1.2
+    helm.sh/chart: zxporter-nodemon-0.1.3
     app.kubernetes.io/name: zxporter-nodemon
     app.kubernetes.io/instance: zxporter-nodemon
-    app.kubernetes.io/version: "0.1.2"
+    app.kubernetes.io/version: "0.1.3"
     app.kubernetes.io/managed-by: Helm
 rules:
   - apiGroups:
@@ -893,10 +893,10 @@ kind: ClusterRoleBinding
 metadata:
   name: zxporter-nodemon
   labels:
-    helm.sh/chart: zxporter-nodemon-0.1.2
+    helm.sh/chart: zxporter-nodemon-0.1.3
     app.kubernetes.io/name: zxporter-nodemon
     app.kubernetes.io/instance: zxporter-nodemon
-    app.kubernetes.io/version: "0.1.2"
+    app.kubernetes.io/version: "0.1.3"
     app.kubernetes.io/managed-by: Helm
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -914,10 +914,10 @@ metadata:
   name: zxporter-nodemon
   namespace: '{{.zxporter_namespace}}'
   labels:
-    helm.sh/chart: zxporter-nodemon-0.1.2
+    helm.sh/chart: zxporter-nodemon-0.1.3
     app.kubernetes.io/name: zxporter-nodemon
     app.kubernetes.io/instance: zxporter-nodemon
-    app.kubernetes.io/version: "0.1.2"
+    app.kubernetes.io/version: "0.1.3"
     app.kubernetes.io/managed-by: Helm
   annotations:
     ignore-check.kube-linter.io/privileged-container: "This daemon set needs to run DCGM Exporter as privileged to access the GPU metrics."
@@ -1056,10 +1056,10 @@ metadata:
   name: zxporter-nodemon-gpu
   namespace: '{{.zxporter_namespace}}'
   labels:
-    helm.sh/chart: zxporter-nodemon-0.1.2
+    helm.sh/chart: zxporter-nodemon-0.1.3
     app.kubernetes.io/name: zxporter-nodemon
     app.kubernetes.io/instance: zxporter-nodemon-gpu
-    app.kubernetes.io/version: "0.1.2"
+    app.kubernetes.io/version: "0.1.3"
     app.kubernetes.io/managed-by: Helm
   annotations:
     ignore-check.kube-linter.io/privileged-container: "This daemon set needs to run DCGM Exporter as privileged to access the GPU metrics."

--- a/dist/installer_updater.yaml
+++ b/dist/installer_updater.yaml
@@ -767,10 +767,10 @@ metadata:
   name: zxporter-nodemon
   namespace: '{{.zxporter_namespace}}'
   labels:
-    helm.sh/chart: zxporter-nodemon-0.1.2
+    helm.sh/chart: zxporter-nodemon-0.1.3
     app.kubernetes.io/name: zxporter-nodemon
     app.kubernetes.io/instance: zxporter-nodemon
-    app.kubernetes.io/version: "0.1.2"
+    app.kubernetes.io/version: "0.1.3"
     app.kubernetes.io/managed-by: Helm
 ---
 # Source: zxporter-nodemon/templates/dcgm-exporter-configmap.yaml
@@ -843,10 +843,10 @@ kind: ClusterRole
 metadata:
   name: zxporter-nodemon
   labels:
-    helm.sh/chart: zxporter-nodemon-0.1.2
+    helm.sh/chart: zxporter-nodemon-0.1.3
     app.kubernetes.io/name: zxporter-nodemon
     app.kubernetes.io/instance: zxporter-nodemon
-    app.kubernetes.io/version: "0.1.2"
+    app.kubernetes.io/version: "0.1.3"
     app.kubernetes.io/managed-by: Helm
 rules:
   - apiGroups:
@@ -894,10 +894,10 @@ kind: ClusterRoleBinding
 metadata:
   name: zxporter-nodemon
   labels:
-    helm.sh/chart: zxporter-nodemon-0.1.2
+    helm.sh/chart: zxporter-nodemon-0.1.3
     app.kubernetes.io/name: zxporter-nodemon
     app.kubernetes.io/instance: zxporter-nodemon
-    app.kubernetes.io/version: "0.1.2"
+    app.kubernetes.io/version: "0.1.3"
     app.kubernetes.io/managed-by: Helm
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -915,10 +915,10 @@ metadata:
   name: zxporter-nodemon
   namespace: '{{.zxporter_namespace}}'
   labels:
-    helm.sh/chart: zxporter-nodemon-0.1.2
+    helm.sh/chart: zxporter-nodemon-0.1.3
     app.kubernetes.io/name: zxporter-nodemon
     app.kubernetes.io/instance: zxporter-nodemon
-    app.kubernetes.io/version: "0.1.2"
+    app.kubernetes.io/version: "0.1.3"
     app.kubernetes.io/managed-by: Helm
   annotations:
     ignore-check.kube-linter.io/privileged-container: "This daemon set needs to run DCGM Exporter as privileged to access the GPU metrics."
@@ -1062,10 +1062,10 @@ metadata:
   name: zxporter-nodemon-gpu
   namespace: '{{.zxporter_namespace}}'
   labels:
-    helm.sh/chart: zxporter-nodemon-0.1.2
+    helm.sh/chart: zxporter-nodemon-0.1.3
     app.kubernetes.io/name: zxporter-nodemon
     app.kubernetes.io/instance: zxporter-nodemon-gpu
-    app.kubernetes.io/version: "0.1.2"
+    app.kubernetes.io/version: "0.1.3"
     app.kubernetes.io/managed-by: Helm
   annotations:
     ignore-check.kube-linter.io/privileged-container: "This daemon set needs to run DCGM Exporter as privileged to access the GPU metrics."

--- a/dist/nodemon-gcp-lowpriv.yaml
+++ b/dist/nodemon-gcp-lowpriv.yaml
@@ -6,10 +6,10 @@ metadata:
   name: zxporter-nodemon
   namespace: devzero-system
   labels:
-    helm.sh/chart: zxporter-nodemon-0.1.2
+    helm.sh/chart: zxporter-nodemon-0.1.3
     app.kubernetes.io/name: zxporter-nodemon
     app.kubernetes.io/instance: zxporter-nodemon
-    app.kubernetes.io/version: "0.1.2"
+    app.kubernetes.io/version: "0.1.3"
     app.kubernetes.io/managed-by: Helm
 ---
 # Source: zxporter-nodemon/templates/dcgm-exporter-configmap.yaml
@@ -82,10 +82,10 @@ kind: ClusterRole
 metadata:
   name: zxporter-nodemon
   labels:
-    helm.sh/chart: zxporter-nodemon-0.1.2
+    helm.sh/chart: zxporter-nodemon-0.1.3
     app.kubernetes.io/name: zxporter-nodemon
     app.kubernetes.io/instance: zxporter-nodemon
-    app.kubernetes.io/version: "0.1.2"
+    app.kubernetes.io/version: "0.1.3"
     app.kubernetes.io/managed-by: Helm
 rules:
 - apiGroups:
@@ -132,10 +132,10 @@ kind: ClusterRoleBinding
 metadata:
   name: zxporter-nodemon
   labels:
-    helm.sh/chart: zxporter-nodemon-0.1.2
+    helm.sh/chart: zxporter-nodemon-0.1.3
     app.kubernetes.io/name: zxporter-nodemon
     app.kubernetes.io/instance: zxporter-nodemon
-    app.kubernetes.io/version: "0.1.2"
+    app.kubernetes.io/version: "0.1.3"
     app.kubernetes.io/managed-by: Helm
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -153,10 +153,10 @@ metadata:
   name: zxporter-nodemon
   namespace: devzero-system
   labels:
-    helm.sh/chart: zxporter-nodemon-0.1.2
+    helm.sh/chart: zxporter-nodemon-0.1.3
     app.kubernetes.io/name: zxporter-nodemon
     app.kubernetes.io/instance: zxporter-nodemon
-    app.kubernetes.io/version: "0.1.2"
+    app.kubernetes.io/version: "0.1.3"
     app.kubernetes.io/managed-by: Helm
   annotations:
     ignore-check.kube-linter.io/privileged-container: "This daemon set needs to run DCGM Exporter as privileged to access the GPU metrics."
@@ -305,10 +305,10 @@ metadata:
   name: zxporter-nodemon-gpu
   namespace: devzero-system
   labels:
-    helm.sh/chart: zxporter-nodemon-0.1.2
+    helm.sh/chart: zxporter-nodemon-0.1.3
     app.kubernetes.io/name: zxporter-nodemon
     app.kubernetes.io/instance: zxporter-nodemon-gpu
-    app.kubernetes.io/version: "0.1.2"
+    app.kubernetes.io/version: "0.1.3"
     app.kubernetes.io/managed-by: Helm
   annotations:
     ignore-check.kube-linter.io/privileged-container: "This daemon set needs to run DCGM Exporter as privileged to access the GPU metrics."

--- a/dist/nodemon-gcp.yaml
+++ b/dist/nodemon-gcp.yaml
@@ -6,10 +6,10 @@ metadata:
   name: zxporter-nodemon
   namespace: devzero-system
   labels:
-    helm.sh/chart: zxporter-nodemon-0.1.2
+    helm.sh/chart: zxporter-nodemon-0.1.3
     app.kubernetes.io/name: zxporter-nodemon
     app.kubernetes.io/instance: zxporter-nodemon
-    app.kubernetes.io/version: "0.1.2"
+    app.kubernetes.io/version: "0.1.3"
     app.kubernetes.io/managed-by: Helm
 ---
 # Source: zxporter-nodemon/templates/dcgm-exporter-configmap.yaml
@@ -82,10 +82,10 @@ kind: ClusterRole
 metadata:
   name: zxporter-nodemon
   labels:
-    helm.sh/chart: zxporter-nodemon-0.1.2
+    helm.sh/chart: zxporter-nodemon-0.1.3
     app.kubernetes.io/name: zxporter-nodemon
     app.kubernetes.io/instance: zxporter-nodemon
-    app.kubernetes.io/version: "0.1.2"
+    app.kubernetes.io/version: "0.1.3"
     app.kubernetes.io/managed-by: Helm
 rules:
 - apiGroups:
@@ -133,10 +133,10 @@ kind: ClusterRoleBinding
 metadata:
   name: zxporter-nodemon
   labels:
-    helm.sh/chart: zxporter-nodemon-0.1.2
+    helm.sh/chart: zxporter-nodemon-0.1.3
     app.kubernetes.io/name: zxporter-nodemon
     app.kubernetes.io/instance: zxporter-nodemon
-    app.kubernetes.io/version: "0.1.2"
+    app.kubernetes.io/version: "0.1.3"
     app.kubernetes.io/managed-by: Helm
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -154,10 +154,10 @@ metadata:
   name: zxporter-nodemon
   namespace: devzero-system
   labels:
-    helm.sh/chart: zxporter-nodemon-0.1.2
+    helm.sh/chart: zxporter-nodemon-0.1.3
     app.kubernetes.io/name: zxporter-nodemon
     app.kubernetes.io/instance: zxporter-nodemon
-    app.kubernetes.io/version: "0.1.2"
+    app.kubernetes.io/version: "0.1.3"
     app.kubernetes.io/managed-by: Helm
   annotations:
     ignore-check.kube-linter.io/privileged-container: "This daemon set needs to run DCGM Exporter as privileged to access the GPU metrics."
@@ -311,10 +311,10 @@ metadata:
   name: zxporter-nodemon-gpu
   namespace: devzero-system
   labels:
-    helm.sh/chart: zxporter-nodemon-0.1.2
+    helm.sh/chart: zxporter-nodemon-0.1.3
     app.kubernetes.io/name: zxporter-nodemon
     app.kubernetes.io/instance: zxporter-nodemon-gpu
-    app.kubernetes.io/version: "0.1.2"
+    app.kubernetes.io/version: "0.1.3"
     app.kubernetes.io/managed-by: Helm
   annotations:
     ignore-check.kube-linter.io/privileged-container: "This daemon set needs to run DCGM Exporter as privileged to access the GPU metrics."

--- a/dist/nodemon-lowpriv.yaml
+++ b/dist/nodemon-lowpriv.yaml
@@ -6,10 +6,10 @@ metadata:
   name: zxporter-nodemon
   namespace: devzero-system
   labels:
-    helm.sh/chart: zxporter-nodemon-0.1.2
+    helm.sh/chart: zxporter-nodemon-0.1.3
     app.kubernetes.io/name: zxporter-nodemon
     app.kubernetes.io/instance: zxporter-nodemon
-    app.kubernetes.io/version: "0.1.2"
+    app.kubernetes.io/version: "0.1.3"
     app.kubernetes.io/managed-by: Helm
 ---
 # Source: zxporter-nodemon/templates/dcgm-exporter-configmap.yaml
@@ -82,10 +82,10 @@ kind: ClusterRole
 metadata:
   name: zxporter-nodemon
   labels:
-    helm.sh/chart: zxporter-nodemon-0.1.2
+    helm.sh/chart: zxporter-nodemon-0.1.3
     app.kubernetes.io/name: zxporter-nodemon
     app.kubernetes.io/instance: zxporter-nodemon
-    app.kubernetes.io/version: "0.1.2"
+    app.kubernetes.io/version: "0.1.3"
     app.kubernetes.io/managed-by: Helm
 rules:
 - apiGroups:
@@ -132,10 +132,10 @@ kind: ClusterRoleBinding
 metadata:
   name: zxporter-nodemon
   labels:
-    helm.sh/chart: zxporter-nodemon-0.1.2
+    helm.sh/chart: zxporter-nodemon-0.1.3
     app.kubernetes.io/name: zxporter-nodemon
     app.kubernetes.io/instance: zxporter-nodemon
-    app.kubernetes.io/version: "0.1.2"
+    app.kubernetes.io/version: "0.1.3"
     app.kubernetes.io/managed-by: Helm
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -153,10 +153,10 @@ metadata:
   name: zxporter-nodemon
   namespace: devzero-system
   labels:
-    helm.sh/chart: zxporter-nodemon-0.1.2
+    helm.sh/chart: zxporter-nodemon-0.1.3
     app.kubernetes.io/name: zxporter-nodemon
     app.kubernetes.io/instance: zxporter-nodemon
-    app.kubernetes.io/version: "0.1.2"
+    app.kubernetes.io/version: "0.1.3"
     app.kubernetes.io/managed-by: Helm
   annotations:
     ignore-check.kube-linter.io/privileged-container: "This daemon set needs to run DCGM Exporter as privileged to access the GPU metrics."
@@ -295,10 +295,10 @@ metadata:
   name: zxporter-nodemon-gpu
   namespace: devzero-system
   labels:
-    helm.sh/chart: zxporter-nodemon-0.1.2
+    helm.sh/chart: zxporter-nodemon-0.1.3
     app.kubernetes.io/name: zxporter-nodemon
     app.kubernetes.io/instance: zxporter-nodemon-gpu
-    app.kubernetes.io/version: "0.1.2"
+    app.kubernetes.io/version: "0.1.3"
     app.kubernetes.io/managed-by: Helm
   annotations:
     ignore-check.kube-linter.io/privileged-container: "This daemon set needs to run DCGM Exporter as privileged to access the GPU metrics."

--- a/dist/nodemon.yaml
+++ b/dist/nodemon.yaml
@@ -6,10 +6,10 @@ metadata:
   name: zxporter-nodemon
   namespace: devzero-system
   labels:
-    helm.sh/chart: zxporter-nodemon-0.1.2
+    helm.sh/chart: zxporter-nodemon-0.1.3
     app.kubernetes.io/name: zxporter-nodemon
     app.kubernetes.io/instance: zxporter-nodemon
-    app.kubernetes.io/version: "0.1.2"
+    app.kubernetes.io/version: "0.1.3"
     app.kubernetes.io/managed-by: Helm
 ---
 # Source: zxporter-nodemon/templates/dcgm-exporter-configmap.yaml
@@ -82,10 +82,10 @@ kind: ClusterRole
 metadata:
   name: zxporter-nodemon
   labels:
-    helm.sh/chart: zxporter-nodemon-0.1.2
+    helm.sh/chart: zxporter-nodemon-0.1.3
     app.kubernetes.io/name: zxporter-nodemon
     app.kubernetes.io/instance: zxporter-nodemon
-    app.kubernetes.io/version: "0.1.2"
+    app.kubernetes.io/version: "0.1.3"
     app.kubernetes.io/managed-by: Helm
 rules:
 - apiGroups:
@@ -133,10 +133,10 @@ kind: ClusterRoleBinding
 metadata:
   name: zxporter-nodemon
   labels:
-    helm.sh/chart: zxporter-nodemon-0.1.2
+    helm.sh/chart: zxporter-nodemon-0.1.3
     app.kubernetes.io/name: zxporter-nodemon
     app.kubernetes.io/instance: zxporter-nodemon
-    app.kubernetes.io/version: "0.1.2"
+    app.kubernetes.io/version: "0.1.3"
     app.kubernetes.io/managed-by: Helm
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -154,10 +154,10 @@ metadata:
   name: zxporter-nodemon
   namespace: devzero-system
   labels:
-    helm.sh/chart: zxporter-nodemon-0.1.2
+    helm.sh/chart: zxporter-nodemon-0.1.3
     app.kubernetes.io/name: zxporter-nodemon
     app.kubernetes.io/instance: zxporter-nodemon
-    app.kubernetes.io/version: "0.1.2"
+    app.kubernetes.io/version: "0.1.3"
     app.kubernetes.io/managed-by: Helm
   annotations:
     ignore-check.kube-linter.io/privileged-container: "This daemon set needs to run DCGM Exporter as privileged to access the GPU metrics."
@@ -301,10 +301,10 @@ metadata:
   name: zxporter-nodemon-gpu
   namespace: devzero-system
   labels:
-    helm.sh/chart: zxporter-nodemon-0.1.2
+    helm.sh/chart: zxporter-nodemon-0.1.3
     app.kubernetes.io/name: zxporter-nodemon
     app.kubernetes.io/instance: zxporter-nodemon-gpu
-    app.kubernetes.io/version: "0.1.2"
+    app.kubernetes.io/version: "0.1.3"
     app.kubernetes.io/managed-by: Helm
   annotations:
     ignore-check.kube-linter.io/privileged-container: "This daemon set needs to run DCGM Exporter as privileged to access the GPU metrics."

--- a/helm-chart/zxporter-netmon/Chart.yaml
+++ b/helm-chart/zxporter-netmon/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: zxporter-netmon
 description: A Helm chart for zxporter network monitor daemonset
 type: application
-version: 0.1.2
-appVersion: "0.1.2"
+version: 0.1.3
+appVersion: "0.1.3"

--- a/helm-chart/zxporter-netmon/values.yaml
+++ b/helm-chart/zxporter-netmon/values.yaml
@@ -2,7 +2,7 @@ image:
   repository: devzeroinc/zxporter-netmon
   pullPolicy: IfNotPresent
   # Overrides the image tag whose default is the chart appVersion.
-  tag: "v0.1.2"
+  tag: "v0.1.3"
 imagePullSecrets: []
 nameOverride: ""
 fullnameOverride: ""

--- a/helm-chart/zxporter-nodemon/Chart.yaml
+++ b/helm-chart/zxporter-nodemon/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: zxporter-nodemon
 description: A Helm chart for Kubernetes
 type: application
-version: 0.1.2
-appVersion: "0.1.2"
+version: 0.1.3
+appVersion: "0.1.3"

--- a/helm-chart/zxporter-nodemon/values.yaml
+++ b/helm-chart/zxporter-nodemon/values.yaml
@@ -13,7 +13,7 @@ serviceAccount:
 image:
   repository: public.ecr.aws/devzeroinc/zxporter-nodemon
   pullPolicy: IfNotPresent
-  tag: "v0.1.2"
+  tag: "v0.1.3"
 nodemon:
   # nodemon.affinity -- optional pod affinity/anti-affinity. Leave empty so nodemon schedules on
   # EVERY node (it is the sole source of node/container metrics). Only set this if you intentionally

--- a/helm-chart/zxporter/Chart.lock
+++ b/helm-chart/zxporter/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: zxporter-nodemon
   repository: file://../zxporter-nodemon
-  version: 0.1.2
-digest: sha256:ea58897ec98cf7363220ccd698bd24b7dfa92f569c8ea0f6a2227397c2944700
-generated: "2026-07-30T03:37:04.025475-03:00"
+  version: 0.1.3
+digest: sha256:2e7326aa79b1b30b540cb2fb879120eef905055e1fe5d40102290fac321ae84b
+generated: "2026-07-30T13:09:10.843554231Z"

--- a/helm-chart/zxporter/Chart.yaml
+++ b/helm-chart/zxporter/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v2
 name: zxporter
 description: A Helm chart for DevZero ZXPorter - Kubernetes resource monitoring and optimization
-version: 0.1.2
-appVersion: "0.1.2"
+version: 0.1.3
+appVersion: "0.1.3"
 home: https://github.com/devzero-inc/zxporter
 sources:
   - https://github.com/devzero-inc/zxporter
@@ -17,5 +17,5 @@ keywords:
   - devzero
 dependencies:
   - name: zxporter-nodemon
-    version: "0.1.2"
+    version: "0.1.3"
     repository: "file://../zxporter-nodemon"

--- a/helm-chart/zxporter/values.yaml
+++ b/helm-chart/zxporter/values.yaml
@@ -11,7 +11,7 @@
 image:
   repository: public.ecr.aws/devzeroinc/zxporter
   pullPolicy: IfNotPresent
-  tag: "v0.1.2"
+  tag: "v0.1.3"
 # ZXPorter configuration
 zxporter:
   dakrUrl: "https://dakr.devzero.io"

--- a/internal/collector/container_resource_collector.go
+++ b/internal/collector/container_resource_collector.go
@@ -350,6 +350,17 @@ func (c *ContainerResourceCollector) collectAllContainerResources(ctx context.Co
 		}
 	}
 
+	// Pods nodemon reported metrics for but that aren't in podByKey. This is
+	// an expected race, not a failure: nodemon's /v2/container/metrics cache
+	// refreshes on a fixed 30s ticker (cmd/zxporter-nodemon/main.go) while
+	// this collector polls every 10s by default and snapshots the pod
+	// informer -- a near-instant k8s watch -- fresh each cycle. A pod that
+	// terminates disappears from podByKey almost immediately but can remain
+	// in nodemon's stale response for up to ~30s. On a churny cluster this
+	// happens routinely, so it's aggregated into one summary below instead
+	// of one ERROR telemetry event per pod (see #9431).
+	var missingPods []string
+
 	// Process each pod's metrics
 	for _, podMetrics := range podMetricsList.Items {
 		// Skip excluded pods
@@ -361,24 +372,7 @@ func (c *ContainerResourceCollector) collectAllContainerResources(ctx context.Co
 		// (see podByKey above) rather than re-reading the informer cache here.
 		pod, exists := podByKey[podMetrics.Namespace+"/"+podMetrics.Name]
 		if !exists {
-			c.logger.Info("Pod not found in informer cache",
-				"namespace", podMetrics.Namespace,
-				"name", podMetrics.Name)
-			if c.telemetryLogger != nil {
-				c.telemetryLogger.Report(
-					gen.LogLevel_LOG_LEVEL_ERROR,
-					"ContainerResourceCollector",
-					"Pod not found in informer cache",
-					fmt.Errorf("pod not found in informer cache"),
-					map[string]string{
-						"collector_type":   c.GetType(),
-						"pod_namespace":    podMetrics.Namespace,
-						"pod_name":         podMetrics.Name,
-						"error_type":       "pod_cache_fail",
-						"zxporter_version": version.Get().String(),
-					},
-				)
-			}
+			missingPods = append(missingPods, podMetrics.Namespace+"/"+podMetrics.Name)
 			continue
 		}
 
@@ -498,6 +492,39 @@ func (c *ContainerResourceCollector) collectAllContainerResources(ctx context.Co
 			)
 		}
 
+	}
+
+	// Surface the informer/nodemon cache race as one summary per cycle
+	// rather than one ERROR per pod (see #9431).
+	if len(missingPods) > 0 {
+		c.logger.Info("Pods reported by nodemon but not found in informer cache",
+			"count", len(missingPods), "pods", missingPods)
+		if c.telemetryLogger != nil {
+			// Cap the sample list: on a churny cluster missingPods can grow
+			// large, and the exact same volume this fix targets would
+			// otherwise bloat this one field instead of spamming many.
+			// missing_count always carries the true total.
+			const maxMissingPodsSample = 20
+			sample := missingPods
+			suffix := ""
+			if len(sample) > maxMissingPodsSample {
+				suffix = fmt.Sprintf(" (+%d more)", len(sample)-maxMissingPodsSample)
+				sample = sample[:maxMissingPodsSample]
+			}
+			c.telemetryLogger.Report(
+				gen.LogLevel_LOG_LEVEL_WARN,
+				"ContainerResourceCollector",
+				"Pods reported by nodemon but not found in informer cache",
+				nil,
+				map[string]string{
+					"collector_type":   c.GetType(),
+					"missing_count":    fmt.Sprintf("%d", len(missingPods)),
+					"missing_pods":     fmt.Sprintf("%v", sample) + suffix,
+					"event_type":       "pod_cache_miss_summary",
+					"zxporter_version": version.Get().String(),
+				},
+			)
+		}
 	}
 }
 

--- a/internal/collector/container_resource_collector_test.go
+++ b/internal/collector/container_resource_collector_test.go
@@ -4,10 +4,12 @@ package collector
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
 	"strconv"
+	"strings"
 	"testing"
 	"time"
 
@@ -20,6 +22,8 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	k8sfake "k8s.io/client-go/kubernetes/fake"
 	"k8s.io/client-go/tools/cache"
+
+	gen "github.com/devzero-inc/zxporter/gen/api/v1"
 )
 
 // testPod builds a minimal pod, scheduled onto nodeName, with a single
@@ -155,4 +159,204 @@ func TestCollectAllContainerResources_SurvivesPodDeletedDuringNodemonFetch(t *te
 
 	require.Empty(t, fakeLogger.reportsWithErrorType("pod_cache_fail"),
 		"collector should not report a cache miss when the pod was captured before the race window")
+}
+
+// TestCollectAllContainerResources_MissingPodsAggregatedNotSpammed is a
+// characterization test for
+// https://github.com/devzero-inc/services/issues/9431: nodemon's
+// /v2/container/metrics cache refreshes on a fixed 30s ticker
+// (cmd/zxporter-nodemon/main.go), while ContainerResourceCollector polls
+// every 10s by default and snapshots the pod informer (a near-instant k8s
+// watch) fresh each cycle. A pod that terminates is gone from the
+// informer snapshot almost immediately but can remain in nodemon's stale
+// response for up to ~30s — an expected race on any sufficiently churny
+// cluster, not a failure. Today, every such pod is reported as its own
+// LOG_LEVEL_ERROR telemetry event ("pod_cache_fail"); on production
+// clusters this produced hundreds of ERROR events per hour (see #9431).
+// This test simulates 5 such "phantom" pods (reported by nodemon, absent
+// from the informer) alongside 1 real pod, and asserts the collector
+// reports one aggregated WARN summary for the cycle instead of one ERROR
+// per phantom pod.
+func TestCollectAllContainerResources_MissingPodsAggregatedNotSpammed(t *testing.T) {
+	realPod := testPod("ns1", "real-pod", "node-a", "app")
+	informer, stopCh := newSyncedPodInformer(t, realPod)
+	defer close(stopCh)
+
+	const numPhantomPods = 5
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/v2/container/metrics" {
+			metrics := []UnifiedContainerMetric{
+				{
+					NodeName:          "node-a",
+					Namespace:         realPod.Namespace,
+					Pod:               realPod.Name,
+					Container:         "app",
+					Timestamp:         time.Now(),
+					CPUUsageNanoCores: 250_000_000,
+					MemoryWorkingSet:  512 * 1024 * 1024,
+				},
+			}
+			for i := range numPhantomPods {
+				metrics = append(metrics, UnifiedContainerMetric{
+					NodeName:          "node-a",
+					Namespace:         "ns1",
+					Pod:               fmt.Sprintf("phantom-pod-%d", i),
+					Container:         "app",
+					Timestamp:         time.Now(),
+					CPUUsageNanoCores: 100_000_000,
+					MemoryWorkingSet:  256 * 1024 * 1024,
+				})
+			}
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(metrics)
+			return
+		}
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	defer server.Close()
+
+	parsed, err := url.Parse(server.URL)
+	require.NoError(t, err)
+	port, err := strconv.Atoi(parsed.Port())
+	require.NoError(t, err)
+
+	nmClient := &NodemonClient{
+		port:          port,
+		httpClient:    server.Client(),
+		log:           logr.Discard(),
+		nodeToIP:      map[string]string{"node-a": parsed.Hostname()},
+		lastRefreshed: time.Now(),
+	}
+
+	fakeLogger := &fakeTelemetryLogger{}
+
+	c := &ContainerResourceCollector{
+		nodemonClient:    nmClient,
+		kubeletClient:    NewKubeletSummaryClient(k8sfake.NewSimpleClientset(), logr.Discard(), 0),
+		podInformer:      informer,
+		batchChan:        make(chan CollectedResource, 10),
+		config:           ContainerResourceCollectorConfig{DisableGPUMetrics: true},
+		excludedPods:     map[types.NamespacedName]bool{},
+		logger:           logr.Discard(),
+		telemetryLogger:  fakeLogger,
+		throttle:         throttleTracker{lastEmitted: make(map[string]time.Time)},
+		networkByteRates: nodemon.NewRateCalculator(),
+	}
+
+	c.collectAllContainerResources(context.Background())
+
+	select {
+	case resource := <-c.batchChan:
+		require.Equal(t, "ns1/real-pod/app", resource.Key,
+			"the real pod's container should still be emitted regardless of the phantom pods")
+	case <-time.After(time.Second):
+		t.Fatal("expected the real pod's container resource to be emitted")
+	}
+
+	require.Empty(t, fakeLogger.reportsWithErrorType("pod_cache_fail"),
+		"expected no per-pod ERROR reports — phantom pods from a stale nodemon cache are an "+
+			"expected race, not individual failures (see #9431)")
+
+	summaries := fakeLogger.reportsWithEventType("pod_cache_miss_summary")
+	require.Lenf(t, summaries, 1,
+		"expected exactly one aggregated summary report for the cycle, got %d", len(summaries))
+	require.Equal(t, gen.LogLevel_LOG_LEVEL_WARN, summaries[0].level)
+	require.Equal(t, fmt.Sprintf("%d", numPhantomPods), summaries[0].fields["missing_count"])
+}
+
+// TestCollectAllContainerResources_MissingPodsSummaryCapsSampleList guards
+// against a gitar-bot review finding on #9432: on a very churny cluster the
+// missing_pods field, which serializes the full phantom-pod list into one
+// telemetry field, could grow unbounded — the exact high-volume scenario
+// the aggregation fix targets in the first place. missing_count must always
+// carry the true total even when the sample list is capped.
+func TestCollectAllContainerResources_MissingPodsSummaryCapsSampleList(t *testing.T) {
+	realPod := testPod("ns1", "real-pod", "node-a", "app")
+	informer, stopCh := newSyncedPodInformer(t, realPod)
+	defer close(stopCh)
+
+	const numPhantomPods = 30 // > the 20-entry sample cap
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/v2/container/metrics" {
+			metrics := []UnifiedContainerMetric{
+				{
+					NodeName:          "node-a",
+					Namespace:         realPod.Namespace,
+					Pod:               realPod.Name,
+					Container:         "app",
+					Timestamp:         time.Now(),
+					CPUUsageNanoCores: 250_000_000,
+					MemoryWorkingSet:  512 * 1024 * 1024,
+				},
+			}
+			for i := range numPhantomPods {
+				metrics = append(metrics, UnifiedContainerMetric{
+					NodeName:          "node-a",
+					Namespace:         "ns1",
+					Pod:               fmt.Sprintf("phantom-pod-%d", i),
+					Container:         "app",
+					Timestamp:         time.Now(),
+					CPUUsageNanoCores: 100_000_000,
+					MemoryWorkingSet:  256 * 1024 * 1024,
+				})
+			}
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(metrics)
+			return
+		}
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	defer server.Close()
+
+	parsed, err := url.Parse(server.URL)
+	require.NoError(t, err)
+	port, err := strconv.Atoi(parsed.Port())
+	require.NoError(t, err)
+
+	nmClient := &NodemonClient{
+		port:          port,
+		httpClient:    server.Client(),
+		log:           logr.Discard(),
+		nodeToIP:      map[string]string{"node-a": parsed.Hostname()},
+		lastRefreshed: time.Now(),
+	}
+
+	fakeLogger := &fakeTelemetryLogger{}
+
+	c := &ContainerResourceCollector{
+		nodemonClient:    nmClient,
+		kubeletClient:    NewKubeletSummaryClient(k8sfake.NewSimpleClientset(), logr.Discard(), 0),
+		podInformer:      informer,
+		batchChan:        make(chan CollectedResource, 10),
+		config:           ContainerResourceCollectorConfig{DisableGPUMetrics: true},
+		excludedPods:     map[types.NamespacedName]bool{},
+		logger:           logr.Discard(),
+		telemetryLogger:  fakeLogger,
+		throttle:         throttleTracker{lastEmitted: make(map[string]time.Time)},
+		networkByteRates: nodemon.NewRateCalculator(),
+	}
+
+	c.collectAllContainerResources(context.Background())
+
+	select {
+	case <-c.batchChan:
+	case <-time.After(time.Second):
+		t.Fatal("expected the real pod's container resource to be emitted")
+	}
+
+	summaries := fakeLogger.reportsWithEventType("pod_cache_miss_summary")
+	require.Len(t, summaries, 1)
+	require.Equal(t, fmt.Sprintf("%d", numPhantomPods), summaries[0].fields["missing_count"],
+		"missing_count must carry the true total even when the sample list is capped")
+
+	sampleField := summaries[0].fields["missing_pods"]
+	require.Contains(t, sampleField, "(+10 more)",
+		"expected the sample list to be capped with a remainder suffix, got: %s", sampleField)
+	// podMetricsList.Items iterates a map internally, so which specific
+	// pods land in the truncated sample isn't deterministic — assert the
+	// sample size is capped rather than which names survive.
+	require.Equal(t, 20, strings.Count(sampleField, "ns1/phantom-pod-"),
+		"expected exactly 20 sampled pod names, got: %s", sampleField)
 }

--- a/internal/collector/node_collector_test.go
+++ b/internal/collector/node_collector_test.go
@@ -60,6 +60,18 @@ func (f *fakeTelemetryLogger) reportsWithErrorType(errorType string) []fakeRepor
 	return out
 }
 
+func (f *fakeTelemetryLogger) reportsWithEventType(eventType string) []fakeReport {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	var out []fakeReport
+	for _, r := range f.reports {
+		if r.fields["event_type"] == eventType {
+			out = append(out, r)
+		}
+	}
+	return out
+}
+
 // newSyncedNodeInformer builds a real SharedIndexInformer for Nodes, backed by
 // a fake clientset seeded with the given nodes, and waits for the initial
 // cache sync so the indexer is populated before the test runs.

--- a/internal/collector/pvc_metrics_collector.go
+++ b/internal/collector/pvc_metrics_collector.go
@@ -268,6 +268,17 @@ func (c *PersistentVolumeClaimMetricsCollector) collectAllPVCMetrics(ctx context
 		"pvc_total", len(pvcs),
 		"namespaces", c.namespaces)
 
+	// Fetch cluster-wide PVC metrics from nodemon once for the whole sweep
+	// (a full fan-out HTTP call to every nodemon pod) and index by
+	// (namespace, pvcName) for O(1) lookup below. Previously this was
+	// fetched fresh inside getFilesystemUsage on every single PVC below,
+	// multiplying nodemon request volume by the PVC count — see #9429.
+	allPVCMetrics, pvcMetricsErr := c.nodemonClient.FetchAllPVCMetrics(ctx)
+	if pvcMetricsErr != nil {
+		c.logger.Error(pvcMetricsErr, "Failed to fetch PVC metrics from nodemon; all PVCs in this cycle will report unavailable stats")
+	}
+	pvcMetricsIndex := indexPVCMetricsByNamespacedName(allPVCMetrics)
+
 	// Track collection stats
 	processedCount := 0
 	skippedCount := 0
@@ -293,7 +304,7 @@ func (c *PersistentVolumeClaimMetricsCollector) collectAllPVCMetrics(ctx context
 		}
 
 		// Process the PVC metrics
-		snapshot, err := c.processPVCMetrics(ctx, pvc)
+		snapshot, err := c.processPVCMetrics(pvc, pvcMetricsIndex, pvcMetricsErr)
 		if err != nil {
 			errorCount++
 			c.logger.Error(err, "Failed to process PVC metrics (continuing with next PVC)",
@@ -342,11 +353,15 @@ func (c *PersistentVolumeClaimMetricsCollector) collectAllPVCMetrics(ctx context
 	}
 }
 
-// processPVCMetrics processes metrics for a single PVC
+// processPVCMetrics processes metrics for a single PVC, looking its usage up
+// in pvcMetricsIndex (the whole sweep's single FetchAllPVCMetrics result,
+// fetched once by the caller) rather than fetching from nodemon itself.
+// fetchErr is the error (if any) from that shared fetch.
 // Returns the snapshot and an error if metrics collection fails
 func (c *PersistentVolumeClaimMetricsCollector) processPVCMetrics(
-	ctx context.Context,
 	pvc *corev1.PersistentVolumeClaim,
+	pvcMetricsIndex map[types.NamespacedName]UnifiedPVCMetric,
+	fetchErr error,
 ) (*PersistentVolumeClaimMetricsSnapshot, error) {
 	c.logger.V(1).Info("Processing PVC metrics",
 		"namespace", pvc.Namespace,
@@ -398,7 +413,7 @@ func (c *PersistentVolumeClaimMetricsCollector) processPVCMetrics(
 		return metricsSnapshot, nil
 	}
 
-	usage, err := c.getFilesystemUsage(ctx, pvc)
+	usage, err := c.getFilesystemUsage(pvc, pvcMetricsIndex, fetchErr)
 	if err != nil {
 		c.logger.V(1).Info("Failed to get filesystem usage from nodemon",
 			"namespace", pvc.Namespace,
@@ -455,27 +470,47 @@ type filesystemUsage struct {
 	AvailableBytes int64
 }
 
-// getFilesystemUsage retrieves PVC filesystem usage from the nodemon DaemonSet.
+// getFilesystemUsage looks up a PVC's filesystem usage in pvcMetricsIndex,
+// the whole sweep's single FetchAllPVCMetrics result. fetchErr is that
+// fetch's error, if any — propagated here so every PVC in the cycle reports
+// it consistently, same as when each PVC fetched independently.
 func (c *PersistentVolumeClaimMetricsCollector) getFilesystemUsage(
-	ctx context.Context,
 	pvc *corev1.PersistentVolumeClaim,
+	pvcMetricsIndex map[types.NamespacedName]UnifiedPVCMetric,
+	fetchErr error,
 ) (*filesystemUsage, error) {
-	allMetrics, err := c.nodemonClient.FetchAllPVCMetrics(ctx)
-	if err != nil {
-		return nil, fmt.Errorf("fetching PVC metrics from nodemon: %w", err)
+	if fetchErr != nil {
+		return nil, fmt.Errorf("fetching PVC metrics from nodemon: %w", fetchErr)
 	}
 
-	for _, m := range allMetrics {
-		if m.Namespace == pvc.Namespace && m.PVCName == pvc.Name {
-			return &filesystemUsage{
-				UsedBytes:      int64(m.UsedBytes),
-				CapacityBytes:  int64(m.CapacityBytes),
-				AvailableBytes: int64(m.AvailableBytes),
-			}, nil
+	m, ok := pvcMetricsIndex[types.NamespacedName{Namespace: pvc.Namespace, Name: pvc.Name}]
+	if !ok {
+		return nil, fmt.Errorf("no nodemon metrics found for PVC %s/%s", pvc.Namespace, pvc.Name)
+	}
+
+	return &filesystemUsage{
+		UsedBytes:      int64(m.UsedBytes),
+		CapacityBytes:  int64(m.CapacityBytes),
+		AvailableBytes: int64(m.AvailableBytes),
+	}, nil
+}
+
+// indexPVCMetricsByNamespacedName indexes a FetchAllPVCMetrics result by
+// (namespace, pvcName) for O(1) lookup, so a single cluster-wide fetch can
+// serve every PVC in a sweep instead of being re-fetched per PVC (#9429).
+// A ReadWriteMany PVC mounted on multiple nodes can produce more than one
+// row for the same (namespace, pvcName); the first occurrence wins, matching
+// the previous linear scan's first-match behavior.
+func indexPVCMetricsByNamespacedName(metrics []UnifiedPVCMetric) map[types.NamespacedName]UnifiedPVCMetric {
+	index := make(map[types.NamespacedName]UnifiedPVCMetric, len(metrics))
+	for _, m := range metrics {
+		key := types.NamespacedName{Namespace: m.Namespace, Name: m.PVCName}
+		if _, exists := index[key]; exists {
+			continue
 		}
+		index[key] = m
 	}
-
-	return nil, fmt.Errorf("no nodemon metrics found for PVC %s/%s", pvc.Namespace, pvc.Name)
+	return index
 }
 
 // emitSnapshot sends the metrics snapshot to the batch channel

--- a/internal/collector/pvc_metrics_collector_perf_test.go
+++ b/internal/collector/pvc_metrics_collector_perf_test.go
@@ -1,0 +1,227 @@
+// internal/collector/pvc_metrics_collector_perf_test.go
+package collector
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/go-logr/logr"
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/informers"
+	k8sfake "k8s.io/client-go/kubernetes/fake"
+	"k8s.io/client-go/tools/cache"
+)
+
+// This file is a characterization/perf-regression test for
+// https://github.com/devzero-inc/services/issues/9429: the PVC-metrics
+// N+1 fetch bug. PersistentVolumeClaimMetricsCollector.collectAllPVCMetrics
+// loops over every PVC and, via processPVCMetrics -> getFilesystemUsage,
+// calls NodemonClient.FetchAllPVCMetrics once PER PVC. FetchAllPVCMetrics
+// does a full fan-out HTTP call to every nodemon pod in the cluster, so
+// total nodemon request volume for one collection sweep is
+// O(pvcCount * nodeCount) instead of O(nodeCount). #9418 parallelized the
+// fan-out *inside* a single FetchAllPVCMetrics call, but did not stop it
+// from being re-invoked once per PVC — this is a distinct bug in the same
+// family, root-caused on two production clusters via ClickHouse (multi-
+// minute PVC collection cycles) and Datadog (thousands of per-hour
+// "Failed to collect PVC metrics from nodemon" telemetry warnings, and
+// >90% of PVCs reporting no stats on the larger cluster).
+//
+// No real network sockets are used — the nodemon HTTP client is pointed at
+// a custom http.RoundTripper that counts every request to /pvc/metrics.
+
+// testPVC builds a bound, filesystem-mode PVC ready for
+// collectAllPVCMetrics to process.
+func testPVC(namespace, name, volumeName string, capacityBytes int64) *corev1.PersistentVolumeClaim {
+	mode := corev1.PersistentVolumeFilesystem
+	quantity := *resource.NewQuantity(capacityBytes, resource.BinarySI)
+	return &corev1.PersistentVolumeClaim{
+		ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: namespace},
+		Spec: corev1.PersistentVolumeClaimSpec{
+			VolumeName:  volumeName,
+			VolumeMode:  &mode,
+			AccessModes: []corev1.PersistentVolumeAccessMode{corev1.ReadWriteOnce},
+			Resources: corev1.VolumeResourceRequirements{
+				Requests: corev1.ResourceList{corev1.ResourceStorage: quantity},
+			},
+		},
+		Status: corev1.PersistentVolumeClaimStatus{
+			Phase:    corev1.ClaimBound,
+			Capacity: corev1.ResourceList{corev1.ResourceStorage: quantity},
+		},
+	}
+}
+
+// newSyncedPVCInformerFactory builds a real SharedInformerFactory backed by a
+// fake clientset seeded with the given PVCs, registers PVC and PV informers
+// on it (collectAllPVCMetrics/processPVCMetrics read through
+// factory.Core().V1()...Lister(), not a standalone informer), and waits for
+// the initial cache sync.
+func newSyncedPVCInformerFactory(t *testing.T, pvcs ...*corev1.PersistentVolumeClaim) (informers.SharedInformerFactory, chan struct{}) {
+	t.Helper()
+	objs := make([]runtime.Object, len(pvcs))
+	for i, p := range pvcs {
+		objs[i] = p
+	}
+	client := k8sfake.NewSimpleClientset(objs...)
+	factory := newInformerFactory(client, nil)
+	pvcInformer := factory.Core().V1().PersistentVolumeClaims().Informer()
+	pvInformer := factory.Core().V1().PersistentVolumes().Informer()
+	stopCh := make(chan struct{})
+	factory.Start(stopCh)
+	require.True(t, cache.WaitForCacheSync(stopCh, pvcInformer.HasSynced, pvInformer.HasSynced), "PVC/PV informer failed to sync")
+	return factory, stopCh
+}
+
+// pvcNodemonRoundTripper simulates numNodes nodemon backends, each owning a
+// disjoint slice of the PVC fleet (mirroring how a real nodemon only
+// reports volumes actually mounted on its own node). It counts every
+// request made to /pvc/metrics across all simulated nodes, regardless of
+// which node served it — that count is exactly the signal this test cares
+// about: it scales with node count alone if the fetch is deduplicated per
+// sweep, or with pvcCount*nodeCount if it is not.
+type pvcNodemonRoundTripper struct {
+	perNode      map[string][]UnifiedPVCMetric // hostname -> this node's PVC metrics
+	requestCount int64
+}
+
+func (rt *pvcNodemonRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
+	if !strings.HasSuffix(req.URL.Path, "/pvc/metrics") {
+		return jsonResponse(http.StatusNotFound, map[string]string{"error": "unknown path"}), nil
+	}
+	atomic.AddInt64(&rt.requestCount, 1)
+
+	metrics, ok := rt.perNode[req.URL.Hostname()]
+	if !ok {
+		return jsonResponse(http.StatusNotFound, map[string]string{"error": "unknown node"}), nil
+	}
+	return jsonResponse(http.StatusOK, metrics), nil
+}
+
+// TestCollectAllPVCMetrics_PerfUnderLatency_KnownRegression_PVCFetchPerPVC
+// proves the fetch-per-PVC bug by counting total /pvc/metrics requests
+// across a whole sweep. With the bug, that count is
+// numPVCs*numNodes (each PVC re-triggers a full fan-out); fixed, it's
+// numNodes (one fan-out for the whole sweep, PVCs looked up from the
+// cached result).
+func TestCollectAllPVCMetrics_PerfUnderLatency_KnownRegression_PVCFetchPerPVC(t *testing.T) {
+	const (
+		numNodes       = 5
+		pvcsPerNode    = 8
+		numPVCs        = numNodes * pvcsPerNode
+		capacityBytes  = 100 << 30 // 100Gi
+		usedBytes      = 40 << 30
+		availableBytes = 60 << 30
+	)
+
+	// A fetch-per-PVC ceiling would be numPVCs*numNodes (200). A
+	// fetch-once-per-sweep implementation should land at exactly numNodes
+	// (5) requests. Multiplying by 3 gives headroom for the constructor's
+	// initial node-discovery call and any reasonable retry, while still
+	// catching the current implementation (200 requests) with a huge
+	// margin.
+	maxAcceptableRequests := int64(numNodes * 3)
+
+	rt := &pvcNodemonRoundTripper{perNode: make(map[string][]UnifiedPVCMetric)}
+	nodeToIP := make(map[string]string)
+	var pvcs []*corev1.PersistentVolumeClaim
+
+	for n := range numNodes {
+		nodeName := fmt.Sprintf("node-%02d", n)
+		nodeToIP[nodeName] = nodeName // hostname doubles as a fake "pod IP" — no real DNS/socket involved
+
+		var nodeMetrics []UnifiedPVCMetric
+		for p := range pvcsPerNode {
+			pvcName := fmt.Sprintf("pvc-%s-%02d", nodeName, p)
+			pvcs = append(pvcs, testPVC("ns1", pvcName, "pv-"+pvcName, capacityBytes))
+			nodeMetrics = append(nodeMetrics, UnifiedPVCMetric{
+				Namespace:      "ns1",
+				PVCName:        pvcName,
+				UsedBytes:      usedBytes,
+				CapacityBytes:  capacityBytes,
+				AvailableBytes: availableBytes,
+			})
+		}
+		rt.perNode[nodeName] = nodeMetrics
+	}
+
+	require.Len(t, pvcs, numPVCs)
+
+	informerFactory, stopInformerCh := newSyncedPVCInformerFactory(t, pvcs...)
+	defer close(stopInformerCh)
+
+	nmClient := &NodemonClient{
+		port:          80, // irrelevant: the custom RoundTripper never opens a real socket
+		httpClient:    &http.Client{Transport: rt},
+		log:           logr.Discard(),
+		nodeToIP:      nodeToIP,
+		lastRefreshed: time.Now(),
+	}
+
+	c := &PersistentVolumeClaimMetricsCollector{
+		nodemonClient:   nmClient,
+		informerFactory: informerFactory,
+		batchChan:       make(chan CollectedResource, numPVCs*2),
+		excludedPVCs:    map[types.NamespacedName]bool{},
+		logger:          logr.Discard(),
+		telemetryLogger: &fakeTelemetryLogger{},
+	}
+
+	c.collectAllPVCMetrics(context.Background())
+
+	close(c.batchChan)
+	statsAvailable := 0
+	for res := range c.batchChan {
+		snapshot, ok := res.Object.(*PersistentVolumeClaimMetricsSnapshot)
+		require.True(t, ok)
+		if snapshot.StatsAvailable {
+			statsAvailable++
+		}
+	}
+	require.Equal(t, numPVCs, statsAvailable,
+		"expected every PVC to get stats from the (deterministic, always-succeeding) simulated nodemon backends")
+
+	got := atomic.LoadInt64(&rt.requestCount)
+	require.LessOrEqualf(t, got, maxAcceptableRequests,
+		"collectAllPVCMetrics made %d requests to /pvc/metrics for %d PVCs across %d nodes — "+
+			"this scales with PVC count instead of being bounded by node count, meaning "+
+			"FetchAllPVCMetrics is being re-invoked once per PVC instead of once per sweep",
+		got, numPVCs, numNodes)
+}
+
+// TestIndexPVCMetricsByNamespacedName_FirstOccurrenceWins guards against a
+// review finding on this PR: a ReadWriteMany PVC mounted on multiple nodes
+// can produce more than one UnifiedPVCMetric row for the same
+// (namespace, pvcName) — one per node/pod that mounted it. The old linear
+// scan in getFilesystemUsage returned the first matching row; a naive
+// map-building loop would let the last row silently win instead, changing
+// which node's numbers get reported for no functional reason.
+func TestIndexPVCMetricsByNamespacedName_FirstOccurrenceWins(t *testing.T) {
+	metrics := []UnifiedPVCMetric{
+		{Namespace: "ns1", Pod: "pod-a", PVCName: "shared-pvc", UsedBytes: 111, CapacityBytes: 1000, AvailableBytes: 889},
+		{Namespace: "ns1", Pod: "pod-b", PVCName: "shared-pvc", UsedBytes: 222, CapacityBytes: 1000, AvailableBytes: 778},
+		{Namespace: "ns1", Pod: "pod-c", PVCName: "other-pvc", UsedBytes: 333, CapacityBytes: 500, AvailableBytes: 167},
+	}
+
+	index := indexPVCMetricsByNamespacedName(metrics)
+
+	require.Len(t, index, 2)
+	shared, ok := index[types.NamespacedName{Namespace: "ns1", Name: "shared-pvc"}]
+	require.True(t, ok)
+	require.Equal(t, "pod-a", shared.Pod, "expected the first row for a duplicate (namespace, pvcName) to win, matching the previous linear-scan first-match behavior")
+	require.EqualValues(t, 111, shared.UsedBytes)
+
+	other, ok := index[types.NamespacedName{Namespace: "ns1", Name: "other-pvc"}]
+	require.True(t, ok)
+	require.Equal(t, "pod-c", other.Pod)
+}


### PR DESCRIPTION
Release v0.1.3 of zxporter, published from the internal services monorepo.

The `v0.1.3` tag has already been created and points at this branch's tip — ArgoCD and other tag consumers can use it immediately. This PR is only to advance public main to the released commit for browser convenience.

Published by hand because the release run's `publish-public` job was skipped: the dispatch run and the tag-push run it spawned raced each other for the same images, so neither run had all three chart jobs green in the same run (see devzero-inc/services — follow-up fix in flight). Images and OCI charts for v0.1.3 are correct and already published.