### PR TITLE
chore(release): v0.1.5

### DIFF
--- a/cmd/zxporter-nodemon/main.go
+++ b/cmd/zxporter-nodemon/main.go
@@ -7,9 +7,16 @@ import (
 	"net/http"
 	"os"
 	"os/signal"
+	"runtime/debug"
 	"strconv"
 	"syscall"
 	"time"
+
+	// Sets GOMEMLIMIT to 0.9 x the container's cgroup memory limit at startup so
+	// the GC collects aggressively before the kernel OOM-kills the pod. No-ops
+	// safely when no cgroup memory limit is set. Mirrors the controller-manager
+	// (operators/zxporter/cmd/main.go).
+	_ "github.com/KimMachineGun/automemlimit"
 
 	"github.com/devzero-inc/zxporter/internal/health"
 	"github.com/devzero-inc/zxporter/internal/nodemon"
@@ -34,6 +41,11 @@ func main() {
 	logger.Info("Starting zxporter-nodemon",
 		"version", versionInfo.String(),
 		"commit", versionInfo.GitCommit)
+
+	// Read back the GOMEMLIMIT set by the automemlimit side-effect import above.
+	// A value of math.MaxInt64 means no limit is in effect (e.g. no cgroup memory
+	// limit); anything smaller confirms the GC ceiling is active.
+	logger.Info("effective GOMEMLIMIT", "bytes", debug.SetMemoryLimit(-1))
 
 	cfg := nodemon.ExporterConfig{
 		HTTPListenPort:      envInt("HTTP_LISTEN_PORT", 6061),
@@ -84,8 +96,16 @@ func main() {
 	)
 	mapper := nodemon.NewMapper(cfg.NodeName, workloadResolver, logger)
 
-	// Create GPU exporter
+	// Create GPU exporter, wrapped in a cache so DCGM is scraped+parsed exactly
+	// once per interval (shared by the collection loop and every
+	// /container/metrics request) rather than per request. The full DCGM parse
+	// is the nodemon's dominant heap cost on GPU nodes; collapsing overlapping
+	// scrapes is the primary OOM defence.
 	exporter := nodemon.NewExporter(cfg, dynClient, scraper, mapper, logger)
+	gpuRefreshInterval := time.Duration(
+		envInt("GPU_REFRESH_INTERVAL_SECONDS", int(nodemon.DefaultGPURefreshInterval/time.Second)),
+	) * time.Second
+	cachedGPU := nodemon.NewCachedGPUExporter(exporter, gpuRefreshInterval, logger)
 
 	// Create a K8s-authenticated HTTP client for kubelet API proxy access
 	k8sTransport, err := rest.TransportFor(kubeConfig)
@@ -131,18 +151,21 @@ func main() {
 		logger.Info("Cgroup metrics collection disabled (set CGROUP_METRICS_ENABLED=true to enable)")
 	}
 
-	// Create unified exporter that combines all data sources
+	// Create unified exporter that combines all data sources. It reads GPU data
+	// from the shared cache (cachedGPU), not by scraping DCGM itself.
 	unifiedExporter := nodemon.NewUnifiedExporter(
-		statsPoller, cadvisorScraper, exporter, cgroupReader, cfg.NodeName, logger,
+		statsPoller, cadvisorScraper, cachedGPU, cgroupReader, cfg.NodeName, logger,
 	)
 
-	// Start unified collection loop (every 30 seconds)
+	// Start the GPU snapshot refresher and the unified collection loop.
 	collectionCtx, collectionCancel := context.WithCancel(context.Background())
 	defer collectionCancel()
+	go cachedGPU.Start(collectionCtx)
 	go unifiedExporter.StartCollectionLoop(collectionCtx, 30*time.Second)
 
-	// Create HTTP handlers
-	containerMetricsHandler := nodemon.NewContainerMetricsHandler(exporter, logger) // GPU-only (backward compat)
+	// Create HTTP handlers. The legacy GPU-only endpoint serves the shared cached
+	// snapshot instead of scraping DCGM on every request.
+	containerMetricsHandler := nodemon.NewContainerMetricsHandler(cachedGPU, logger) // GPU-only (backward compat)
 
 	// Process-introspection collectors are enabled only via Helm values
 	// (runtimeMetrics.enabled). They require hostPID: true and SYS_PTRACE, granted in
@@ -162,6 +185,7 @@ func main() {
 
 	var jvmMetricsHandler http.Handler
 	var runtimeMetricsHandler http.Handler
+	var runtimeSnapshotSource nodemon.RuntimeSnapshotQuerier
 	switch {
 	case runtimeMetricsEnabled && podContainerIndex != nil:
 		jvmCollector := nodemon.NewJVMCollector(cfg.NodeName, podContainerIndex, logger)
@@ -171,6 +195,7 @@ func main() {
 
 		runtimeCollector := nodemon.NewRuntimeCollector(cfg.NodeName, podContainerIndex, logger)
 		runtimeMetricsHandler = nodemon.NewRuntimeMetricsHandler(runtimeCollector, logger, scanHandlerTimeout)
+		runtimeSnapshotSource = runtimeCollector
 		go runtimeCollector.StartCollectionLoop(collectionCtx, 30*time.Second)
 		logger.Info("Combined runtime metrics collection enabled")
 	case runtimeMetricsEnabled:
@@ -185,6 +210,11 @@ func main() {
 	mux.Handle("/v2/container/metrics", nodemon.NewUnifiedContainerHandler(unifiedExporter, logger))
 	mux.Handle("/node/metrics", nodemon.NewNodeMetricsHandler(unifiedExporter, logger))
 	mux.Handle("/pvc/metrics", nodemon.NewPVCMetricsHandler(unifiedExporter, logger))
+	mux.Handle("/v2/node/snapshot", nodemon.NewNodeSnapshotHandler(unifiedExporter, cachedGPU, logger))
+	mux.Handle(
+		"/v2/container/snapshot",
+		nodemon.NewContainerSnapshotHandler(unifiedExporter, runtimeSnapshotSource, logger),
+	)
 
 	server := &http.Server{
 		Addr:    fmt.Sprintf(":%d", cfg.HTTPListenPort),

--- a/dist/backend-install-gcp-lowpriv.yaml
+++ b/dist/backend-install-gcp-lowpriv.yaml
@@ -833,10 +833,10 @@ metadata:
   name: zxporter-nodemon
   namespace: {{.zxporter_namespace}}
   labels:
-    helm.sh/chart: zxporter-nodemon-0.1.4
+    helm.sh/chart: zxporter-nodemon-0.1.5
     app.kubernetes.io/name: zxporter-nodemon
     app.kubernetes.io/instance: zxporter-nodemon
-    app.kubernetes.io/version: "0.1.4"
+    app.kubernetes.io/version: "0.1.5"
     app.kubernetes.io/managed-by: Helm
 ---
 # Source: zxporter-nodemon/templates/dcgm-exporter-configmap.yaml
@@ -909,10 +909,10 @@ kind: ClusterRole
 metadata:
   name: zxporter-nodemon
   labels:
-    helm.sh/chart: zxporter-nodemon-0.1.4
+    helm.sh/chart: zxporter-nodemon-0.1.5
     app.kubernetes.io/name: zxporter-nodemon
     app.kubernetes.io/instance: zxporter-nodemon
-    app.kubernetes.io/version: "0.1.4"
+    app.kubernetes.io/version: "0.1.5"
     app.kubernetes.io/managed-by: Helm
 rules:
   - apiGroups:
@@ -959,10 +959,10 @@ kind: ClusterRoleBinding
 metadata:
   name: zxporter-nodemon
   labels:
-    helm.sh/chart: zxporter-nodemon-0.1.4
+    helm.sh/chart: zxporter-nodemon-0.1.5
     app.kubernetes.io/name: zxporter-nodemon
     app.kubernetes.io/instance: zxporter-nodemon
-    app.kubernetes.io/version: "0.1.4"
+    app.kubernetes.io/version: "0.1.5"
     app.kubernetes.io/managed-by: Helm
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -980,10 +980,10 @@ metadata:
   name: zxporter-nodemon
   namespace: {{.zxporter_namespace}}
   labels:
-    helm.sh/chart: zxporter-nodemon-0.1.4
+    helm.sh/chart: zxporter-nodemon-0.1.5
     app.kubernetes.io/name: zxporter-nodemon
     app.kubernetes.io/instance: zxporter-nodemon
-    app.kubernetes.io/version: "0.1.4"
+    app.kubernetes.io/version: "0.1.5"
     app.kubernetes.io/managed-by: Helm
   annotations:
     ignore-check.kube-linter.io/privileged-container: "This daemon set needs to run DCGM Exporter as privileged to access the GPU metrics."
@@ -1067,6 +1067,11 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: metadata.namespace
+            # Cap GOMAXPROCS: nodemon has no CPU limit, so on high-core GPU nodes
+            # the Go runtime would otherwise size P's/GC workers to the full node
+            # core count, inflating baseline memory. nodemon's work is light.
+            - name: "GOMAXPROCS"
+              value: "2"
             - name: "RUNTIME_METRICS_ENABLED"
               value: "false"
             - name: "CGROUP_METRICS_ENABLED"
@@ -1132,10 +1137,10 @@ metadata:
   name: zxporter-nodemon-gpu
   namespace: {{.zxporter_namespace}}
   labels:
-    helm.sh/chart: zxporter-nodemon-0.1.4
+    helm.sh/chart: zxporter-nodemon-0.1.5
     app.kubernetes.io/name: zxporter-nodemon
     app.kubernetes.io/instance: zxporter-nodemon-gpu
-    app.kubernetes.io/version: "0.1.4"
+    app.kubernetes.io/version: "0.1.5"
     app.kubernetes.io/managed-by: Helm
   annotations:
     ignore-check.kube-linter.io/privileged-container: "This daemon set needs to run DCGM Exporter as privileged to access the GPU metrics."
@@ -1222,6 +1227,11 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: metadata.namespace
+            # Cap GOMAXPROCS: nodemon has no CPU limit, so on high-core GPU nodes
+            # the Go runtime would otherwise size P's/GC workers to the full node
+            # core count, inflating baseline memory. nodemon's work is light.
+            - name: "GOMAXPROCS"
+              value: "2"
             - name: "RUNTIME_METRICS_ENABLED"
               value: "false"
             - name: "CGROUP_METRICS_ENABLED"

--- a/dist/backend-install-gcp.yaml
+++ b/dist/backend-install-gcp.yaml
@@ -833,10 +833,10 @@ metadata:
   name: zxporter-nodemon
   namespace: {{.zxporter_namespace}}
   labels:
-    helm.sh/chart: zxporter-nodemon-0.1.4
+    helm.sh/chart: zxporter-nodemon-0.1.5
     app.kubernetes.io/name: zxporter-nodemon
     app.kubernetes.io/instance: zxporter-nodemon
-    app.kubernetes.io/version: "0.1.4"
+    app.kubernetes.io/version: "0.1.5"
     app.kubernetes.io/managed-by: Helm
 ---
 # Source: zxporter-nodemon/templates/dcgm-exporter-configmap.yaml
@@ -909,10 +909,10 @@ kind: ClusterRole
 metadata:
   name: zxporter-nodemon
   labels:
-    helm.sh/chart: zxporter-nodemon-0.1.4
+    helm.sh/chart: zxporter-nodemon-0.1.5
     app.kubernetes.io/name: zxporter-nodemon
     app.kubernetes.io/instance: zxporter-nodemon
-    app.kubernetes.io/version: "0.1.4"
+    app.kubernetes.io/version: "0.1.5"
     app.kubernetes.io/managed-by: Helm
 rules:
   - apiGroups:
@@ -960,10 +960,10 @@ kind: ClusterRoleBinding
 metadata:
   name: zxporter-nodemon
   labels:
-    helm.sh/chart: zxporter-nodemon-0.1.4
+    helm.sh/chart: zxporter-nodemon-0.1.5
     app.kubernetes.io/name: zxporter-nodemon
     app.kubernetes.io/instance: zxporter-nodemon
-    app.kubernetes.io/version: "0.1.4"
+    app.kubernetes.io/version: "0.1.5"
     app.kubernetes.io/managed-by: Helm
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -981,10 +981,10 @@ metadata:
   name: zxporter-nodemon
   namespace: {{.zxporter_namespace}}
   labels:
-    helm.sh/chart: zxporter-nodemon-0.1.4
+    helm.sh/chart: zxporter-nodemon-0.1.5
     app.kubernetes.io/name: zxporter-nodemon
     app.kubernetes.io/instance: zxporter-nodemon
-    app.kubernetes.io/version: "0.1.4"
+    app.kubernetes.io/version: "0.1.5"
     app.kubernetes.io/managed-by: Helm
   annotations:
     ignore-check.kube-linter.io/privileged-container: "This daemon set needs to run DCGM Exporter as privileged to access the GPU metrics."
@@ -1073,6 +1073,11 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: metadata.namespace
+            # Cap GOMAXPROCS: nodemon has no CPU limit, so on high-core GPU nodes
+            # the Go runtime would otherwise size P's/GC workers to the full node
+            # core count, inflating baseline memory. nodemon's work is light.
+            - name: "GOMAXPROCS"
+              value: "2"
             - name: "RUNTIME_METRICS_ENABLED"
               value: "true"
             - name: "CGROUP_METRICS_ENABLED"
@@ -1138,10 +1143,10 @@ metadata:
   name: zxporter-nodemon-gpu
   namespace: {{.zxporter_namespace}}
   labels:
-    helm.sh/chart: zxporter-nodemon-0.1.4
+    helm.sh/chart: zxporter-nodemon-0.1.5
     app.kubernetes.io/name: zxporter-nodemon
     app.kubernetes.io/instance: zxporter-nodemon-gpu
-    app.kubernetes.io/version: "0.1.4"
+    app.kubernetes.io/version: "0.1.5"
     app.kubernetes.io/managed-by: Helm
   annotations:
     ignore-check.kube-linter.io/privileged-container: "This daemon set needs to run DCGM Exporter as privileged to access the GPU metrics."
@@ -1233,6 +1238,11 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: metadata.namespace
+            # Cap GOMAXPROCS: nodemon has no CPU limit, so on high-core GPU nodes
+            # the Go runtime would otherwise size P's/GC workers to the full node
+            # core count, inflating baseline memory. nodemon's work is light.
+            - name: "GOMAXPROCS"
+              value: "2"
             - name: "RUNTIME_METRICS_ENABLED"
               value: "true"
             - name: "CGROUP_METRICS_ENABLED"

--- a/dist/backend-install-lowpriv.yaml
+++ b/dist/backend-install-lowpriv.yaml
@@ -833,10 +833,10 @@ metadata:
   name: zxporter-nodemon
   namespace: {{.zxporter_namespace}}
   labels:
-    helm.sh/chart: zxporter-nodemon-0.1.4
+    helm.sh/chart: zxporter-nodemon-0.1.5
     app.kubernetes.io/name: zxporter-nodemon
     app.kubernetes.io/instance: zxporter-nodemon
-    app.kubernetes.io/version: "0.1.4"
+    app.kubernetes.io/version: "0.1.5"
     app.kubernetes.io/managed-by: Helm
 ---
 # Source: zxporter-nodemon/templates/dcgm-exporter-configmap.yaml
@@ -909,10 +909,10 @@ kind: ClusterRole
 metadata:
   name: zxporter-nodemon
   labels:
-    helm.sh/chart: zxporter-nodemon-0.1.4
+    helm.sh/chart: zxporter-nodemon-0.1.5
     app.kubernetes.io/name: zxporter-nodemon
     app.kubernetes.io/instance: zxporter-nodemon
-    app.kubernetes.io/version: "0.1.4"
+    app.kubernetes.io/version: "0.1.5"
     app.kubernetes.io/managed-by: Helm
 rules:
   - apiGroups:
@@ -959,10 +959,10 @@ kind: ClusterRoleBinding
 metadata:
   name: zxporter-nodemon
   labels:
-    helm.sh/chart: zxporter-nodemon-0.1.4
+    helm.sh/chart: zxporter-nodemon-0.1.5
     app.kubernetes.io/name: zxporter-nodemon
     app.kubernetes.io/instance: zxporter-nodemon
-    app.kubernetes.io/version: "0.1.4"
+    app.kubernetes.io/version: "0.1.5"
     app.kubernetes.io/managed-by: Helm
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -980,10 +980,10 @@ metadata:
   name: zxporter-nodemon
   namespace: {{.zxporter_namespace}}
   labels:
-    helm.sh/chart: zxporter-nodemon-0.1.4
+    helm.sh/chart: zxporter-nodemon-0.1.5
     app.kubernetes.io/name: zxporter-nodemon
     app.kubernetes.io/instance: zxporter-nodemon
-    app.kubernetes.io/version: "0.1.4"
+    app.kubernetes.io/version: "0.1.5"
     app.kubernetes.io/managed-by: Helm
   annotations:
     ignore-check.kube-linter.io/privileged-container: "This daemon set needs to run DCGM Exporter as privileged to access the GPU metrics."
@@ -1064,6 +1064,11 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: metadata.namespace
+            # Cap GOMAXPROCS: nodemon has no CPU limit, so on high-core GPU nodes
+            # the Go runtime would otherwise size P's/GC workers to the full node
+            # core count, inflating baseline memory. nodemon's work is light.
+            - name: "GOMAXPROCS"
+              value: "2"
             - name: "RUNTIME_METRICS_ENABLED"
               value: "false"
             - name: "CGROUP_METRICS_ENABLED"
@@ -1122,10 +1127,10 @@ metadata:
   name: zxporter-nodemon-gpu
   namespace: {{.zxporter_namespace}}
   labels:
-    helm.sh/chart: zxporter-nodemon-0.1.4
+    helm.sh/chart: zxporter-nodemon-0.1.5
     app.kubernetes.io/name: zxporter-nodemon
     app.kubernetes.io/instance: zxporter-nodemon-gpu
-    app.kubernetes.io/version: "0.1.4"
+    app.kubernetes.io/version: "0.1.5"
     app.kubernetes.io/managed-by: Helm
   annotations:
     ignore-check.kube-linter.io/privileged-container: "This daemon set needs to run DCGM Exporter as privileged to access the GPU metrics."
@@ -1209,6 +1214,11 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: metadata.namespace
+            # Cap GOMAXPROCS: nodemon has no CPU limit, so on high-core GPU nodes
+            # the Go runtime would otherwise size P's/GC workers to the full node
+            # core count, inflating baseline memory. nodemon's work is light.
+            - name: "GOMAXPROCS"
+              value: "2"
             - name: "RUNTIME_METRICS_ENABLED"
               value: "false"
             - name: "CGROUP_METRICS_ENABLED"

--- a/dist/backend-install.yaml
+++ b/dist/backend-install.yaml
@@ -833,10 +833,10 @@ metadata:
   name: zxporter-nodemon
   namespace: {{.zxporter_namespace}}
   labels:
-    helm.sh/chart: zxporter-nodemon-0.1.4
+    helm.sh/chart: zxporter-nodemon-0.1.5
     app.kubernetes.io/name: zxporter-nodemon
     app.kubernetes.io/instance: zxporter-nodemon
-    app.kubernetes.io/version: "0.1.4"
+    app.kubernetes.io/version: "0.1.5"
     app.kubernetes.io/managed-by: Helm
 ---
 # Source: zxporter-nodemon/templates/dcgm-exporter-configmap.yaml
@@ -909,10 +909,10 @@ kind: ClusterRole
 metadata:
   name: zxporter-nodemon
   labels:
-    helm.sh/chart: zxporter-nodemon-0.1.4
+    helm.sh/chart: zxporter-nodemon-0.1.5
     app.kubernetes.io/name: zxporter-nodemon
     app.kubernetes.io/instance: zxporter-nodemon
-    app.kubernetes.io/version: "0.1.4"
+    app.kubernetes.io/version: "0.1.5"
     app.kubernetes.io/managed-by: Helm
 rules:
   - apiGroups:
@@ -960,10 +960,10 @@ kind: ClusterRoleBinding
 metadata:
   name: zxporter-nodemon
   labels:
-    helm.sh/chart: zxporter-nodemon-0.1.4
+    helm.sh/chart: zxporter-nodemon-0.1.5
     app.kubernetes.io/name: zxporter-nodemon
     app.kubernetes.io/instance: zxporter-nodemon
-    app.kubernetes.io/version: "0.1.4"
+    app.kubernetes.io/version: "0.1.5"
     app.kubernetes.io/managed-by: Helm
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -981,10 +981,10 @@ metadata:
   name: zxporter-nodemon
   namespace: {{.zxporter_namespace}}
   labels:
-    helm.sh/chart: zxporter-nodemon-0.1.4
+    helm.sh/chart: zxporter-nodemon-0.1.5
     app.kubernetes.io/name: zxporter-nodemon
     app.kubernetes.io/instance: zxporter-nodemon
-    app.kubernetes.io/version: "0.1.4"
+    app.kubernetes.io/version: "0.1.5"
     app.kubernetes.io/managed-by: Helm
   annotations:
     ignore-check.kube-linter.io/privileged-container: "This daemon set needs to run DCGM Exporter as privileged to access the GPU metrics."
@@ -1070,6 +1070,11 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: metadata.namespace
+            # Cap GOMAXPROCS: nodemon has no CPU limit, so on high-core GPU nodes
+            # the Go runtime would otherwise size P's/GC workers to the full node
+            # core count, inflating baseline memory. nodemon's work is light.
+            - name: "GOMAXPROCS"
+              value: "2"
             - name: "RUNTIME_METRICS_ENABLED"
               value: "true"
             - name: "CGROUP_METRICS_ENABLED"
@@ -1128,10 +1133,10 @@ metadata:
   name: zxporter-nodemon-gpu
   namespace: {{.zxporter_namespace}}
   labels:
-    helm.sh/chart: zxporter-nodemon-0.1.4
+    helm.sh/chart: zxporter-nodemon-0.1.5
     app.kubernetes.io/name: zxporter-nodemon
     app.kubernetes.io/instance: zxporter-nodemon-gpu
-    app.kubernetes.io/version: "0.1.4"
+    app.kubernetes.io/version: "0.1.5"
     app.kubernetes.io/managed-by: Helm
   annotations:
     ignore-check.kube-linter.io/privileged-container: "This daemon set needs to run DCGM Exporter as privileged to access the GPU metrics."
@@ -1220,6 +1225,11 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: metadata.namespace
+            # Cap GOMAXPROCS: nodemon has no CPU limit, so on high-core GPU nodes
+            # the Go runtime would otherwise size P's/GC workers to the full node
+            # core count, inflating baseline memory. nodemon's work is light.
+            - name: "GOMAXPROCS"
+              value: "2"
             - name: "RUNTIME_METRICS_ENABLED"
               value: "true"
             - name: "CGROUP_METRICS_ENABLED"

--- a/dist/install-gcp-lowpriv.yaml
+++ b/dist/install-gcp-lowpriv.yaml
@@ -833,10 +833,10 @@ metadata:
   name: zxporter-nodemon
   namespace: devzero-system
   labels:
-    helm.sh/chart: zxporter-nodemon-0.1.4
+    helm.sh/chart: zxporter-nodemon-0.1.5
     app.kubernetes.io/name: zxporter-nodemon
     app.kubernetes.io/instance: zxporter-nodemon
-    app.kubernetes.io/version: "0.1.4"
+    app.kubernetes.io/version: "0.1.5"
     app.kubernetes.io/managed-by: Helm
 ---
 # Source: zxporter-nodemon/templates/dcgm-exporter-configmap.yaml
@@ -909,10 +909,10 @@ kind: ClusterRole
 metadata:
   name: zxporter-nodemon
   labels:
-    helm.sh/chart: zxporter-nodemon-0.1.4
+    helm.sh/chart: zxporter-nodemon-0.1.5
     app.kubernetes.io/name: zxporter-nodemon
     app.kubernetes.io/instance: zxporter-nodemon
-    app.kubernetes.io/version: "0.1.4"
+    app.kubernetes.io/version: "0.1.5"
     app.kubernetes.io/managed-by: Helm
 rules:
 - apiGroups:
@@ -959,10 +959,10 @@ kind: ClusterRoleBinding
 metadata:
   name: zxporter-nodemon
   labels:
-    helm.sh/chart: zxporter-nodemon-0.1.4
+    helm.sh/chart: zxporter-nodemon-0.1.5
     app.kubernetes.io/name: zxporter-nodemon
     app.kubernetes.io/instance: zxporter-nodemon
-    app.kubernetes.io/version: "0.1.4"
+    app.kubernetes.io/version: "0.1.5"
     app.kubernetes.io/managed-by: Helm
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -980,10 +980,10 @@ metadata:
   name: zxporter-nodemon
   namespace: devzero-system
   labels:
-    helm.sh/chart: zxporter-nodemon-0.1.4
+    helm.sh/chart: zxporter-nodemon-0.1.5
     app.kubernetes.io/name: zxporter-nodemon
     app.kubernetes.io/instance: zxporter-nodemon
-    app.kubernetes.io/version: "0.1.4"
+    app.kubernetes.io/version: "0.1.5"
     app.kubernetes.io/managed-by: Helm
   annotations:
     ignore-check.kube-linter.io/privileged-container: "This daemon set needs to run DCGM Exporter as privileged to access the GPU metrics."
@@ -1067,6 +1067,11 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: metadata.namespace
+            # Cap GOMAXPROCS: nodemon has no CPU limit, so on high-core GPU nodes
+            # the Go runtime would otherwise size P's/GC workers to the full node
+            # core count, inflating baseline memory. nodemon's work is light.
+            - name: "GOMAXPROCS"
+              value: "2"
             - name: "RUNTIME_METRICS_ENABLED"
               value: "false"
             - name: "CGROUP_METRICS_ENABLED"
@@ -1132,10 +1137,10 @@ metadata:
   name: zxporter-nodemon-gpu
   namespace: devzero-system
   labels:
-    helm.sh/chart: zxporter-nodemon-0.1.4
+    helm.sh/chart: zxporter-nodemon-0.1.5
     app.kubernetes.io/name: zxporter-nodemon
     app.kubernetes.io/instance: zxporter-nodemon-gpu
-    app.kubernetes.io/version: "0.1.4"
+    app.kubernetes.io/version: "0.1.5"
     app.kubernetes.io/managed-by: Helm
   annotations:
     ignore-check.kube-linter.io/privileged-container: "This daemon set needs to run DCGM Exporter as privileged to access the GPU metrics."
@@ -1222,6 +1227,11 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: metadata.namespace
+            # Cap GOMAXPROCS: nodemon has no CPU limit, so on high-core GPU nodes
+            # the Go runtime would otherwise size P's/GC workers to the full node
+            # core count, inflating baseline memory. nodemon's work is light.
+            - name: "GOMAXPROCS"
+              value: "2"
             - name: "RUNTIME_METRICS_ENABLED"
               value: "false"
             - name: "CGROUP_METRICS_ENABLED"

--- a/dist/install-gcp.yaml
+++ b/dist/install-gcp.yaml
@@ -833,10 +833,10 @@ metadata:
   name: zxporter-nodemon
   namespace: devzero-system
   labels:
-    helm.sh/chart: zxporter-nodemon-0.1.4
+    helm.sh/chart: zxporter-nodemon-0.1.5
     app.kubernetes.io/name: zxporter-nodemon
     app.kubernetes.io/instance: zxporter-nodemon
-    app.kubernetes.io/version: "0.1.4"
+    app.kubernetes.io/version: "0.1.5"
     app.kubernetes.io/managed-by: Helm
 ---
 # Source: zxporter-nodemon/templates/dcgm-exporter-configmap.yaml
@@ -909,10 +909,10 @@ kind: ClusterRole
 metadata:
   name: zxporter-nodemon
   labels:
-    helm.sh/chart: zxporter-nodemon-0.1.4
+    helm.sh/chart: zxporter-nodemon-0.1.5
     app.kubernetes.io/name: zxporter-nodemon
     app.kubernetes.io/instance: zxporter-nodemon
-    app.kubernetes.io/version: "0.1.4"
+    app.kubernetes.io/version: "0.1.5"
     app.kubernetes.io/managed-by: Helm
 rules:
 - apiGroups:
@@ -960,10 +960,10 @@ kind: ClusterRoleBinding
 metadata:
   name: zxporter-nodemon
   labels:
-    helm.sh/chart: zxporter-nodemon-0.1.4
+    helm.sh/chart: zxporter-nodemon-0.1.5
     app.kubernetes.io/name: zxporter-nodemon
     app.kubernetes.io/instance: zxporter-nodemon
-    app.kubernetes.io/version: "0.1.4"
+    app.kubernetes.io/version: "0.1.5"
     app.kubernetes.io/managed-by: Helm
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -981,10 +981,10 @@ metadata:
   name: zxporter-nodemon
   namespace: devzero-system
   labels:
-    helm.sh/chart: zxporter-nodemon-0.1.4
+    helm.sh/chart: zxporter-nodemon-0.1.5
     app.kubernetes.io/name: zxporter-nodemon
     app.kubernetes.io/instance: zxporter-nodemon
-    app.kubernetes.io/version: "0.1.4"
+    app.kubernetes.io/version: "0.1.5"
     app.kubernetes.io/managed-by: Helm
   annotations:
     ignore-check.kube-linter.io/privileged-container: "This daemon set needs to run DCGM Exporter as privileged to access the GPU metrics."
@@ -1073,6 +1073,11 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: metadata.namespace
+            # Cap GOMAXPROCS: nodemon has no CPU limit, so on high-core GPU nodes
+            # the Go runtime would otherwise size P's/GC workers to the full node
+            # core count, inflating baseline memory. nodemon's work is light.
+            - name: "GOMAXPROCS"
+              value: "2"
             - name: "RUNTIME_METRICS_ENABLED"
               value: "true"
             - name: "CGROUP_METRICS_ENABLED"
@@ -1138,10 +1143,10 @@ metadata:
   name: zxporter-nodemon-gpu
   namespace: devzero-system
   labels:
-    helm.sh/chart: zxporter-nodemon-0.1.4
+    helm.sh/chart: zxporter-nodemon-0.1.5
     app.kubernetes.io/name: zxporter-nodemon
     app.kubernetes.io/instance: zxporter-nodemon-gpu
-    app.kubernetes.io/version: "0.1.4"
+    app.kubernetes.io/version: "0.1.5"
     app.kubernetes.io/managed-by: Helm
   annotations:
     ignore-check.kube-linter.io/privileged-container: "This daemon set needs to run DCGM Exporter as privileged to access the GPU metrics."
@@ -1233,6 +1238,11 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: metadata.namespace
+            # Cap GOMAXPROCS: nodemon has no CPU limit, so on high-core GPU nodes
+            # the Go runtime would otherwise size P's/GC workers to the full node
+            # core count, inflating baseline memory. nodemon's work is light.
+            - name: "GOMAXPROCS"
+              value: "2"
             - name: "RUNTIME_METRICS_ENABLED"
               value: "true"
             - name: "CGROUP_METRICS_ENABLED"

--- a/dist/install-lowpriv.yaml
+++ b/dist/install-lowpriv.yaml
@@ -833,10 +833,10 @@ metadata:
   name: zxporter-nodemon
   namespace: devzero-system
   labels:
-    helm.sh/chart: zxporter-nodemon-0.1.4
+    helm.sh/chart: zxporter-nodemon-0.1.5
     app.kubernetes.io/name: zxporter-nodemon
     app.kubernetes.io/instance: zxporter-nodemon
-    app.kubernetes.io/version: "0.1.4"
+    app.kubernetes.io/version: "0.1.5"
     app.kubernetes.io/managed-by: Helm
 ---
 # Source: zxporter-nodemon/templates/dcgm-exporter-configmap.yaml
@@ -909,10 +909,10 @@ kind: ClusterRole
 metadata:
   name: zxporter-nodemon
   labels:
-    helm.sh/chart: zxporter-nodemon-0.1.4
+    helm.sh/chart: zxporter-nodemon-0.1.5
     app.kubernetes.io/name: zxporter-nodemon
     app.kubernetes.io/instance: zxporter-nodemon
-    app.kubernetes.io/version: "0.1.4"
+    app.kubernetes.io/version: "0.1.5"
     app.kubernetes.io/managed-by: Helm
 rules:
 - apiGroups:
@@ -959,10 +959,10 @@ kind: ClusterRoleBinding
 metadata:
   name: zxporter-nodemon
   labels:
-    helm.sh/chart: zxporter-nodemon-0.1.4
+    helm.sh/chart: zxporter-nodemon-0.1.5
     app.kubernetes.io/name: zxporter-nodemon
     app.kubernetes.io/instance: zxporter-nodemon
-    app.kubernetes.io/version: "0.1.4"
+    app.kubernetes.io/version: "0.1.5"
     app.kubernetes.io/managed-by: Helm
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -980,10 +980,10 @@ metadata:
   name: zxporter-nodemon
   namespace: devzero-system
   labels:
-    helm.sh/chart: zxporter-nodemon-0.1.4
+    helm.sh/chart: zxporter-nodemon-0.1.5
     app.kubernetes.io/name: zxporter-nodemon
     app.kubernetes.io/instance: zxporter-nodemon
-    app.kubernetes.io/version: "0.1.4"
+    app.kubernetes.io/version: "0.1.5"
     app.kubernetes.io/managed-by: Helm
   annotations:
     ignore-check.kube-linter.io/privileged-container: "This daemon set needs to run DCGM Exporter as privileged to access the GPU metrics."
@@ -1064,6 +1064,11 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: metadata.namespace
+            # Cap GOMAXPROCS: nodemon has no CPU limit, so on high-core GPU nodes
+            # the Go runtime would otherwise size P's/GC workers to the full node
+            # core count, inflating baseline memory. nodemon's work is light.
+            - name: "GOMAXPROCS"
+              value: "2"
             - name: "RUNTIME_METRICS_ENABLED"
               value: "false"
             - name: "CGROUP_METRICS_ENABLED"
@@ -1122,10 +1127,10 @@ metadata:
   name: zxporter-nodemon-gpu
   namespace: devzero-system
   labels:
-    helm.sh/chart: zxporter-nodemon-0.1.4
+    helm.sh/chart: zxporter-nodemon-0.1.5
     app.kubernetes.io/name: zxporter-nodemon
     app.kubernetes.io/instance: zxporter-nodemon-gpu
-    app.kubernetes.io/version: "0.1.4"
+    app.kubernetes.io/version: "0.1.5"
     app.kubernetes.io/managed-by: Helm
   annotations:
     ignore-check.kube-linter.io/privileged-container: "This daemon set needs to run DCGM Exporter as privileged to access the GPU metrics."
@@ -1209,6 +1214,11 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: metadata.namespace
+            # Cap GOMAXPROCS: nodemon has no CPU limit, so on high-core GPU nodes
+            # the Go runtime would otherwise size P's/GC workers to the full node
+            # core count, inflating baseline memory. nodemon's work is light.
+            - name: "GOMAXPROCS"
+              value: "2"
             - name: "RUNTIME_METRICS_ENABLED"
               value: "false"
             - name: "CGROUP_METRICS_ENABLED"

--- a/dist/install.yaml
+++ b/dist/install.yaml
@@ -833,10 +833,10 @@ metadata:
   name: zxporter-nodemon
   namespace: devzero-system
   labels:
-    helm.sh/chart: zxporter-nodemon-0.1.4
+    helm.sh/chart: zxporter-nodemon-0.1.5
     app.kubernetes.io/name: zxporter-nodemon
     app.kubernetes.io/instance: zxporter-nodemon
-    app.kubernetes.io/version: "0.1.4"
+    app.kubernetes.io/version: "0.1.5"
     app.kubernetes.io/managed-by: Helm
 ---
 # Source: zxporter-nodemon/templates/dcgm-exporter-configmap.yaml
@@ -909,10 +909,10 @@ kind: ClusterRole
 metadata:
   name: zxporter-nodemon
   labels:
-    helm.sh/chart: zxporter-nodemon-0.1.4
+    helm.sh/chart: zxporter-nodemon-0.1.5
     app.kubernetes.io/name: zxporter-nodemon
     app.kubernetes.io/instance: zxporter-nodemon
-    app.kubernetes.io/version: "0.1.4"
+    app.kubernetes.io/version: "0.1.5"
     app.kubernetes.io/managed-by: Helm
 rules:
 - apiGroups:
@@ -960,10 +960,10 @@ kind: ClusterRoleBinding
 metadata:
   name: zxporter-nodemon
   labels:
-    helm.sh/chart: zxporter-nodemon-0.1.4
+    helm.sh/chart: zxporter-nodemon-0.1.5
     app.kubernetes.io/name: zxporter-nodemon
     app.kubernetes.io/instance: zxporter-nodemon
-    app.kubernetes.io/version: "0.1.4"
+    app.kubernetes.io/version: "0.1.5"
     app.kubernetes.io/managed-by: Helm
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -981,10 +981,10 @@ metadata:
   name: zxporter-nodemon
   namespace: devzero-system
   labels:
-    helm.sh/chart: zxporter-nodemon-0.1.4
+    helm.sh/chart: zxporter-nodemon-0.1.5
     app.kubernetes.io/name: zxporter-nodemon
     app.kubernetes.io/instance: zxporter-nodemon
-    app.kubernetes.io/version: "0.1.4"
+    app.kubernetes.io/version: "0.1.5"
     app.kubernetes.io/managed-by: Helm
   annotations:
     ignore-check.kube-linter.io/privileged-container: "This daemon set needs to run DCGM Exporter as privileged to access the GPU metrics."
@@ -1070,6 +1070,11 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: metadata.namespace
+            # Cap GOMAXPROCS: nodemon has no CPU limit, so on high-core GPU nodes
+            # the Go runtime would otherwise size P's/GC workers to the full node
+            # core count, inflating baseline memory. nodemon's work is light.
+            - name: "GOMAXPROCS"
+              value: "2"
             - name: "RUNTIME_METRICS_ENABLED"
               value: "true"
             - name: "CGROUP_METRICS_ENABLED"
@@ -1128,10 +1133,10 @@ metadata:
   name: zxporter-nodemon-gpu
   namespace: devzero-system
   labels:
-    helm.sh/chart: zxporter-nodemon-0.1.4
+    helm.sh/chart: zxporter-nodemon-0.1.5
     app.kubernetes.io/name: zxporter-nodemon
     app.kubernetes.io/instance: zxporter-nodemon-gpu
-    app.kubernetes.io/version: "0.1.4"
+    app.kubernetes.io/version: "0.1.5"
     app.kubernetes.io/managed-by: Helm
   annotations:
     ignore-check.kube-linter.io/privileged-container: "This daemon set needs to run DCGM Exporter as privileged to access the GPU metrics."
@@ -1220,6 +1225,11 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: metadata.namespace
+            # Cap GOMAXPROCS: nodemon has no CPU limit, so on high-core GPU nodes
+            # the Go runtime would otherwise size P's/GC workers to the full node
+            # core count, inflating baseline memory. nodemon's work is light.
+            - name: "GOMAXPROCS"
+              value: "2"
             - name: "RUNTIME_METRICS_ENABLED"
               value: "true"
             - name: "CGROUP_METRICS_ENABLED"

--- a/dist/installer_updater-gcp-lowpriv.yaml
+++ b/dist/installer_updater-gcp-lowpriv.yaml
@@ -767,10 +767,10 @@ metadata:
   name: zxporter-nodemon
   namespace: '{{.zxporter_namespace}}'
   labels:
-    helm.sh/chart: zxporter-nodemon-0.1.4
+    helm.sh/chart: zxporter-nodemon-0.1.5
     app.kubernetes.io/name: zxporter-nodemon
     app.kubernetes.io/instance: zxporter-nodemon
-    app.kubernetes.io/version: "0.1.4"
+    app.kubernetes.io/version: "0.1.5"
     app.kubernetes.io/managed-by: Helm
 ---
 # Source: zxporter-nodemon/templates/dcgm-exporter-configmap.yaml
@@ -843,10 +843,10 @@ kind: ClusterRole
 metadata:
   name: zxporter-nodemon
   labels:
-    helm.sh/chart: zxporter-nodemon-0.1.4
+    helm.sh/chart: zxporter-nodemon-0.1.5
     app.kubernetes.io/name: zxporter-nodemon
     app.kubernetes.io/instance: zxporter-nodemon
-    app.kubernetes.io/version: "0.1.4"
+    app.kubernetes.io/version: "0.1.5"
     app.kubernetes.io/managed-by: Helm
 rules:
   - apiGroups:
@@ -893,10 +893,10 @@ kind: ClusterRoleBinding
 metadata:
   name: zxporter-nodemon
   labels:
-    helm.sh/chart: zxporter-nodemon-0.1.4
+    helm.sh/chart: zxporter-nodemon-0.1.5
     app.kubernetes.io/name: zxporter-nodemon
     app.kubernetes.io/instance: zxporter-nodemon
-    app.kubernetes.io/version: "0.1.4"
+    app.kubernetes.io/version: "0.1.5"
     app.kubernetes.io/managed-by: Helm
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -914,10 +914,10 @@ metadata:
   name: zxporter-nodemon
   namespace: '{{.zxporter_namespace}}'
   labels:
-    helm.sh/chart: zxporter-nodemon-0.1.4
+    helm.sh/chart: zxporter-nodemon-0.1.5
     app.kubernetes.io/name: zxporter-nodemon
     app.kubernetes.io/instance: zxporter-nodemon
-    app.kubernetes.io/version: "0.1.4"
+    app.kubernetes.io/version: "0.1.5"
     app.kubernetes.io/managed-by: Helm
   annotations:
     ignore-check.kube-linter.io/privileged-container: "This daemon set needs to run DCGM Exporter as privileged to access the GPU metrics."
@@ -1001,6 +1001,11 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: metadata.namespace
+            # Cap GOMAXPROCS: nodemon has no CPU limit, so on high-core GPU nodes
+            # the Go runtime would otherwise size P's/GC workers to the full node
+            # core count, inflating baseline memory. nodemon's work is light.
+            - name: "GOMAXPROCS"
+              value: "2"
             - name: "RUNTIME_METRICS_ENABLED"
               value: "false"
             - name: "CGROUP_METRICS_ENABLED"
@@ -1066,10 +1071,10 @@ metadata:
   name: zxporter-nodemon-gpu
   namespace: '{{.zxporter_namespace}}'
   labels:
-    helm.sh/chart: zxporter-nodemon-0.1.4
+    helm.sh/chart: zxporter-nodemon-0.1.5
     app.kubernetes.io/name: zxporter-nodemon
     app.kubernetes.io/instance: zxporter-nodemon-gpu
-    app.kubernetes.io/version: "0.1.4"
+    app.kubernetes.io/version: "0.1.5"
     app.kubernetes.io/managed-by: Helm
   annotations:
     ignore-check.kube-linter.io/privileged-container: "This daemon set needs to run DCGM Exporter as privileged to access the GPU metrics."
@@ -1156,6 +1161,11 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: metadata.namespace
+            # Cap GOMAXPROCS: nodemon has no CPU limit, so on high-core GPU nodes
+            # the Go runtime would otherwise size P's/GC workers to the full node
+            # core count, inflating baseline memory. nodemon's work is light.
+            - name: "GOMAXPROCS"
+              value: "2"
             - name: "RUNTIME_METRICS_ENABLED"
               value: "false"
             - name: "CGROUP_METRICS_ENABLED"

--- a/dist/installer_updater-gcp.yaml
+++ b/dist/installer_updater-gcp.yaml
@@ -767,10 +767,10 @@ metadata:
   name: zxporter-nodemon
   namespace: '{{.zxporter_namespace}}'
   labels:
-    helm.sh/chart: zxporter-nodemon-0.1.4
+    helm.sh/chart: zxporter-nodemon-0.1.5
     app.kubernetes.io/name: zxporter-nodemon
     app.kubernetes.io/instance: zxporter-nodemon
-    app.kubernetes.io/version: "0.1.4"
+    app.kubernetes.io/version: "0.1.5"
     app.kubernetes.io/managed-by: Helm
 ---
 # Source: zxporter-nodemon/templates/dcgm-exporter-configmap.yaml
@@ -843,10 +843,10 @@ kind: ClusterRole
 metadata:
   name: zxporter-nodemon
   labels:
-    helm.sh/chart: zxporter-nodemon-0.1.4
+    helm.sh/chart: zxporter-nodemon-0.1.5
     app.kubernetes.io/name: zxporter-nodemon
     app.kubernetes.io/instance: zxporter-nodemon
-    app.kubernetes.io/version: "0.1.4"
+    app.kubernetes.io/version: "0.1.5"
     app.kubernetes.io/managed-by: Helm
 rules:
   - apiGroups:
@@ -894,10 +894,10 @@ kind: ClusterRoleBinding
 metadata:
   name: zxporter-nodemon
   labels:
-    helm.sh/chart: zxporter-nodemon-0.1.4
+    helm.sh/chart: zxporter-nodemon-0.1.5
     app.kubernetes.io/name: zxporter-nodemon
     app.kubernetes.io/instance: zxporter-nodemon
-    app.kubernetes.io/version: "0.1.4"
+    app.kubernetes.io/version: "0.1.5"
     app.kubernetes.io/managed-by: Helm
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -915,10 +915,10 @@ metadata:
   name: zxporter-nodemon
   namespace: '{{.zxporter_namespace}}'
   labels:
-    helm.sh/chart: zxporter-nodemon-0.1.4
+    helm.sh/chart: zxporter-nodemon-0.1.5
     app.kubernetes.io/name: zxporter-nodemon
     app.kubernetes.io/instance: zxporter-nodemon
-    app.kubernetes.io/version: "0.1.4"
+    app.kubernetes.io/version: "0.1.5"
     app.kubernetes.io/managed-by: Helm
   annotations:
     ignore-check.kube-linter.io/privileged-container: "This daemon set needs to run DCGM Exporter as privileged to access the GPU metrics."
@@ -1007,6 +1007,11 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: metadata.namespace
+            # Cap GOMAXPROCS: nodemon has no CPU limit, so on high-core GPU nodes
+            # the Go runtime would otherwise size P's/GC workers to the full node
+            # core count, inflating baseline memory. nodemon's work is light.
+            - name: "GOMAXPROCS"
+              value: "2"
             - name: "RUNTIME_METRICS_ENABLED"
               value: "true"
             - name: "CGROUP_METRICS_ENABLED"
@@ -1072,10 +1077,10 @@ metadata:
   name: zxporter-nodemon-gpu
   namespace: '{{.zxporter_namespace}}'
   labels:
-    helm.sh/chart: zxporter-nodemon-0.1.4
+    helm.sh/chart: zxporter-nodemon-0.1.5
     app.kubernetes.io/name: zxporter-nodemon
     app.kubernetes.io/instance: zxporter-nodemon-gpu
-    app.kubernetes.io/version: "0.1.4"
+    app.kubernetes.io/version: "0.1.5"
     app.kubernetes.io/managed-by: Helm
   annotations:
     ignore-check.kube-linter.io/privileged-container: "This daemon set needs to run DCGM Exporter as privileged to access the GPU metrics."
@@ -1167,6 +1172,11 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: metadata.namespace
+            # Cap GOMAXPROCS: nodemon has no CPU limit, so on high-core GPU nodes
+            # the Go runtime would otherwise size P's/GC workers to the full node
+            # core count, inflating baseline memory. nodemon's work is light.
+            - name: "GOMAXPROCS"
+              value: "2"
             - name: "RUNTIME_METRICS_ENABLED"
               value: "true"
             - name: "CGROUP_METRICS_ENABLED"

--- a/dist/installer_updater-lowpriv.yaml
+++ b/dist/installer_updater-lowpriv.yaml
@@ -767,10 +767,10 @@ metadata:
   name: zxporter-nodemon
   namespace: '{{.zxporter_namespace}}'
   labels:
-    helm.sh/chart: zxporter-nodemon-0.1.4
+    helm.sh/chart: zxporter-nodemon-0.1.5
     app.kubernetes.io/name: zxporter-nodemon
     app.kubernetes.io/instance: zxporter-nodemon
-    app.kubernetes.io/version: "0.1.4"
+    app.kubernetes.io/version: "0.1.5"
     app.kubernetes.io/managed-by: Helm
 ---
 # Source: zxporter-nodemon/templates/dcgm-exporter-configmap.yaml
@@ -843,10 +843,10 @@ kind: ClusterRole
 metadata:
   name: zxporter-nodemon
   labels:
-    helm.sh/chart: zxporter-nodemon-0.1.4
+    helm.sh/chart: zxporter-nodemon-0.1.5
     app.kubernetes.io/name: zxporter-nodemon
     app.kubernetes.io/instance: zxporter-nodemon
-    app.kubernetes.io/version: "0.1.4"
+    app.kubernetes.io/version: "0.1.5"
     app.kubernetes.io/managed-by: Helm
 rules:
   - apiGroups:
@@ -893,10 +893,10 @@ kind: ClusterRoleBinding
 metadata:
   name: zxporter-nodemon
   labels:
-    helm.sh/chart: zxporter-nodemon-0.1.4
+    helm.sh/chart: zxporter-nodemon-0.1.5
     app.kubernetes.io/name: zxporter-nodemon
     app.kubernetes.io/instance: zxporter-nodemon
-    app.kubernetes.io/version: "0.1.4"
+    app.kubernetes.io/version: "0.1.5"
     app.kubernetes.io/managed-by: Helm
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -914,10 +914,10 @@ metadata:
   name: zxporter-nodemon
   namespace: '{{.zxporter_namespace}}'
   labels:
-    helm.sh/chart: zxporter-nodemon-0.1.4
+    helm.sh/chart: zxporter-nodemon-0.1.5
     app.kubernetes.io/name: zxporter-nodemon
     app.kubernetes.io/instance: zxporter-nodemon
-    app.kubernetes.io/version: "0.1.4"
+    app.kubernetes.io/version: "0.1.5"
     app.kubernetes.io/managed-by: Helm
   annotations:
     ignore-check.kube-linter.io/privileged-container: "This daemon set needs to run DCGM Exporter as privileged to access the GPU metrics."
@@ -998,6 +998,11 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: metadata.namespace
+            # Cap GOMAXPROCS: nodemon has no CPU limit, so on high-core GPU nodes
+            # the Go runtime would otherwise size P's/GC workers to the full node
+            # core count, inflating baseline memory. nodemon's work is light.
+            - name: "GOMAXPROCS"
+              value: "2"
             - name: "RUNTIME_METRICS_ENABLED"
               value: "false"
             - name: "CGROUP_METRICS_ENABLED"
@@ -1056,10 +1061,10 @@ metadata:
   name: zxporter-nodemon-gpu
   namespace: '{{.zxporter_namespace}}'
   labels:
-    helm.sh/chart: zxporter-nodemon-0.1.4
+    helm.sh/chart: zxporter-nodemon-0.1.5
     app.kubernetes.io/name: zxporter-nodemon
     app.kubernetes.io/instance: zxporter-nodemon-gpu
-    app.kubernetes.io/version: "0.1.4"
+    app.kubernetes.io/version: "0.1.5"
     app.kubernetes.io/managed-by: Helm
   annotations:
     ignore-check.kube-linter.io/privileged-container: "This daemon set needs to run DCGM Exporter as privileged to access the GPU metrics."
@@ -1143,6 +1148,11 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: metadata.namespace
+            # Cap GOMAXPROCS: nodemon has no CPU limit, so on high-core GPU nodes
+            # the Go runtime would otherwise size P's/GC workers to the full node
+            # core count, inflating baseline memory. nodemon's work is light.
+            - name: "GOMAXPROCS"
+              value: "2"
             - name: "RUNTIME_METRICS_ENABLED"
               value: "false"
             - name: "CGROUP_METRICS_ENABLED"

--- a/dist/installer_updater.yaml
+++ b/dist/installer_updater.yaml
@@ -767,10 +767,10 @@ metadata:
   name: zxporter-nodemon
   namespace: '{{.zxporter_namespace}}'
   labels:
-    helm.sh/chart: zxporter-nodemon-0.1.4
+    helm.sh/chart: zxporter-nodemon-0.1.5
     app.kubernetes.io/name: zxporter-nodemon
     app.kubernetes.io/instance: zxporter-nodemon
-    app.kubernetes.io/version: "0.1.4"
+    app.kubernetes.io/version: "0.1.5"
     app.kubernetes.io/managed-by: Helm
 ---
 # Source: zxporter-nodemon/templates/dcgm-exporter-configmap.yaml
@@ -843,10 +843,10 @@ kind: ClusterRole
 metadata:
   name: zxporter-nodemon
   labels:
-    helm.sh/chart: zxporter-nodemon-0.1.4
+    helm.sh/chart: zxporter-nodemon-0.1.5
     app.kubernetes.io/name: zxporter-nodemon
     app.kubernetes.io/instance: zxporter-nodemon
-    app.kubernetes.io/version: "0.1.4"
+    app.kubernetes.io/version: "0.1.5"
     app.kubernetes.io/managed-by: Helm
 rules:
   - apiGroups:
@@ -894,10 +894,10 @@ kind: ClusterRoleBinding
 metadata:
   name: zxporter-nodemon
   labels:
-    helm.sh/chart: zxporter-nodemon-0.1.4
+    helm.sh/chart: zxporter-nodemon-0.1.5
     app.kubernetes.io/name: zxporter-nodemon
     app.kubernetes.io/instance: zxporter-nodemon
-    app.kubernetes.io/version: "0.1.4"
+    app.kubernetes.io/version: "0.1.5"
     app.kubernetes.io/managed-by: Helm
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -915,10 +915,10 @@ metadata:
   name: zxporter-nodemon
   namespace: '{{.zxporter_namespace}}'
   labels:
-    helm.sh/chart: zxporter-nodemon-0.1.4
+    helm.sh/chart: zxporter-nodemon-0.1.5
     app.kubernetes.io/name: zxporter-nodemon
     app.kubernetes.io/instance: zxporter-nodemon
-    app.kubernetes.io/version: "0.1.4"
+    app.kubernetes.io/version: "0.1.5"
     app.kubernetes.io/managed-by: Helm
   annotations:
     ignore-check.kube-linter.io/privileged-container: "This daemon set needs to run DCGM Exporter as privileged to access the GPU metrics."
@@ -1004,6 +1004,11 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: metadata.namespace
+            # Cap GOMAXPROCS: nodemon has no CPU limit, so on high-core GPU nodes
+            # the Go runtime would otherwise size P's/GC workers to the full node
+            # core count, inflating baseline memory. nodemon's work is light.
+            - name: "GOMAXPROCS"
+              value: "2"
             - name: "RUNTIME_METRICS_ENABLED"
               value: "true"
             - name: "CGROUP_METRICS_ENABLED"
@@ -1062,10 +1067,10 @@ metadata:
   name: zxporter-nodemon-gpu
   namespace: '{{.zxporter_namespace}}'
   labels:
-    helm.sh/chart: zxporter-nodemon-0.1.4
+    helm.sh/chart: zxporter-nodemon-0.1.5
     app.kubernetes.io/name: zxporter-nodemon
     app.kubernetes.io/instance: zxporter-nodemon-gpu
-    app.kubernetes.io/version: "0.1.4"
+    app.kubernetes.io/version: "0.1.5"
     app.kubernetes.io/managed-by: Helm
   annotations:
     ignore-check.kube-linter.io/privileged-container: "This daemon set needs to run DCGM Exporter as privileged to access the GPU metrics."
@@ -1154,6 +1159,11 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: metadata.namespace
+            # Cap GOMAXPROCS: nodemon has no CPU limit, so on high-core GPU nodes
+            # the Go runtime would otherwise size P's/GC workers to the full node
+            # core count, inflating baseline memory. nodemon's work is light.
+            - name: "GOMAXPROCS"
+              value: "2"
             - name: "RUNTIME_METRICS_ENABLED"
               value: "true"
             - name: "CGROUP_METRICS_ENABLED"

--- a/dist/nodemon-gcp-lowpriv.yaml
+++ b/dist/nodemon-gcp-lowpriv.yaml
@@ -6,10 +6,10 @@ metadata:
   name: zxporter-nodemon
   namespace: devzero-system
   labels:
-    helm.sh/chart: zxporter-nodemon-0.1.4
+    helm.sh/chart: zxporter-nodemon-0.1.5
     app.kubernetes.io/name: zxporter-nodemon
     app.kubernetes.io/instance: zxporter-nodemon
-    app.kubernetes.io/version: "0.1.4"
+    app.kubernetes.io/version: "0.1.5"
     app.kubernetes.io/managed-by: Helm
 ---
 # Source: zxporter-nodemon/templates/dcgm-exporter-configmap.yaml
@@ -82,10 +82,10 @@ kind: ClusterRole
 metadata:
   name: zxporter-nodemon
   labels:
-    helm.sh/chart: zxporter-nodemon-0.1.4
+    helm.sh/chart: zxporter-nodemon-0.1.5
     app.kubernetes.io/name: zxporter-nodemon
     app.kubernetes.io/instance: zxporter-nodemon
-    app.kubernetes.io/version: "0.1.4"
+    app.kubernetes.io/version: "0.1.5"
     app.kubernetes.io/managed-by: Helm
 rules:
 - apiGroups:
@@ -132,10 +132,10 @@ kind: ClusterRoleBinding
 metadata:
   name: zxporter-nodemon
   labels:
-    helm.sh/chart: zxporter-nodemon-0.1.4
+    helm.sh/chart: zxporter-nodemon-0.1.5
     app.kubernetes.io/name: zxporter-nodemon
     app.kubernetes.io/instance: zxporter-nodemon
-    app.kubernetes.io/version: "0.1.4"
+    app.kubernetes.io/version: "0.1.5"
     app.kubernetes.io/managed-by: Helm
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -153,10 +153,10 @@ metadata:
   name: zxporter-nodemon
   namespace: devzero-system
   labels:
-    helm.sh/chart: zxporter-nodemon-0.1.4
+    helm.sh/chart: zxporter-nodemon-0.1.5
     app.kubernetes.io/name: zxporter-nodemon
     app.kubernetes.io/instance: zxporter-nodemon
-    app.kubernetes.io/version: "0.1.4"
+    app.kubernetes.io/version: "0.1.5"
     app.kubernetes.io/managed-by: Helm
   annotations:
     ignore-check.kube-linter.io/privileged-container: "This daemon set needs to run DCGM Exporter as privileged to access the GPU metrics."
@@ -240,6 +240,11 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: metadata.namespace
+            # Cap GOMAXPROCS: nodemon has no CPU limit, so on high-core GPU nodes
+            # the Go runtime would otherwise size P's/GC workers to the full node
+            # core count, inflating baseline memory. nodemon's work is light.
+            - name: "GOMAXPROCS"
+              value: "2"
             - name: "RUNTIME_METRICS_ENABLED"
               value: "false"
             - name: "CGROUP_METRICS_ENABLED"
@@ -305,10 +310,10 @@ metadata:
   name: zxporter-nodemon-gpu
   namespace: devzero-system
   labels:
-    helm.sh/chart: zxporter-nodemon-0.1.4
+    helm.sh/chart: zxporter-nodemon-0.1.5
     app.kubernetes.io/name: zxporter-nodemon
     app.kubernetes.io/instance: zxporter-nodemon-gpu
-    app.kubernetes.io/version: "0.1.4"
+    app.kubernetes.io/version: "0.1.5"
     app.kubernetes.io/managed-by: Helm
   annotations:
     ignore-check.kube-linter.io/privileged-container: "This daemon set needs to run DCGM Exporter as privileged to access the GPU metrics."
@@ -395,6 +400,11 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: metadata.namespace
+            # Cap GOMAXPROCS: nodemon has no CPU limit, so on high-core GPU nodes
+            # the Go runtime would otherwise size P's/GC workers to the full node
+            # core count, inflating baseline memory. nodemon's work is light.
+            - name: "GOMAXPROCS"
+              value: "2"
             - name: "RUNTIME_METRICS_ENABLED"
               value: "false"
             - name: "CGROUP_METRICS_ENABLED"

--- a/dist/nodemon-gcp.yaml
+++ b/dist/nodemon-gcp.yaml
@@ -6,10 +6,10 @@ metadata:
   name: zxporter-nodemon
   namespace: devzero-system
   labels:
-    helm.sh/chart: zxporter-nodemon-0.1.4
+    helm.sh/chart: zxporter-nodemon-0.1.5
     app.kubernetes.io/name: zxporter-nodemon
     app.kubernetes.io/instance: zxporter-nodemon
-    app.kubernetes.io/version: "0.1.4"
+    app.kubernetes.io/version: "0.1.5"
     app.kubernetes.io/managed-by: Helm
 ---
 # Source: zxporter-nodemon/templates/dcgm-exporter-configmap.yaml
@@ -82,10 +82,10 @@ kind: ClusterRole
 metadata:
   name: zxporter-nodemon
   labels:
-    helm.sh/chart: zxporter-nodemon-0.1.4
+    helm.sh/chart: zxporter-nodemon-0.1.5
     app.kubernetes.io/name: zxporter-nodemon
     app.kubernetes.io/instance: zxporter-nodemon
-    app.kubernetes.io/version: "0.1.4"
+    app.kubernetes.io/version: "0.1.5"
     app.kubernetes.io/managed-by: Helm
 rules:
 - apiGroups:
@@ -133,10 +133,10 @@ kind: ClusterRoleBinding
 metadata:
   name: zxporter-nodemon
   labels:
-    helm.sh/chart: zxporter-nodemon-0.1.4
+    helm.sh/chart: zxporter-nodemon-0.1.5
     app.kubernetes.io/name: zxporter-nodemon
     app.kubernetes.io/instance: zxporter-nodemon
-    app.kubernetes.io/version: "0.1.4"
+    app.kubernetes.io/version: "0.1.5"
     app.kubernetes.io/managed-by: Helm
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -154,10 +154,10 @@ metadata:
   name: zxporter-nodemon
   namespace: devzero-system
   labels:
-    helm.sh/chart: zxporter-nodemon-0.1.4
+    helm.sh/chart: zxporter-nodemon-0.1.5
     app.kubernetes.io/name: zxporter-nodemon
     app.kubernetes.io/instance: zxporter-nodemon
-    app.kubernetes.io/version: "0.1.4"
+    app.kubernetes.io/version: "0.1.5"
     app.kubernetes.io/managed-by: Helm
   annotations:
     ignore-check.kube-linter.io/privileged-container: "This daemon set needs to run DCGM Exporter as privileged to access the GPU metrics."
@@ -246,6 +246,11 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: metadata.namespace
+            # Cap GOMAXPROCS: nodemon has no CPU limit, so on high-core GPU nodes
+            # the Go runtime would otherwise size P's/GC workers to the full node
+            # core count, inflating baseline memory. nodemon's work is light.
+            - name: "GOMAXPROCS"
+              value: "2"
             - name: "RUNTIME_METRICS_ENABLED"
               value: "true"
             - name: "CGROUP_METRICS_ENABLED"
@@ -311,10 +316,10 @@ metadata:
   name: zxporter-nodemon-gpu
   namespace: devzero-system
   labels:
-    helm.sh/chart: zxporter-nodemon-0.1.4
+    helm.sh/chart: zxporter-nodemon-0.1.5
     app.kubernetes.io/name: zxporter-nodemon
     app.kubernetes.io/instance: zxporter-nodemon-gpu
-    app.kubernetes.io/version: "0.1.4"
+    app.kubernetes.io/version: "0.1.5"
     app.kubernetes.io/managed-by: Helm
   annotations:
     ignore-check.kube-linter.io/privileged-container: "This daemon set needs to run DCGM Exporter as privileged to access the GPU metrics."
@@ -406,6 +411,11 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: metadata.namespace
+            # Cap GOMAXPROCS: nodemon has no CPU limit, so on high-core GPU nodes
+            # the Go runtime would otherwise size P's/GC workers to the full node
+            # core count, inflating baseline memory. nodemon's work is light.
+            - name: "GOMAXPROCS"
+              value: "2"
             - name: "RUNTIME_METRICS_ENABLED"
               value: "true"
             - name: "CGROUP_METRICS_ENABLED"

--- a/dist/nodemon-lowpriv.yaml
+++ b/dist/nodemon-lowpriv.yaml
@@ -6,10 +6,10 @@ metadata:
   name: zxporter-nodemon
   namespace: devzero-system
   labels:
-    helm.sh/chart: zxporter-nodemon-0.1.4
+    helm.sh/chart: zxporter-nodemon-0.1.5
     app.kubernetes.io/name: zxporter-nodemon
     app.kubernetes.io/instance: zxporter-nodemon
-    app.kubernetes.io/version: "0.1.4"
+    app.kubernetes.io/version: "0.1.5"
     app.kubernetes.io/managed-by: Helm
 ---
 # Source: zxporter-nodemon/templates/dcgm-exporter-configmap.yaml
@@ -82,10 +82,10 @@ kind: ClusterRole
 metadata:
   name: zxporter-nodemon
   labels:
-    helm.sh/chart: zxporter-nodemon-0.1.4
+    helm.sh/chart: zxporter-nodemon-0.1.5
     app.kubernetes.io/name: zxporter-nodemon
     app.kubernetes.io/instance: zxporter-nodemon
-    app.kubernetes.io/version: "0.1.4"
+    app.kubernetes.io/version: "0.1.5"
     app.kubernetes.io/managed-by: Helm
 rules:
 - apiGroups:
@@ -132,10 +132,10 @@ kind: ClusterRoleBinding
 metadata:
   name: zxporter-nodemon
   labels:
-    helm.sh/chart: zxporter-nodemon-0.1.4
+    helm.sh/chart: zxporter-nodemon-0.1.5
     app.kubernetes.io/name: zxporter-nodemon
     app.kubernetes.io/instance: zxporter-nodemon
-    app.kubernetes.io/version: "0.1.4"
+    app.kubernetes.io/version: "0.1.5"
     app.kubernetes.io/managed-by: Helm
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -153,10 +153,10 @@ metadata:
   name: zxporter-nodemon
   namespace: devzero-system
   labels:
-    helm.sh/chart: zxporter-nodemon-0.1.4
+    helm.sh/chart: zxporter-nodemon-0.1.5
     app.kubernetes.io/name: zxporter-nodemon
     app.kubernetes.io/instance: zxporter-nodemon
-    app.kubernetes.io/version: "0.1.4"
+    app.kubernetes.io/version: "0.1.5"
     app.kubernetes.io/managed-by: Helm
   annotations:
     ignore-check.kube-linter.io/privileged-container: "This daemon set needs to run DCGM Exporter as privileged to access the GPU metrics."
@@ -237,6 +237,11 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: metadata.namespace
+            # Cap GOMAXPROCS: nodemon has no CPU limit, so on high-core GPU nodes
+            # the Go runtime would otherwise size P's/GC workers to the full node
+            # core count, inflating baseline memory. nodemon's work is light.
+            - name: "GOMAXPROCS"
+              value: "2"
             - name: "RUNTIME_METRICS_ENABLED"
               value: "false"
             - name: "CGROUP_METRICS_ENABLED"
@@ -295,10 +300,10 @@ metadata:
   name: zxporter-nodemon-gpu
   namespace: devzero-system
   labels:
-    helm.sh/chart: zxporter-nodemon-0.1.4
+    helm.sh/chart: zxporter-nodemon-0.1.5
     app.kubernetes.io/name: zxporter-nodemon
     app.kubernetes.io/instance: zxporter-nodemon-gpu
-    app.kubernetes.io/version: "0.1.4"
+    app.kubernetes.io/version: "0.1.5"
     app.kubernetes.io/managed-by: Helm
   annotations:
     ignore-check.kube-linter.io/privileged-container: "This daemon set needs to run DCGM Exporter as privileged to access the GPU metrics."
@@ -382,6 +387,11 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: metadata.namespace
+            # Cap GOMAXPROCS: nodemon has no CPU limit, so on high-core GPU nodes
+            # the Go runtime would otherwise size P's/GC workers to the full node
+            # core count, inflating baseline memory. nodemon's work is light.
+            - name: "GOMAXPROCS"
+              value: "2"
             - name: "RUNTIME_METRICS_ENABLED"
               value: "false"
             - name: "CGROUP_METRICS_ENABLED"

--- a/dist/nodemon.yaml
+++ b/dist/nodemon.yaml
@@ -6,10 +6,10 @@ metadata:
   name: zxporter-nodemon
   namespace: devzero-system
   labels:
-    helm.sh/chart: zxporter-nodemon-0.1.4
+    helm.sh/chart: zxporter-nodemon-0.1.5
     app.kubernetes.io/name: zxporter-nodemon
     app.kubernetes.io/instance: zxporter-nodemon
-    app.kubernetes.io/version: "0.1.4"
+    app.kubernetes.io/version: "0.1.5"
     app.kubernetes.io/managed-by: Helm
 ---
 # Source: zxporter-nodemon/templates/dcgm-exporter-configmap.yaml
@@ -82,10 +82,10 @@ kind: ClusterRole
 metadata:
   name: zxporter-nodemon
   labels:
-    helm.sh/chart: zxporter-nodemon-0.1.4
+    helm.sh/chart: zxporter-nodemon-0.1.5
     app.kubernetes.io/name: zxporter-nodemon
     app.kubernetes.io/instance: zxporter-nodemon
-    app.kubernetes.io/version: "0.1.4"
+    app.kubernetes.io/version: "0.1.5"
     app.kubernetes.io/managed-by: Helm
 rules:
 - apiGroups:
@@ -133,10 +133,10 @@ kind: ClusterRoleBinding
 metadata:
   name: zxporter-nodemon
   labels:
-    helm.sh/chart: zxporter-nodemon-0.1.4
+    helm.sh/chart: zxporter-nodemon-0.1.5
     app.kubernetes.io/name: zxporter-nodemon
     app.kubernetes.io/instance: zxporter-nodemon
-    app.kubernetes.io/version: "0.1.4"
+    app.kubernetes.io/version: "0.1.5"
     app.kubernetes.io/managed-by: Helm
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -154,10 +154,10 @@ metadata:
   name: zxporter-nodemon
   namespace: devzero-system
   labels:
-    helm.sh/chart: zxporter-nodemon-0.1.4
+    helm.sh/chart: zxporter-nodemon-0.1.5
     app.kubernetes.io/name: zxporter-nodemon
     app.kubernetes.io/instance: zxporter-nodemon
-    app.kubernetes.io/version: "0.1.4"
+    app.kubernetes.io/version: "0.1.5"
     app.kubernetes.io/managed-by: Helm
   annotations:
     ignore-check.kube-linter.io/privileged-container: "This daemon set needs to run DCGM Exporter as privileged to access the GPU metrics."
@@ -243,6 +243,11 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: metadata.namespace
+            # Cap GOMAXPROCS: nodemon has no CPU limit, so on high-core GPU nodes
+            # the Go runtime would otherwise size P's/GC workers to the full node
+            # core count, inflating baseline memory. nodemon's work is light.
+            - name: "GOMAXPROCS"
+              value: "2"
             - name: "RUNTIME_METRICS_ENABLED"
               value: "true"
             - name: "CGROUP_METRICS_ENABLED"
@@ -301,10 +306,10 @@ metadata:
   name: zxporter-nodemon-gpu
   namespace: devzero-system
   labels:
-    helm.sh/chart: zxporter-nodemon-0.1.4
+    helm.sh/chart: zxporter-nodemon-0.1.5
     app.kubernetes.io/name: zxporter-nodemon
     app.kubernetes.io/instance: zxporter-nodemon-gpu
-    app.kubernetes.io/version: "0.1.4"
+    app.kubernetes.io/version: "0.1.5"
     app.kubernetes.io/managed-by: Helm
   annotations:
     ignore-check.kube-linter.io/privileged-container: "This daemon set needs to run DCGM Exporter as privileged to access the GPU metrics."
@@ -393,6 +398,11 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: metadata.namespace
+            # Cap GOMAXPROCS: nodemon has no CPU limit, so on high-core GPU nodes
+            # the Go runtime would otherwise size P's/GC workers to the full node
+            # core count, inflating baseline memory. nodemon's work is light.
+            - name: "GOMAXPROCS"
+              value: "2"
             - name: "RUNTIME_METRICS_ENABLED"
               value: "true"
             - name: "CGROUP_METRICS_ENABLED"

--- a/docs/specs/2026-07-30-nodemon-gpu-memory-design.md
+++ b/docs/specs/2026-07-30-nodemon-gpu-memory-design.md
@@ -1,0 +1,100 @@
+# Nodemon GPU Memory — OOM Fix
+
+**Date:** 2026-07-30
+**Component:** `operators/zxporter` — `zxporter-nodemon` DaemonSet (GPU nodes)
+**Status:** Approved — A+C this pass, B as follow-up. Keep the 256Mi limit.
+
+## Problem
+
+`zxporter-nodemon-gpu-*` pods OOM at their **256Mi** cgroup cap (observed
+12:05 and 12:31, OOM → restart → OOM). Non-GPU nodemon peaks at ~107MB; GPU
+nodemon reaches 256MB+. The entire delta is the **DCGM scrape+parse path**,
+which only runs on GPU nodes.
+
+### Root cause (three compounding factors)
+
+1. **Full-export parse.** `scraper.go` calls
+   `expfmt.TextToMetricFamilies(resp.Body)`, materializing the *entire* DCGM
+   export as a pointer-dense object graph (`*MetricFamily`→`[]*Metric`→
+   `[]*LabelPair`, values `*float64`). The `EnabledMetrics` filter (~30 metrics)
+   runs only *after* the full parse (`mapper.go`), so every series is
+   materialized then mostly discarded. This is the peak.
+2. **Redundant/overlapping parses.** GPU DCGM is parsed on two independent
+   paths: the 30s unified loop *and* every `/container/metrics` request
+   (`handler.go` → `QueryMetrics` re-scrapes per request; the collector hits it
+   once per node per cycle). Overlap → concurrent parses → additive peak.
+3. **No runtime containment.** The nodemon binary
+   (`cmd/zxporter-nodemon/main.go`) does not import `automemlimit` (only the
+   controller-manager does), and has **no CPU limit** — so on a 100+‑core GPU
+   node `GOMAXPROCS` = core count, inflating per-P mcaches and GC worker count.
+   With `GOGC=100` and no soft limit, a transient parse burst sails past the
+   256Mi cap before GC runs.
+
+### Consumer cadence (data-quality anchor)
+
+- DCGM exporter refreshes every **5s** (`DCGM_EXPORTER_INTERVAL=5000`).
+- The container collector polls `/container/metrics` every **10s**
+  (`container_resource_collector.go`, default `UpdateInterval`).
+- So today's per-request scrape already yields ~10s-granular data downstream.
+
+## Data-quality invariants (must not break)
+
+1. **Value fidelity** — enabled metric values byte-identical to today.
+2. **Full cardinality** — every GPU×pod×container×MIG series still emitted.
+3. **Freshness** — no consumer sees staler data than today. Cache refresh
+   interval ∈ [5s (DCGM), 10s (collector poll)]. 10s is data-quality-neutral.
+
+## Fixes
+
+### This pass
+
+**Fix A — Single shared, periodically-refreshed GPU snapshot.**
+Wrap the GPU `*Exporter` with a cache: `[]GPUMetric` + `lastRefresh` +
+`lastErr`, guarded by `RWMutex`. A single background goroutine
+(`Start(ctx)`) scrapes+parses+maps on a ticker (default **10s**, env
+`GPU_REFRESH_INTERVAL`, clamped ≥5s). `QueryMetrics` becomes a non-blocking
+cache read. Both the legacy `/container/metrics` handler and the unified
+exporter's `fetchGPU` read the snapshot → **exactly one parse per interval**,
+independent of request rate; no overlapping parses.
+- *Staleness guard:* if `now - lastRefresh > k×interval`, still serve the
+  snapshot but log + flag stale (protects quality; never silently serves very
+  old data).
+- *Decoupled from the 30s unified loop* — GPU refresh runs at 10s so GPU
+  granularity is preserved.
+
+**Fix C — Runtime containment.**
+- Import `automemlimit` in `cmd/zxporter-nodemon/main.go`; log effective
+  `GOMEMLIMIT` (mirror the controller-manager).
+- Pin `GOMAXPROCS` low via env (e.g. `2`–`4`) in the DaemonSet — nodemon's work
+  is light; avoids the high-core baseline. (Preferred over adding a CPU limit,
+  which causes CFS throttling.)
+- **Keep the 256Mi limit** (per decision). `GOMEMLIMIT` derives from it.
+
+### Follow-up (next PR)
+
+**Fix B — Streaming, filter-during-parse.**
+Replace `TextToMetricFamilies` with a dependency-free streaming parser
+(`bufio.Reader` over `io.LimitReader(body)`) that keeps only
+`EnabledMetrics` lines and discards the rest immediately. Avoid
+`prometheus/prometheus/model/textparse` (heavy dep tree). Peak drops from
+"whole export" to "≈30 kept series."
+- **Gate:** golden-sample parity test — a captured DCGM `/metrics` body run
+  through both the current `TextToMetricFamilies`+mapper and the new parser must
+  yield identical `[]GPUMetric`. This guarantees B changes memory, not data.
+
+## Risk called out
+
+Keeping 256Mi while deferring B means A+C must fit **one** DCGM parse + reduced
+baseline under 256Mi. A removes the overlap peak; the `GOMAXPROCS` cut lowers
+the ~107MB floor; but a single large parse is only fully addressed by B. Read
+the pprof heap after deploy — if the single-parse peak still crowds 256Mi,
+promote B.
+
+## Verification
+
+- Unit test: legacy handler serves the cached snapshot without scraping
+  per-request; staleness guard behaves.
+- Golden-sample parity test (with Fix B).
+- Existing nodemon suite green; `just fmt` / `just lint` / build.
+- Live: pprof heap (`:6061/debug/pprof/heap`, `allocs`) before/after on a GPU
+  nodemon pod; `kubectl top` RSS.

--- a/helm-chart/zxporter-netmon/Chart.yaml
+++ b/helm-chart/zxporter-netmon/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: zxporter-netmon
 description: A Helm chart for zxporter network monitor daemonset
 type: application
-version: 0.1.4
-appVersion: "0.1.4"
+version: 0.1.5
+appVersion: "0.1.5"

--- a/helm-chart/zxporter-netmon/values.yaml
+++ b/helm-chart/zxporter-netmon/values.yaml
@@ -2,7 +2,7 @@ image:
   repository: devzeroinc/zxporter-netmon
   pullPolicy: IfNotPresent
   # Overrides the image tag whose default is the chart appVersion.
-  tag: "v0.1.4"
+  tag: "v0.1.5"
 imagePullSecrets: []
 nameOverride: ""
 fullnameOverride: ""

--- a/helm-chart/zxporter-nodemon/Chart.yaml
+++ b/helm-chart/zxporter-nodemon/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: zxporter-nodemon
 description: A Helm chart for Kubernetes
 type: application
-version: 0.1.4
-appVersion: "0.1.4"
+version: 0.1.5
+appVersion: "0.1.5"

--- a/helm-chart/zxporter-nodemon/templates/daemonset.yaml
+++ b/helm-chart/zxporter-nodemon/templates/daemonset.yaml
@@ -202,6 +202,11 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: metadata.namespace
+            # Cap GOMAXPROCS: nodemon has no CPU limit, so on high-core GPU nodes
+            # the Go runtime would otherwise size P's/GC workers to the full node
+            # core count, inflating baseline memory. nodemon's work is light.
+            - name: "GOMAXPROCS"
+              value: {{ $.Values.nodemon.goMaxProcs | default 2 | quote }}
             - name: "RUNTIME_METRICS_ENABLED"
               value: {{ $runtimeMetricsEnabled | quote }}
             - name: "CGROUP_METRICS_ENABLED"

--- a/helm-chart/zxporter-nodemon/values.yaml
+++ b/helm-chart/zxporter-nodemon/values.yaml
@@ -13,7 +13,7 @@ serviceAccount:
 image:
   repository: public.ecr.aws/devzeroinc/zxporter-nodemon
   pullPolicy: IfNotPresent
-  tag: "v0.1.4"
+  tag: "v0.1.5"
 nodemon:
   # nodemon.affinity -- optional pod affinity/anti-affinity. Leave empty so nodemon schedules on
   # EVERY node (it is the sole source of node/container metrics). Only set this if you intentionally
@@ -26,6 +26,12 @@ nodemon:
   #   DCGM_HOST: ""
   #   # comma-separated list of labels that the DCGM instances have
   #   DCGM_LABELS: ""
+  # goMaxProcs caps the Go runtime's GOMAXPROCS. nodemon runs without a CPU limit,
+  # so on high-core GPU nodes the runtime would otherwise size itself to the full
+  # node core count, inflating baseline memory (per-P caches, GC workers). Its
+  # workload is light (one DCGM scrape + kubelet polls per interval), so a small
+  # value is plenty.
+  goMaxProcs: 2
   resources:
     limits:
       memory: 256Mi

--- a/helm-chart/zxporter/Chart.lock
+++ b/helm-chart/zxporter/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: zxporter-nodemon
   repository: file://../zxporter-nodemon
-  version: 0.1.4
-digest: sha256:45bd68279f05a4f37f91e97ff40121a7d6fc60224d5a08fe1a3b06517e9202dc
-generated: "2026-07-30T18:02:57.213040776Z"
+  version: 0.1.5
+digest: sha256:83bc77246829846e128e0842eeded20811e78cf8be36ea80d6ce9017813c89cb
+generated: "2026-08-04T05:45:12.753317046Z"

--- a/helm-chart/zxporter/Chart.yaml
+++ b/helm-chart/zxporter/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v2
 name: zxporter
 description: A Helm chart for DevZero ZXPorter - Kubernetes resource monitoring and optimization
-version: 0.1.4
-appVersion: "0.1.4"
+version: 0.1.5
+appVersion: "0.1.5"
 home: https://github.com/devzero-inc/zxporter
 sources:
   - https://github.com/devzero-inc/zxporter
@@ -17,5 +17,5 @@ keywords:
   - devzero
 dependencies:
   - name: zxporter-nodemon
-    version: "0.1.4"
+    version: "0.1.5"
     repository: "file://../zxporter-nodemon"

--- a/helm-chart/zxporter/values.yaml
+++ b/helm-chart/zxporter/values.yaml
@@ -11,7 +11,7 @@
 image:
   repository: public.ecr.aws/devzeroinc/zxporter
   pullPolicy: IfNotPresent
-  tag: "v0.1.4"
+  tag: "v0.1.5"
 # ZXPorter configuration
 zxporter:
   dakrUrl: "https://dakr.devzero.io"

--- a/internal/collector/composite_request_count_test.go
+++ b/internal/collector/composite_request_count_test.go
@@ -1,0 +1,206 @@
+// internal/collector/composite_request_count_test.go
+package collector
+
+import (
+	"context"
+	"net/http"
+	"strconv"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/go-logr/logr"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/types"
+	metricsv1 "k8s.io/metrics/pkg/client/clientset/versioned"
+
+	"github.com/devzero-inc/zxporter/internal/nodemon"
+)
+
+// countingRT counts nodemon requests by endpoint family and simulates a fixed
+// per-call latency. It serves BOTH the composite and the legacy endpoints, so
+// the exact same test runs on this branch (collectors hit the composite path)
+// and on main (collectors hit the legacy path) — the request tallies below are
+// what proves the 4N-vs-2N difference.
+type countingRT struct {
+	mu           sync.Mutex
+	byPath       map[string]int
+	perCallDelay time.Duration
+}
+
+func (rt *countingRT) count(key string) int {
+	rt.mu.Lock()
+	defer rt.mu.Unlock()
+	return rt.byPath[key]
+}
+
+func (rt *countingRT) record(key string) {
+	rt.mu.Lock()
+	if rt.byPath == nil {
+		rt.byPath = map[string]int{}
+	}
+	rt.byPath[key]++
+	rt.mu.Unlock()
+}
+
+func (rt *countingRT) RoundTrip(req *http.Request) (*http.Response, error) {
+	host := req.URL.Hostname()
+	if rt.perCallDelay > 0 {
+		select {
+		case <-time.After(rt.perCallDelay):
+		case <-req.Context().Done():
+			return nil, req.Context().Err()
+		}
+	}
+	switch {
+	case strings.HasSuffix(req.URL.Path, "/v2/node/snapshot"):
+		rt.record("composite")
+		return jsonResponse(http.StatusOK, map[string]any{
+			"schema_version": 1,
+			"node_metrics": map[string]any{
+				"node_name": host, "cpu_usage_nanocores": 500_000_000, "memory_working_set_bytes": 1073741824,
+			},
+			"gpu_summary": map[string]any{"gpu_count": 0},
+			"sections":    map[string]any{"node": map[string]any{"state": "ready"}, "gpu": map[string]any{"state": "not_ready"}},
+		}), nil
+	case strings.HasSuffix(req.URL.Path, "/v2/container/snapshot"):
+		rt.record("composite")
+		return jsonResponse(http.StatusOK, map[string]any{
+			"schema_version": 1,
+			"container_metrics": []map[string]any{{
+				"node_name": host, "namespace": "ns1", "pod": "pod-" + host, "container": "app",
+				"cpu_usage_nanocores": 250_000_000, "memory_working_set_bytes": 536870912,
+			}},
+			"runtime_metrics": map[string]any{"jvm": []any{}, "runtimes": []any{}},
+			"sections":        map[string]any{"containers": map[string]any{"state": "ready"}, "runtime": map[string]any{"state": "disabled"}},
+		}), nil
+	case strings.HasSuffix(req.URL.Path, "/v2/container/metrics"):
+		rt.record("legacy")
+		return jsonResponse(http.StatusOK, []map[string]any{{
+			"node_name": host, "namespace": "ns1", "pod": "pod-" + host, "container": "app",
+			"cpu_usage_nanocores": 250_000_000, "memory_working_set_bytes": 536870912,
+		}}), nil
+	case strings.HasSuffix(req.URL.Path, "/container/runtime-metrics"):
+		rt.record("legacy")
+		return jsonResponse(http.StatusOK, map[string]any{"jvm": []any{}, "runtimes": []any{}}), nil
+	case strings.HasSuffix(req.URL.Path, "/container/metrics"): // legacy GPU (node collector)
+		rt.record("legacy")
+		return jsonResponse(http.StatusOK, []map[string]any{}), nil
+	case strings.HasSuffix(req.URL.Path, "/node/metrics"):
+		rt.record("legacy")
+		return jsonResponse(http.StatusOK, map[string]any{
+			"node_name": host, "cpu_usage_nanocores": 500_000_000, "memory_working_set_bytes": 1073741824,
+		}), nil
+	}
+	return jsonResponse(http.StatusNotFound, map[string]any{"error": "unknown " + req.URL.Path}), nil
+}
+
+// TestCollectors_CompositeAvoids4NLegacyCalls is the negative test against the
+// legacy 4N request pattern. Across N nodemon-covered nodes, the two collectors
+// on this branch issue exactly 2N nodemon requests (one composite call per node
+// per collector) and ZERO legacy per-metric calls. On main — where NodeCollector
+// still does /node/metrics + /container/metrics and ContainerResourceCollector
+// still does /v2/container/metrics + /container/runtime-metrics — the identical
+// test instead records 4N requests, all on the legacy endpoints, and fails these
+// assertions. It also logs each collector's sweep wall-clock under a fixed
+// per-call latency so the latency delta is visible in the test output on both
+// branches.
+func TestCollectors_CompositeAvoids4NLegacyCalls(t *testing.T) {
+	const (
+		numNodes     = 20 // one bounded-concurrency batch (cap is 20)
+		perCallDelay = 15 * time.Millisecond
+	)
+
+	var nodes []*corev1.Node
+	var pods []*corev1.Pod
+	nodeToIP := make(map[string]string)
+	for i := 0; i < numNodes; i++ {
+		name := "cnt-node-" + strconv.Itoa(i)
+		nodes = append(nodes, testNode(name))
+		pods = append(pods, testPod("ns1", "pod-"+name, name, "app"))
+		nodeToIP[name] = name
+	}
+
+	rt := &countingRT{perCallDelay: perCallDelay}
+	newClient := func() *NodemonClient {
+		return &NodemonClient{
+			port: 80, httpClient: &http.Client{Transport: rt}, log: logr.Discard(),
+			nodeToIP: nodeToIP, lastRefreshed: time.Now(),
+		}
+	}
+
+	// --- NodeCollector sweep ---
+	nodeInformer, nodeStop := newSyncedNodeInformer(t, nodes...)
+	defer close(nodeStop)
+	nodeBatch := make(chan CollectedResource, numNodes*8)
+	go drainForever(nodeBatch)
+	nc := &NodeCollector{
+		metricsClient:   &metricsv1.Clientset{},
+		nodemonClient:   newClient(),
+		kubeletClient:   NewKubeletSummaryClient(nil, logr.Discard(), 0),
+		nodeInformer:    nodeInformer,
+		batchChan:       nodeBatch,
+		config:          NodeCollectorConfig{DisableGPUMetrics: false},
+		excludedNodes:   map[string]bool{},
+		logger:          logr.Discard(),
+		telemetryLogger: &fakeTelemetryLogger{},
+		nodeToPodsMap:   make(map[string]map[string]*corev1.Pod),
+	}
+	nodeStart := time.Now()
+	nc.collectAllNodeResources(context.Background())
+	nodeElapsed := time.Since(nodeStart)
+	nodeComposite, nodeLegacy := rt.count("composite"), rt.count("legacy")
+
+	// --- ContainerResourceCollector sweep (fresh counter) ---
+	rt2 := &countingRT{perCallDelay: perCallDelay}
+	podInformer, podStop := newSyncedPodInformer(t, pods...)
+	defer close(podStop)
+	ctrBatch := make(chan CollectedResource, numNodes*8)
+	go drainForever(ctrBatch)
+	cc := &ContainerResourceCollector{
+		nodemonClient: &NodemonClient{
+			port: 80, httpClient: &http.Client{Transport: rt2}, log: logr.Discard(),
+			nodeToIP: nodeToIP, lastRefreshed: time.Now(),
+		},
+		kubeletClient:    NewKubeletSummaryClient(nil, logr.Discard(), 0),
+		podInformer:      podInformer,
+		batchChan:        ctrBatch,
+		config:           ContainerResourceCollectorConfig{DisableGPUMetrics: false},
+		excludedPods:     map[types.NamespacedName]bool{},
+		logger:           logr.Discard(),
+		telemetryLogger:  &fakeTelemetryLogger{},
+		throttle:         throttleTracker{lastEmitted: make(map[string]time.Time)},
+		networkByteRates: nodemon.NewRateCalculator(),
+	}
+	ctrStart := time.Now()
+	cc.collectAllContainerResources(context.Background())
+	ctrElapsed := time.Since(ctrStart)
+	ctrComposite, ctrLegacy := rt2.count("composite"), rt2.count("legacy")
+
+	total := nodeComposite + nodeLegacy + ctrComposite + ctrLegacy
+	t.Logf("N=%d per-call=%s | node: %d composite + %d legacy in %s | container: %d composite + %d legacy in %s | TOTAL requests=%d",
+		numNodes, perCallDelay,
+		nodeComposite, nodeLegacy, nodeElapsed,
+		ctrComposite, ctrLegacy, ctrElapsed, total)
+
+	// Negative assertions vs the legacy 4N pattern: composite path only.
+	if nodeLegacy != 0 || ctrLegacy != 0 {
+		t.Fatalf("collectors hit the legacy 4N endpoints (node legacy=%d, container legacy=%d); "+
+			"expected the composite path with zero legacy calls", nodeLegacy, ctrLegacy)
+	}
+	if nodeComposite != numNodes {
+		t.Fatalf("NodeCollector made %d composite requests, want exactly N=%d (one per node)", nodeComposite, numNodes)
+	}
+	if ctrComposite != numNodes {
+		t.Fatalf("ContainerResourceCollector made %d composite requests, want exactly N=%d (one per node)", ctrComposite, numNodes)
+	}
+	if total != 2*numNodes {
+		t.Fatalf("total nodemon requests=%d, want 2N=%d (the legacy path would be 4N=%d)", total, 2*numNodes, 4*numNodes)
+	}
+}
+
+func drainForever(ch <-chan CollectedResource) {
+	for range ch {
+	}
+}

--- a/internal/collector/container_resource_collector.go
+++ b/internal/collector/container_resource_collector.go
@@ -282,12 +282,15 @@ func (c *ContainerResourceCollector) collectAllContainerResources(ctx context.Co
 		}
 	}
 
-	// Fetch container metrics from nodemon ONCE and derive both the
-	// PodMetricsList (CPU/memory) and nodemonContainerMetricsCache
-	// (network/IO/throttle/GPU lookups) from the same result — this used to
-	// be two separate FetchAllContainerMetrics calls hitting the exact same
-	// endpoint on every node for identical data (see #9417).
-	allContainerMetrics, failedNodes, err := c.nodemonClient.FetchAllContainerMetrics(ctx)
+	// Fetch container resource metrics AND runtime (JVM/generic) metrics from
+	// nodemon in a single composite request wave — one /v2/container/snapshot
+	// call per nodemon pod instead of a /v2/container/metrics wave followed by a
+	// /container/runtime-metrics wave. Both sections are served from nodemon's
+	// background caches. The container metrics derive both the PodMetricsList
+	// (CPU/memory) and the nodemonContainerMetricsCache (network/IO/throttle/GPU
+	// lookups) from the same result (see #9417); the runtime section is indexed
+	// further below.
+	snapshot, err := c.nodemonClient.FetchAllContainerSnapshots(ctx)
 	if err != nil {
 		if c.telemetryLogger != nil {
 			c.telemetryLogger.Report(
@@ -306,6 +309,8 @@ func (c *ContainerResourceCollector) collectAllContainerResources(ctx context.Co
 		c.logger.Error(err, "Failed to get pod metrics", "source", "nodemon")
 		return
 	}
+	allContainerMetrics := snapshot.ContainerMetrics
+	failedNodes := snapshot.FailedContainerNodes
 
 	// Kubelet fallback: for any node that has pods but no nodemon pod — OR where
 	// the nodemon pod is Running but failed to serve metrics — scrape the kubelet
@@ -325,30 +330,46 @@ func (c *ContainerResourceCollector) collectAllContainerResources(ctx context.Co
 				"pod_count":        fmt.Sprintf("%d", len(podMetricsList.Items)),
 				"namespaces":       fmt.Sprintf("%v", c.namespaces),
 				"source":           "nodemon",
+				"composite_pods":   fmt.Sprintf("%d", snapshot.CompositeCount),
+				"legacy_fallback":  fmt.Sprintf("%d", snapshot.LegacyFallbackCount),
 				"event_type":       "metrics_query_success",
 				"zxporter_version": version.Get().String(),
 			},
 		)
 	}
 
-	// Pre-fetch JVM + Node.js metrics from the nodemon in a single combined request
-	// (one HTTP call per node, backed by one /proc walk on the nodemon side) rather
-	// than issuing two independent per-runtime fetches.
-	var jvmIndex map[gpuContainerKey]NodemonJVMMetrics
-	var runtimeProcessIndex map[gpuContainerKey][]NodemonRuntimeProcessMetrics
-	// Runtime detection is gated node-side by the Helm value
-	// runtimeMetrics.enabled — when disabled, nodemon doesn't register the
-	// route and FetchAllRuntimeMetrics quietly returns nothing. No separate
-	// collector-side flag: one gate, one source of truth.
-	if c.nodemonClient != nil {
-		runtimeMetrics, err := c.nodemonClient.FetchAllRuntimeMetrics(ctx)
-		if err != nil {
-			c.logger.Error(err, "Failed to fetch runtime metrics from nodemon")
-		} else {
-			jvmIndex = IndexJVMMetricsByContainer(runtimeMetrics.JVM)
-			runtimeProcessIndex = IndexRuntimeProcessMetricsByContainer(runtimeMetrics.Runtimes)
+	// Signal when nodemon pods served the legacy /v2/container/metrics +
+	// /container/runtime-metrics endpoints instead of the composite
+	// /v2/container/snapshot — i.e. this sweep paid the old two-request-wave
+	// cost. Expected transiently during a nodemon rolling upgrade; a persistent
+	// nonzero count means the fleet never converged to the composite path.
+	if snapshot.LegacyFallbackCount > 0 {
+		c.logger.Info("Container metrics served via legacy fallback (composite snapshot unavailable)",
+			"legacyFallbackPods", snapshot.LegacyFallbackCount, "compositePods", snapshot.CompositeCount)
+		if c.telemetryLogger != nil {
+			c.telemetryLogger.Report(
+				gen.LogLevel_LOG_LEVEL_WARN,
+				"ContainerResourceCollector",
+				"Container metrics served via legacy fallback instead of composite snapshot",
+				nil,
+				map[string]string{
+					"collector_type":   c.GetType(),
+					"legacy_fallback":  fmt.Sprintf("%d", snapshot.LegacyFallbackCount),
+					"composite_pods":   fmt.Sprintf("%d", snapshot.CompositeCount),
+					"event_type":       "nodemon_legacy_fallback",
+					"zxporter_version": version.Get().String(),
+				},
+			)
 		}
 	}
+
+	// JVM + Node.js metrics arrived in the same composite snapshot fetched above
+	// (the runtime section), so there is no second request wave here. Runtime
+	// detection is still gated node-side by the Helm value runtimeMetrics.enabled
+	// — when disabled, nodemon reports the runtime section as disabled and the
+	// snapshot carries no runtime data, so these indexes are simply empty.
+	jvmIndex := IndexJVMMetricsByContainer(snapshot.RuntimeMetrics.JVM)
+	runtimeProcessIndex := IndexRuntimeProcessMetricsByContainer(snapshot.RuntimeMetrics.Runtimes)
 
 	// Pods nodemon reported metrics for but that aren't in podByKey. This is
 	// an expected race, not a failure: nodemon's /v2/container/metrics cache
@@ -407,20 +428,19 @@ func (c *ContainerResourceCollector) collectAllContainerResources(ctx context.Co
 			// GPU metrics: requests/limits from pod spec + usage from nodemon
 			gpuMetrics = make(map[string]interface{})
 			if !c.config.DisableGPUMetrics {
-				// GPU requests/limits from the pod spec (nvidia.com/gpu resource)
-				for i := range pod.Spec.Containers {
-					if pod.Spec.Containers[i].Name == containerMetrics.Name {
-						if pod.Spec.Containers[i].Resources.Requests != nil {
-							if gpuReq, ok := pod.Spec.Containers[i].Resources.Requests[corev1.ResourceName("nvidia.com/gpu")]; ok {
-								gpuMetrics["GPURequestCount"] = gpuReq.Value()
-							}
+				// GPU requests/limits from the pod spec (nvidia.com/gpu resource).
+				// Search init containers too so native sidecars requesting GPUs
+				// resolve (see findContainerSpec).
+				if cs := findContainerSpec(pod, containerMetrics.Name); cs != nil {
+					if cs.Resources.Requests != nil {
+						if gpuReq, ok := cs.Resources.Requests[corev1.ResourceName("nvidia.com/gpu")]; ok {
+							gpuMetrics["GPURequestCount"] = gpuReq.Value()
 						}
-						if pod.Spec.Containers[i].Resources.Limits != nil {
-							if gpuLim, ok := pod.Spec.Containers[i].Resources.Limits[corev1.ResourceName("nvidia.com/gpu")]; ok {
-								gpuMetrics["GPULimitCount"] = gpuLim.Value()
-							}
+					}
+					if cs.Resources.Limits != nil {
+						if gpuLim, ok := cs.Resources.Limits[corev1.ResourceName("nvidia.com/gpu")]; ok {
+							gpuMetrics["GPULimitCount"] = gpuLim.Value()
 						}
-						break
 					}
 				}
 
@@ -528,6 +548,29 @@ func (c *ContainerResourceCollector) collectAllContainerResources(ctx context.Co
 	}
 }
 
+// findContainerSpec returns the spec for containerName, searching both regular
+// containers and init containers. Native sidecars (init containers with
+// restartPolicy: Always) and any currently-running init container are reported
+// by the metrics source (nodemon / kubelet Summary API) under their container
+// name, but their specs live in pod.Spec.InitContainers, not
+// pod.Spec.Containers. A Containers-only lookup misses them, which previously
+// dropped their metrics and logged a high-volume ERROR ("Container spec not
+// found") with a stacktrace on every collection cycle. Returns nil only when
+// the name matches neither slice (a transient pod-churn artifact).
+func findContainerSpec(pod *corev1.Pod, containerName string) *corev1.Container {
+	for i := range pod.Spec.Containers {
+		if pod.Spec.Containers[i].Name == containerName {
+			return &pod.Spec.Containers[i]
+		}
+	}
+	for i := range pod.Spec.InitContainers {
+		if pod.Spec.InitContainers[i].Name == containerName {
+			return &pod.Spec.InitContainers[i]
+		}
+	}
+	return nil
+}
+
 // processContainerMetrics processes metrics for a single container
 func (c *ContainerResourceCollector) processContainerMetrics(
 	pod *corev1.Pod,
@@ -539,17 +582,17 @@ func (c *ContainerResourceCollector) processContainerMetrics(
 	runtimeProcesses []ContainerRuntimeProcess,
 	throttleFraction float64,
 ) {
-	// Find the container spec in the pod
-	var containerSpec *corev1.Container
-	for i := range pod.Spec.Containers {
-		if pod.Spec.Containers[i].Name == containerMetrics.Name {
-			containerSpec = &pod.Spec.Containers[i]
-			break
-		}
-	}
-
+	// Find the container spec in the pod, including init containers so native
+	// sidecars and running init containers resolve instead of being dropped
+	// (see findContainerSpec).
+	containerSpec := findContainerSpec(pod, containerMetrics.Name)
 	if containerSpec == nil {
-		c.logger.Error(nil, "Container spec not found",
+		// Expected transient condition (pod churn), not an error: the metrics
+		// source reported a container name that is in neither Containers nor
+		// InitContainers. Logged at V(1)/Debug without a stacktrace to avoid
+		// the ERROR-level, stacktrace-per-line spam this used to produce for
+		// every init/sidecar container on every cycle.
+		c.logger.V(1).Info("Container spec not found; skipping container",
 			"namespace", pod.Namespace,
 			"pod", pod.Name,
 			"container", containerMetrics.Name)
@@ -1017,19 +1060,18 @@ func (c *ContainerResourceCollector) emitCPUThrottleEvent(
 	// Get CPU resources from container spec
 	var cpuUsageMillis, cpuRequestMillis, cpuLimitMillis int64
 	cpuUsageMillis = containerMetrics.Usage.Cpu().MilliValue()
-	for i := range pod.Spec.Containers {
-		if pod.Spec.Containers[i].Name == containerMetrics.Name {
-			if pod.Spec.Containers[i].Resources.Requests != nil {
-				if cpu := pod.Spec.Containers[i].Resources.Requests.Cpu(); cpu != nil {
-					cpuRequestMillis = cpu.MilliValue()
-				}
+	// Search init containers too so native/running sidecars resolve their CPU
+	// requests/limits (see findContainerSpec).
+	if cs := findContainerSpec(pod, containerMetrics.Name); cs != nil {
+		if cs.Resources.Requests != nil {
+			if cpu := cs.Resources.Requests.Cpu(); cpu != nil {
+				cpuRequestMillis = cpu.MilliValue()
 			}
-			if pod.Spec.Containers[i].Resources.Limits != nil {
-				if cpu := pod.Spec.Containers[i].Resources.Limits.Cpu(); cpu != nil {
-					cpuLimitMillis = cpu.MilliValue()
-				}
+		}
+		if cs.Resources.Limits != nil {
+			if cpu := cs.Resources.Limits.Cpu(); cpu != nil {
+				cpuLimitMillis = cpu.MilliValue()
 			}
-			break
 		}
 	}
 

--- a/internal/collector/container_resource_collector_perf_test.go
+++ b/internal/collector/container_resource_collector_perf_test.go
@@ -57,6 +57,31 @@ func (rt *containerNodemonRoundTripper) RoundTrip(req *http.Request) (*http.Resp
 	}
 
 	switch {
+	case strings.HasSuffix(req.URL.Path, "v2/container/snapshot"):
+		// Composite endpoint: one cache-only response carrying both the
+		// container and runtime sections. Modelled with a single container
+		// latency since nodemon serves it from already-refreshed caches.
+		if err := simSleep(req, sim.containerMetricsDelay); err != nil {
+			return nil, err
+		}
+		return jsonResponse(http.StatusOK, containerSnapshotResponse{
+			SchemaVersion: snapshotSchemaVersion,
+			ContainerMetrics: []UnifiedContainerMetric{
+				{
+					NodeName:          sim.nodeName,
+					Namespace:         "ns1",
+					Pod:               "pod-" + sim.nodeName,
+					Container:         "app",
+					Timestamp:         time.Now(),
+					CPUUsageNanoCores: 250_000_000,
+					MemoryWorkingSet:  512 * 1024 * 1024,
+				},
+			},
+			Sections: containerSnapshotSections{
+				Containers: snapshotSectionStatus{State: snapshotStateReady},
+				Runtime:    snapshotSectionStatus{State: snapshotStateDisabled},
+			},
+		}), nil
 	case strings.HasSuffix(req.URL.Path, "v2/container/metrics"):
 		if err := simSleep(req, sim.containerMetricsDelay); err != nil {
 			return nil, err

--- a/internal/collector/container_resource_collector_test.go
+++ b/internal/collector/container_resource_collector_test.go
@@ -9,7 +9,6 @@ import (
 	"net/http/httptest"
 	"net/url"
 	"strconv"
-	"strings"
 	"testing"
 	"time"
 
@@ -17,14 +16,20 @@ import (
 	"github.com/go-logr/logr"
 	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	k8sfake "k8s.io/client-go/kubernetes/fake"
 	"k8s.io/client-go/tools/cache"
+	metricsv1beta1 "k8s.io/metrics/pkg/apis/metrics/v1beta1"
 
 	gen "github.com/devzero-inc/zxporter/gen/api/v1"
 )
+
+// legacyRuntimeMetricsPath is the legacy nodemon runtime endpoint the fleet
+// fetch falls back to when the composite /v2/container/snapshot is unavailable.
+const legacyRuntimeMetricsPath = "/container/runtime-metrics"
 
 // testPod builds a minimal pod, scheduled onto nodeName, with a single
 // container named containerName — enough to survive processContainerMetrics'
@@ -81,7 +86,7 @@ func TestCollectAllContainerResources_SurvivesPodDeletedDuringNodemonFetch(t *te
 
 	var deleteOnce bool
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if r.URL.Path == "/v2/container/metrics" {
+		if r.URL.Path == containerSnapshotPath {
 			// Simulate a watch event removing the pod from the informer's
 			// indexer while we're blocked in this "network" call — the
 			// window the TOCTOU race lived in. Only needs to happen once;
@@ -91,19 +96,26 @@ func TestCollectAllContainerResources_SurvivesPodDeletedDuringNodemonFetch(t *te
 				deleteOnce = true
 			}
 
-			metrics := []UnifiedContainerMetric{
-				{
-					NodeName:          "node-a",
-					Namespace:         pod.Namespace,
-					Pod:               pod.Name,
-					Container:         "app",
-					Timestamp:         time.Now(),
-					CPUUsageNanoCores: 250_000_000,
-					MemoryWorkingSet:  512 * 1024 * 1024,
+			resp := containerSnapshotResponse{
+				SchemaVersion: snapshotSchemaVersion,
+				ContainerMetrics: []UnifiedContainerMetric{
+					{
+						NodeName:          "node-a",
+						Namespace:         pod.Namespace,
+						Pod:               pod.Name,
+						Container:         "app",
+						Timestamp:         time.Now(),
+						CPUUsageNanoCores: 250_000_000,
+						MemoryWorkingSet:  512 * 1024 * 1024,
+					},
+				},
+				Sections: containerSnapshotSections{
+					Containers: snapshotSectionStatus{State: snapshotStateReady},
+					Runtime:    snapshotSectionStatus{State: snapshotStateDisabled},
 				},
 			}
 			w.Header().Set("Content-Type", "application/json")
-			_ = json.NewEncoder(w).Encode(metrics)
+			_ = json.NewEncoder(w).Encode(resp)
 			return
 		}
 		w.WriteHeader(http.StatusNotFound)
@@ -161,22 +173,106 @@ func TestCollectAllContainerResources_SurvivesPodDeletedDuringNodemonFetch(t *te
 		"collector should not report a cache miss when the pod was captured before the race window")
 }
 
+// TestCollectAllContainerResources_UsesSingleCompositeWave asserts the
+// steady-state path: exactly one /v2/container/snapshot request per nodemon
+// pod, zero legacy /v2/container/metrics or /container/runtime-metrics calls,
+// and a disabled runtime section does not suppress usable container data.
+func TestCollectAllContainerResources_UsesSingleCompositeWave(t *testing.T) {
+	pod := testPod("ns1", "pod-a", "node-a", "app")
+	informer, stopCh := newSyncedPodInformer(t, pod)
+	defer close(stopCh)
+
+	counter := &pathCountingNodemon{}
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		counter.record(r.URL.Path)
+		if r.URL.Path != containerSnapshotPath {
+			w.WriteHeader(http.StatusNotFound)
+			return
+		}
+		resp := containerSnapshotResponse{
+			SchemaVersion: snapshotSchemaVersion,
+			ContainerMetrics: []UnifiedContainerMetric{
+				{
+					NodeName:          "node-a",
+					Namespace:         pod.Namespace,
+					Pod:               pod.Name,
+					Container:         "app",
+					Timestamp:         time.Now(),
+					CPUUsageNanoCores: 250_000_000,
+					MemoryWorkingSet:  512 * 1024 * 1024,
+				},
+			},
+			Sections: containerSnapshotSections{
+				Containers: snapshotSectionStatus{State: snapshotStateReady},
+				// Runtime disabled must NOT suppress the usable container data.
+				Runtime: snapshotSectionStatus{State: snapshotStateDisabled},
+			},
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(resp)
+	}))
+	defer server.Close()
+
+	parsed, err := url.Parse(server.URL)
+	require.NoError(t, err)
+	port, err := strconv.Atoi(parsed.Port())
+	require.NoError(t, err)
+
+	nmClient := &NodemonClient{
+		port:          port,
+		httpClient:    server.Client(),
+		log:           logr.Discard(),
+		nodeToIP:      map[string]string{"node-a": parsed.Hostname()},
+		lastRefreshed: time.Now(),
+	}
+
+	c := &ContainerResourceCollector{
+		nodemonClient:    nmClient,
+		kubeletClient:    NewKubeletSummaryClient(k8sfake.NewSimpleClientset(), logr.Discard(), 0),
+		podInformer:      informer,
+		batchChan:        make(chan CollectedResource, 10),
+		config:           ContainerResourceCollectorConfig{DisableGPUMetrics: true},
+		excludedPods:     map[types.NamespacedName]bool{},
+		logger:           logr.Discard(),
+		telemetryLogger:  &fakeTelemetryLogger{},
+		throttle:         throttleTracker{lastEmitted: make(map[string]time.Time)},
+		networkByteRates: nodemon.NewRateCalculator(),
+	}
+
+	c.collectAllContainerResources(context.Background())
+
+	require.Equal(t, 1, counter.count(containerSnapshotPath), "exactly one composite request per node")
+	require.Equal(t, 0, counter.count("/v2/container/metrics"), "no legacy container-metrics call in steady state")
+	require.Equal(t, 0, counter.count(legacyRuntimeMetricsPath), "no legacy runtime call in steady state")
+
+	select {
+	case res := <-c.batchChan:
+		require.Equal(t, "ns1/pod-a/app", res.Key)
+		require.Equal(t, ContainerResource, res.ResourceType)
+	case <-time.After(time.Second):
+		t.Fatal("expected container resource to be emitted from the composite snapshot")
+	}
+}
+
 // TestCollectAllContainerResources_MissingPodsAggregatedNotSpammed is a
 // characterization test for
-// https://github.com/devzero-inc/services/issues/9431: nodemon's
-// /v2/container/metrics cache refreshes on a fixed 30s ticker
-// (cmd/zxporter-nodemon/main.go), while ContainerResourceCollector polls
-// every 10s by default and snapshots the pod informer (a near-instant k8s
-// watch) fresh each cycle. A pod that terminates is gone from the
-// informer snapshot almost immediately but can remain in nodemon's stale
-// response for up to ~30s — an expected race on any sufficiently churny
-// cluster, not a failure. Today, every such pod is reported as its own
-// LOG_LEVEL_ERROR telemetry event ("pod_cache_fail"); on production
-// clusters this produced hundreds of ERROR events per hour (see #9431).
-// This test simulates 5 such "phantom" pods (reported by nodemon, absent
-// from the informer) alongside 1 real pod, and asserts the collector
-// reports one aggregated WARN summary for the cycle instead of one ERROR
-// per phantom pod.
+// https://github.com/devzero-inc/services/issues/9431: nodemon's container
+// metrics cache refreshes on a fixed 30s ticker (cmd/zxporter-nodemon/main.go),
+// while ContainerResourceCollector polls every 10s by default and snapshots the
+// pod informer (a near-instant k8s watch) fresh each cycle. A pod that
+// terminates is gone from the informer snapshot almost immediately but can
+// remain in nodemon's stale response for up to ~30s — an expected race on any
+// sufficiently churny cluster, not a failure. Today, every such pod is reported
+// as its own LOG_LEVEL_ERROR telemetry event ("pod_cache_fail"); on production
+// clusters this produced hundreds of ERROR events per hour (see #9431). This
+// test simulates 5 such "phantom" pods (reported by nodemon, absent from the
+// informer) alongside 1 real pod, and asserts the collector reports one
+// aggregated WARN summary for the cycle instead of one ERROR per phantom pod.
+//
+// The test server serves only the legacy /v2/container/metrics endpoint (404 on
+// the composite path), so on this branch the collector reaches the phantom pods
+// through the composite→legacy fallback — exercising both the fallback and the
+// aggregation in one pass.
 func TestCollectAllContainerResources_MissingPodsAggregatedNotSpammed(t *testing.T) {
 	realPod := testPod("ns1", "real-pod", "node-a", "app")
 	informer, stopCh := newSyncedPodInformer(t, realPod)
@@ -265,48 +361,28 @@ func TestCollectAllContainerResources_MissingPodsAggregatedNotSpammed(t *testing
 	require.Equal(t, fmt.Sprintf("%d", numPhantomPods), summaries[0].fields["missing_count"])
 }
 
-// TestCollectAllContainerResources_MissingPodsSummaryCapsSampleList guards
-// against a gitar-bot review finding on #9432: on a very churny cluster the
-// missing_pods field, which serializes the full phantom-pod list into one
-// telemetry field, could grow unbounded — the exact high-volume scenario
-// the aggregation fix targets in the first place. missing_count must always
-// carry the true total even when the sample list is capped.
-func TestCollectAllContainerResources_MissingPodsSummaryCapsSampleList(t *testing.T) {
-	realPod := testPod("ns1", "real-pod", "node-a", "app")
-	informer, stopCh := newSyncedPodInformer(t, realPod)
+// TestCollectAllContainerResources_LegacyFallbackEmitsTelemetry asserts that
+// when the composite /v2/container/snapshot is unavailable (404) and the fleet
+// fetch falls back to the legacy /v2/container/metrics + /container/runtime-metrics
+// endpoints, a WARN telemetry summary is emitted so a stalled rollout on the old
+// two-request-wave path is observable.
+func TestCollectAllContainerResources_LegacyFallbackEmitsTelemetry(t *testing.T) {
+	pod := testPod("ns1", "pod-a", "node-a", "app")
+	informer, stopCh := newSyncedPodInformer(t, pod)
 	defer close(stopCh)
 
-	const numPhantomPods = 30 // > the 20-entry sample cap
-
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if r.URL.Path == "/v2/container/metrics" {
-			metrics := []UnifiedContainerMetric{
-				{
-					NodeName:          "node-a",
-					Namespace:         realPod.Namespace,
-					Pod:               realPod.Name,
-					Container:         "app",
-					Timestamp:         time.Now(),
-					CPUUsageNanoCores: 250_000_000,
-					MemoryWorkingSet:  512 * 1024 * 1024,
-				},
-			}
-			for i := range numPhantomPods {
-				metrics = append(metrics, UnifiedContainerMetric{
-					NodeName:          "node-a",
-					Namespace:         "ns1",
-					Pod:               fmt.Sprintf("phantom-pod-%d", i),
-					Container:         "app",
-					Timestamp:         time.Now(),
-					CPUUsageNanoCores: 100_000_000,
-					MemoryWorkingSet:  256 * 1024 * 1024,
-				})
-			}
-			w.Header().Set("Content-Type", "application/json")
-			_ = json.NewEncoder(w).Encode(metrics)
-			return
+		switch r.URL.Path {
+		case "/v2/container/metrics":
+			_ = json.NewEncoder(w).Encode([]UnifiedContainerMetric{{
+				NodeName: "node-a", Namespace: pod.Namespace, Pod: pod.Name, Container: "app",
+				Timestamp: time.Now(), CPUUsageNanoCores: 250_000_000, MemoryWorkingSet: 512 * 1024 * 1024,
+			}})
+		case legacyRuntimeMetricsPath:
+			_ = json.NewEncoder(w).Encode(NodemonRuntimeMetrics{})
+		default: // /v2/container/snapshot → 404, forcing the legacy fallback
+			w.WriteHeader(http.StatusNotFound)
 		}
-		w.WriteHeader(http.StatusNotFound)
 	}))
 	defer server.Close()
 
@@ -315,18 +391,12 @@ func TestCollectAllContainerResources_MissingPodsSummaryCapsSampleList(t *testin
 	port, err := strconv.Atoi(parsed.Port())
 	require.NoError(t, err)
 
-	nmClient := &NodemonClient{
-		port:          port,
-		httpClient:    server.Client(),
-		log:           logr.Discard(),
-		nodeToIP:      map[string]string{"node-a": parsed.Hostname()},
-		lastRefreshed: time.Now(),
-	}
-
 	fakeLogger := &fakeTelemetryLogger{}
-
 	c := &ContainerResourceCollector{
-		nodemonClient:    nmClient,
+		nodemonClient: &NodemonClient{
+			port: port, httpClient: server.Client(), log: logr.Discard(),
+			nodeToIP: map[string]string{"node-a": parsed.Hostname()}, lastRefreshed: time.Now(),
+		},
 		kubeletClient:    NewKubeletSummaryClient(k8sfake.NewSimpleClientset(), logr.Discard(), 0),
 		podInformer:      informer,
 		batchChan:        make(chan CollectedResource, 10),
@@ -340,23 +410,91 @@ func TestCollectAllContainerResources_MissingPodsSummaryCapsSampleList(t *testin
 
 	c.collectAllContainerResources(context.Background())
 
-	select {
-	case <-c.batchChan:
-	case <-time.After(time.Second):
-		t.Fatal("expected the real pod's container resource to be emitted")
+	warns := fakeLogger.reportsWithEventType("nodemon_legacy_fallback")
+	require.Len(t, warns, 1, "expected one legacy-fallback WARN summary for the sweep")
+	require.Equal(t, gen.LogLevel_LOG_LEVEL_WARN, warns[0].level)
+	require.Equal(t, "1", warns[0].fields["legacy_fallback"])
+}
+
+// containerMetricsFor builds a minimal metricsv1beta1.ContainerMetrics with CPU
+// and memory usage, enough to drive processContainerMetrics.
+func containerMetricsFor(name string) metricsv1beta1.ContainerMetrics {
+	return metricsv1beta1.ContainerMetrics{
+		Name: name,
+		Usage: corev1.ResourceList{
+			corev1.ResourceCPU:    *resource.NewMilliQuantity(100, resource.DecimalSI),
+			corev1.ResourceMemory: *resource.NewQuantity(64*1024*1024, resource.BinarySI),
+		},
+	}
+}
+
+// TestProcessContainerMetrics_ResolvesInitContainerSidecar is a regression test
+// for the high-volume "Container spec not found" ERROR spam
+// (github.com/devzero-inc/services/issues, ~22M log lines/day in one fleet).
+// Native sidecars (init containers with restartPolicy: Always, e.g.
+// otel-collector) and running init containers are reported by the metrics
+// source under their container name, but their specs live in
+// pod.Spec.InitContainers. processContainerMetrics used to look only in
+// pod.Spec.Containers, so every such container failed the lookup, logged an
+// ERROR + stacktrace, and was dropped on every cycle. It must now resolve the
+// spec from InitContainers and emit the metric.
+func TestProcessContainerMetrics_ResolvesInitContainerSidecar(t *testing.T) {
+	always := corev1.ContainerRestartPolicyAlways
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{Namespace: "ns1", Name: "pod-a"},
+		Spec: corev1.PodSpec{
+			NodeName:   "node-a",
+			Containers: []corev1.Container{{Name: "app"}},
+			InitContainers: []corev1.Container{{
+				Name:          "otel-collector",
+				RestartPolicy: &always, // native sidecar
+			}},
+		},
 	}
 
-	summaries := fakeLogger.reportsWithEventType("pod_cache_miss_summary")
-	require.Len(t, summaries, 1)
-	require.Equal(t, fmt.Sprintf("%d", numPhantomPods), summaries[0].fields["missing_count"],
-		"missing_count must carry the true total even when the sample list is capped")
+	c := &ContainerResourceCollector{
+		batchChan: make(chan CollectedResource, 4),
+		logger:    logr.Discard(),
+		throttle:  throttleTracker{lastEmitted: make(map[string]time.Time)},
+	}
 
-	sampleField := summaries[0].fields["missing_pods"]
-	require.Contains(t, sampleField, "(+10 more)",
-		"expected the sample list to be capped with a remainder suffix, got: %s", sampleField)
-	// podMetricsList.Items iterates a map internally, so which specific
-	// pods land in the truncated sample isn't deterministic — assert the
-	// sample size is capped rather than which names survive.
-	require.Equal(t, 20, strings.Count(sampleField, "ns1/phantom-pod-"),
-		"expected exactly 20 sampled pod names, got: %s", sampleField)
+	c.processContainerMetrics(pod, containerMetricsFor("otel-collector"), nil, nil, nil, nil, nil, 0)
+
+	select {
+	case res := <-c.batchChan:
+		require.Equal(t, "ns1/pod-a/otel-collector", res.Key,
+			"native sidecar in InitContainers must be emitted, not dropped")
+		require.Equal(t, ContainerResource, res.ResourceType)
+	case <-time.After(time.Second):
+		t.Fatal("expected the init-container sidecar metric to be emitted")
+	}
+}
+
+// TestProcessContainerMetrics_UnknownContainerSkipped asserts that a container
+// name present in neither Containers nor InitContainers is skipped silently
+// (no emit, no panic) — the residual transient pod-churn case, now logged at
+// Debug rather than ERROR.
+func TestProcessContainerMetrics_UnknownContainerSkipped(t *testing.T) {
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{Namespace: "ns1", Name: "pod-a"},
+		Spec: corev1.PodSpec{
+			NodeName:   "node-a",
+			Containers: []corev1.Container{{Name: "app"}},
+		},
+	}
+
+	c := &ContainerResourceCollector{
+		batchChan: make(chan CollectedResource, 4),
+		logger:    logr.Discard(),
+		throttle:  throttleTracker{lastEmitted: make(map[string]time.Time)},
+	}
+
+	c.processContainerMetrics(pod, containerMetricsFor("ghost"), nil, nil, nil, nil, nil, 0)
+
+	select {
+	case res := <-c.batchChan:
+		t.Fatalf("expected no emit for a container absent from the pod spec, got %q", res.Key)
+	case <-time.After(100 * time.Millisecond):
+		// expected: nothing emitted
+	}
 }

--- a/internal/collector/node_collector.go
+++ b/internal/collector/node_collector.go
@@ -487,6 +487,17 @@ const defaultMaxConcurrentNodeCollections = 20
 type nodeCollectionOutcome struct {
 	nodeName string
 	coverage nodeCoverage
+	// usedLegacy is true when the composite /v2/node/snapshot request had to
+	// fall back to the legacy /node/metrics + /container/metrics endpoints for
+	// this node (e.g. a nodemon pod that predates the composite contract). It
+	// means this node paid the old 2-calls-per-node cost instead of 1, and is
+	// aggregated into a per-sweep signal so a stalled rollout is visible.
+	usedLegacy     bool
+	fallbackReason string
+	// gpuStale is true when this node's composite GPU section was stale (nodemon's
+	// DCGM refresh is failing) and therefore dropped. Aggregated per sweep so the
+	// DCGM problem is visible in DAKR telemetry, not only in nodemon's logs.
+	gpuStale bool
 }
 
 type nodeCoverage int
@@ -551,6 +562,16 @@ func (c *NodeCollector) collectAllNodeResources(ctx context.Context) {
 	// fail are true gaps.
 	var nodemonCovered, kubeletFallback int
 	var uncoveredNodes []string
+	// Nodes that fell back from the composite /v2/node/snapshot to the legacy
+	// per-metric endpoints — i.e. paid the old 2-calls-per-node cost. Tracked
+	// per sweep so a mixed-version rollout that never converges to the composite
+	// path is visible instead of silently slow.
+	var legacyFallbackNodes []string
+	legacyReasons := map[string]int{}
+	// Nodes whose GPU section was stale (nodemon's DCGM refresh failing) and thus
+	// dropped — surfaced as a per-sweep signal so a DCGM problem is visible in
+	// DAKR telemetry, not just nodemon logs.
+	var gpuStaleNodes []string
 	for _, o := range outcomes {
 		switch o.coverage {
 		case nodeCoverageNodemon:
@@ -559,6 +580,13 @@ func (c *NodeCollector) collectAllNodeResources(ctx context.Context) {
 			kubeletFallback++
 		case nodeCoverageUncovered:
 			uncoveredNodes = append(uncoveredNodes, o.nodeName)
+		}
+		if o.usedLegacy {
+			legacyFallbackNodes = append(legacyFallbackNodes, o.nodeName)
+			legacyReasons[o.fallbackReason]++
+		}
+		if o.gpuStale {
+			gpuStaleNodes = append(gpuStaleNodes, o.nodeName)
 		}
 	}
 	c.logger.V(1).Info("Built node metrics",
@@ -577,11 +605,75 @@ func (c *NodeCollector) collectAllNodeResources(ctx context.Context) {
 				"node_count":       fmt.Sprintf("%d", len(outcomes)),
 				"nodemon_covered":  fmt.Sprintf("%d", nodemonCovered),
 				"kubelet_fallback": fmt.Sprintf("%d", kubeletFallback),
+				"legacy_fallback":  fmt.Sprintf("%d", len(legacyFallbackNodes)),
 				"excluded_nodes":   fmt.Sprintf("%v", c.excludedNodes),
 				"event_type":       "node_metrics_query_success",
 				"zxporter_version": version.Get().String(),
 			},
 		)
+	}
+
+	// Signal when nodemon pods are serving the legacy per-metric endpoints
+	// instead of the composite /v2/node/snapshot — this node collector is paying
+	// the old 2-calls-per-node cost. Expected transiently during a nodemon
+	// rolling upgrade; a persistent nonzero count means the fleet never
+	// converged to the composite path.
+	if len(legacyFallbackNodes) > 0 {
+		c.logger.Info("Node metrics served via legacy fallback (composite snapshot unavailable)",
+			"count", len(legacyFallbackNodes), "reasons", legacyReasons)
+		if c.telemetryLogger != nil {
+			// Cap the sample list so this one field can't bloat on a large fleet;
+			// legacy_fallback always carries the true total.
+			const maxLegacyNodesSample = 20
+			sample := legacyFallbackNodes
+			suffix := ""
+			if len(sample) > maxLegacyNodesSample {
+				suffix = fmt.Sprintf(" (+%d more)", len(sample)-maxLegacyNodesSample)
+				sample = sample[:maxLegacyNodesSample]
+			}
+			c.telemetryLogger.Report(
+				gen.LogLevel_LOG_LEVEL_WARN,
+				"NodeCollector",
+				"Node metrics served via legacy fallback instead of composite snapshot",
+				nil,
+				map[string]string{
+					"legacy_fallback":  fmt.Sprintf("%d", len(legacyFallbackNodes)),
+					"fallback_reasons": fmt.Sprintf("%v", legacyReasons),
+					"sample_nodes":     fmt.Sprintf("%v", sample) + suffix,
+					"event_type":       "nodemon_legacy_fallback",
+					"zxporter_version": version.Get().String(),
+				},
+			)
+		}
+	}
+
+	// Signal when GPU metrics were dropped because nodemon is serving a stale
+	// DCGM snapshot (its scrape is failing). Without this the DCGM problem is
+	// only visible in nodemon's own logs, never in DAKR telemetry.
+	if len(gpuStaleNodes) > 0 {
+		c.logger.Info("GPU metrics dropped for nodes with a stale nodemon DCGM snapshot",
+			"count", len(gpuStaleNodes))
+		if c.telemetryLogger != nil {
+			const maxGPUStaleSample = 20
+			sample := gpuStaleNodes
+			suffix := ""
+			if len(sample) > maxGPUStaleSample {
+				suffix = fmt.Sprintf(" (+%d more)", len(sample)-maxGPUStaleSample)
+				sample = sample[:maxGPUStaleSample]
+			}
+			c.telemetryLogger.Report(
+				gen.LogLevel_LOG_LEVEL_WARN,
+				"NodeCollector",
+				"GPU metrics dropped: nodemon DCGM snapshot is stale",
+				nil,
+				map[string]string{
+					"gpu_dropped_stale": fmt.Sprintf("%d", len(gpuStaleNodes)),
+					"sample_nodes":      fmt.Sprintf("%v", sample) + suffix,
+					"event_type":        "gpu_dropped_stale",
+					"zxporter_version":  version.Get().String(),
+				},
+			)
+		}
 	}
 
 	// Surface coverage gaps: nodes where neither nodemon nor the kubelet fallback
@@ -621,16 +713,35 @@ func (c *NodeCollector) collectAllNodeResources(ctx context.Context) {
 func (c *NodeCollector) collectSingleNodeResources(ctx context.Context, node *corev1.Node) nodeCollectionOutcome {
 	outcome := nodeCollectionOutcome{nodeName: node.Name}
 
-	// Fetch node-level metrics from nodemon (includes system process CPU/memory).
-	nodeMetric, err := c.nodemonClient.FetchNodeMetricsByNode(ctx, node.Name)
-	if err != nil {
-		c.logger.V(1).Info("Failed to fetch node metrics from nodemon", "node", node.Name, "error", err)
-		nodeMetric = nil
+	// Fetch node-level and GPU metrics from nodemon in a single composite
+	// request (was two: /node/metrics + /container/metrics). The node and GPU
+	// sections are independently usable, and FetchNodeSnapshotByNode falls back
+	// to the legacy endpoints only for a nodemon pod that predates the composite
+	// contract. A non-nil snapshot can accompany a non-nil error when only one
+	// legacy fallback section failed, so we use whatever sections came back.
+	var nodeMetric *UnifiedNodeMetric
+	var gpuMetrics map[string]interface{}
+	if c.nodemonClient != nil {
+		snapshot, err := c.nodemonClient.FetchNodeSnapshotByNode(ctx, node.Name)
+		if err != nil {
+			c.logger.V(1).Info("nodemon node snapshot returned an error", "node", node.Name, "error", err)
+		}
+		if snapshot != nil {
+			nodeMetric = snapshot.NodeMetric
+			// The composite always carries a GPU summary; honor the collector's
+			// opt-out by only attaching it when GPU metrics are enabled.
+			if !c.config.DisableGPUMetrics {
+				gpuMetrics = snapshot.GPUMetrics
+			}
+			outcome.usedLegacy = snapshot.UsedLegacy
+			outcome.fallbackReason = snapshot.FallbackReason
+			outcome.gpuStale = snapshot.GPUStale
+		}
 	}
 
 	fromNodemon := nodeMetric != nil
 	if !fromNodemon {
-		// No nodemon pod on this node — fall back to the kubelet Summary API.
+		// No usable node section from nodemon — fall back to the kubelet Summary API.
 		if km, kerr := c.kubeletClient.FetchNodeMetricsByNode(ctx, node.Name); kerr != nil {
 			c.logger.V(1).Info("Kubelet node-metrics fallback failed", "node", node.Name, "error", kerr)
 			outcome.coverage = nodeCoverageUncovered
@@ -679,19 +790,9 @@ func (c *NodeCollector) collectSingleNodeResources(ctx context.Context, node *co
 		networkMetrics = networkIOMetricsFromNodeMetric(nodeMetric)
 	}
 
-	// Fetch GPU metrics from nodemon if enabled.
-	var gpuMetrics map[string]interface{}
-	if !c.config.DisableGPUMetrics && c.nodemonClient != nil {
-		nodemonMetrics, fetchErr := c.nodemonClient.FetchMetricsByNode(ctx, node.Name)
-		if fetchErr != nil {
-			c.logger.Error(fetchErr, "Failed to fetch GPU metrics from nodemon", "node", node.Name)
-			gpuMetrics = make(map[string]interface{})
-		} else if len(nodemonMetrics) > 0 {
-			gpuMetrics = NodeGPUMetricsFromNodemon(nodemonMetrics)
-		} else {
-			gpuMetrics = make(map[string]interface{})
-		}
-	}
+	// GPU metrics (gpuMetrics) were already populated from the composite node
+	// snapshot above when GPU collection is enabled and the GPU section was
+	// usable; nothing further to fetch here.
 
 	// Create resource data
 	resourceData := map[string]interface{}{

--- a/internal/collector/node_collector_perf_test.go
+++ b/internal/collector/node_collector_perf_test.go
@@ -62,6 +62,27 @@ func (rt *nodemonRoundTripper) RoundTrip(req *http.Request) (*http.Response, err
 	// its request paths from, so this simulator doesn't drift silently if
 	// that path ever changes shape (e.g. gains a query string).
 	switch {
+	case strings.HasSuffix(req.URL.Path, "v2/node/snapshot"):
+		// Composite endpoint: one cache-only response carrying both the node
+		// and GPU sections. Modelled with a single node-metrics latency since
+		// nodemon serves it from an already-refreshed cache (no per-request
+		// scrape), which is the whole point of the composite path.
+		if err := simSleep(req, sim.nodeMetricsDelay); err != nil {
+			return nil, err
+		}
+		return jsonResponse(http.StatusOK, nodeSnapshotResponse{
+			SchemaVersion: snapshotSchemaVersion,
+			NodeMetrics: &UnifiedNodeMetric{
+				NodeName:          req.URL.Hostname(),
+				Timestamp:         time.Now(),
+				CPUUsageNanoCores: 500_000_000,
+				MemoryWorkingSet:  1024 * 1024 * 1024,
+			},
+			Sections: nodeSnapshotSections{
+				Node: snapshotSectionStatus{State: snapshotStateReady},
+				GPU:  snapshotSectionStatus{State: snapshotStateNotReady},
+			},
+		}), nil
 	case strings.HasSuffix(req.URL.Path, "container/metrics"):
 		if err := simSleep(req, sim.gpuMetricsDelay); err != nil {
 			return nil, err

--- a/internal/collector/node_collector_test.go
+++ b/internal/collector/node_collector_test.go
@@ -18,12 +18,319 @@ import (
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/kubernetes"
 	k8sfake "k8s.io/client-go/kubernetes/fake"
+	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/cache"
 	metricsv1 "k8s.io/metrics/pkg/client/clientset/versioned"
 
 	gen "github.com/devzero-inc/zxporter/gen/api/v1"
 )
+
+// Legacy nodemon endpoints the node collector falls back to when the composite
+// /v2/node/snapshot is unavailable.
+const (
+	legacyNodeMetricsPath    = "/node/metrics"
+	legacyNodeGPUMetricsPath = "/container/metrics"
+)
+
+// newFakeKubeletClientForNode returns a KubeletSummaryClient backed by an
+// in-memory API-server proxy round tripper (see kubeletProxyRoundTripper) that
+// serves a Summary API response for nodeName with the given CPU (nanocores) and
+// working-set (bytes) usage. Used to exercise the node-section kubelet fallback
+// without opening a real socket.
+func newFakeKubeletClientForNode(t *testing.T, nodeName string, usageNanoCores, workingSetBytes uint64) *KubeletSummaryClient {
+	t.Helper()
+	kubeletRT := &kubeletProxyRoundTripper{delayByNode: map[string]time.Duration{nodeName: 0}}
+	_ = usageNanoCores // the round tripper serves fixed sample values
+	_ = workingSetBytes
+	client, err := kubernetes.NewForConfigAndClient(
+		&rest.Config{Host: "http://fake-apiserver", QPS: -1},
+		&http.Client{Transport: kubeletRT},
+	)
+	require.NoError(t, err)
+	return NewKubeletSummaryClient(client, logr.Discard(), 0)
+}
+
+// pathCountingNodemon is a fake nodemon that records how many requests hit each
+// path, so tests can assert the collector makes exactly one composite request
+// per node and never falls back to the legacy endpoints in steady state.
+type pathCountingNodemon struct {
+	mu     sync.Mutex
+	counts map[string]int
+}
+
+func (p *pathCountingNodemon) record(path string) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	if p.counts == nil {
+		p.counts = map[string]int{}
+	}
+	p.counts[path]++
+}
+
+func (p *pathCountingNodemon) count(path string) int {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	return p.counts[path]
+}
+
+// newNodemonClientForServer wires a NodemonClient to a test server, mapping the
+// single node to the server's host:port so discovery is bypassed.
+func newNodemonClientForServer(t *testing.T, server *httptest.Server, nodeName string) *NodemonClient {
+	t.Helper()
+	parsed, err := url.Parse(server.URL)
+	require.NoError(t, err)
+	port, err := strconv.Atoi(parsed.Port())
+	require.NoError(t, err)
+	return &NodemonClient{
+		port:          port,
+		httpClient:    server.Client(),
+		log:           logr.Discard(),
+		nodeToIP:      map[string]string{nodeName: parsed.Hostname()},
+		lastRefreshed: time.Now(),
+	}
+}
+
+func newNodeCollectorForTest(nmClient *NodemonClient, informer cache.SharedIndexInformer) *NodeCollector {
+	return &NodeCollector{
+		metricsClient:   &metricsv1.Clientset{},
+		nodemonClient:   nmClient,
+		kubeletClient:   NewKubeletSummaryClient(k8sfake.NewSimpleClientset(), logr.Discard(), 0),
+		nodeInformer:    informer,
+		batchChan:       make(chan CollectedResource, 10),
+		config:          NodeCollectorConfig{DisableGPUMetrics: false},
+		excludedNodes:   map[string]bool{},
+		logger:          logr.Discard(),
+		telemetryLogger: &fakeTelemetryLogger{},
+		nodeToPodsMap:   make(map[string]map[string]*corev1.Pod),
+	}
+}
+
+// TestCollectAllNodeResources_UsesSingleCompositeRequest asserts the steady-state
+// path: exactly one /v2/node/snapshot request per covered node, zero legacy
+// requests, and both node and GPU fields emitted from the composite response.
+func TestCollectAllNodeResources_UsesSingleCompositeRequest(t *testing.T) {
+	node := testNode("gpu-node")
+	informer, stopCh := newSyncedNodeInformer(t, node)
+	defer close(stopCh)
+
+	counter := &pathCountingNodemon{}
+	collectedAt := time.Now()
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		counter.record(r.URL.Path)
+		if r.URL.Path != nodeSnapshotPath {
+			w.WriteHeader(http.StatusNotFound)
+			return
+		}
+		resp := nodeSnapshotResponse{
+			SchemaVersion: snapshotSchemaVersion,
+			NodeMetrics: &UnifiedNodeMetric{
+				NodeName:             node.Name,
+				Timestamp:            collectedAt,
+				CPUUsageNanoCores:    1_000_000_000,
+				MemoryWorkingSet:     2 * 1024 * 1024 * 1024,
+				NetworkRxBytesPerSec: 42,
+			},
+			GPUSummary: &nodeGPUSummary{
+				GPUCount:          2,
+				GPUUtilizationAvg: 73.5,
+				GPUUtilizationMax: 91,
+				GPUModels:         []string{"A100"},
+			},
+			Sections: nodeSnapshotSections{
+				Node: snapshotSectionStatus{State: snapshotStateReady, CollectedAt: &collectedAt},
+				GPU:  snapshotSectionStatus{State: snapshotStateReady, CollectedAt: &collectedAt},
+			},
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(resp)
+	}))
+	defer server.Close()
+
+	nmClient := newNodemonClientForServer(t, server, node.Name)
+	c := newNodeCollectorForTest(nmClient, informer)
+
+	c.collectAllNodeResources(context.Background())
+
+	require.Equal(t, 1, counter.count(nodeSnapshotPath), "expected exactly one composite request")
+	require.Equal(t, 0, counter.count(legacyNodeMetricsPath), "no legacy node-metrics call in steady state")
+	require.Equal(t, 0, counter.count(legacyNodeGPUMetricsPath), "no legacy GPU call in steady state")
+
+	select {
+	case res := <-c.batchChan:
+		require.Equal(t, node.Name, res.Key)
+		data := res.Object.(map[string]interface{})
+		require.EqualValues(t, 42, data["networkReceiveBytes"], "node network fields from composite")
+		require.EqualValues(t, 2, data["gpuCount"], "GPU fields from composite")
+		require.EqualValues(t, 73.5, data["gpuUtilizationAvg"])
+	case <-time.After(time.Second):
+		t.Fatal("expected a node resource to be emitted")
+	}
+}
+
+// TestCollectAllNodeResources_NodeNotReadyFallsBackToKubelet asserts that when
+// the composite node section is not_ready, the collector uses the kubelet
+// fallback for node metrics while still attaching a usable GPU section.
+func TestCollectAllNodeResources_NodeNotReadyFallsBackToKubelet(t *testing.T) {
+	node := testNode("gpu-node")
+	informer, stopCh := newSyncedNodeInformer(t, node)
+	defer close(stopCh)
+
+	counter := &pathCountingNodemon{}
+	collectedAt := time.Now()
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		counter.record(r.URL.Path)
+		if r.URL.Path != nodeSnapshotPath {
+			w.WriteHeader(http.StatusNotFound)
+			return
+		}
+		// Node section not_ready (so node_metrics is omitted), GPU ready.
+		resp := nodeSnapshotResponse{
+			SchemaVersion: snapshotSchemaVersion,
+			GPUSummary:    &nodeGPUSummary{GPUCount: 1, GPUUtilizationAvg: 50},
+			Sections: nodeSnapshotSections{
+				Node: snapshotSectionStatus{State: snapshotStateNotReady},
+				GPU:  snapshotSectionStatus{State: snapshotStateReady, CollectedAt: &collectedAt},
+			},
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(resp)
+	}))
+	defer server.Close()
+
+	nmClient := newNodemonClientForServer(t, server, node.Name)
+	c := newNodeCollectorForTest(nmClient, informer)
+	// Composite node section is not_ready, so node CPU/memory must come from the
+	// kubelet Summary API fallback — while the usable GPU section is preserved.
+	c.kubeletClient = newFakeKubeletClientForNode(t, node.Name, 300_000_000, 512*1024*1024)
+
+	c.collectAllNodeResources(context.Background())
+
+	require.Equal(t, 1, counter.count(nodeSnapshotPath))
+
+	select {
+	case res := <-c.batchChan:
+		require.Equal(t, node.Name, res.Key)
+		data := res.Object.(map[string]interface{})
+		require.EqualValues(t, 1, data["gpuCount"], "usable GPU section survives node fallback")
+		require.EqualValues(t, 300, data["cpuUsageMillis"], "node CPU came from the kubelet fallback")
+	case <-time.After(time.Second):
+		t.Fatal("expected a node resource to be emitted via kubelet fallback")
+	}
+}
+
+// TestCollectAllNodeResources_StaleGPUDropped asserts that a GPU section marked
+// "stale" (nodemon's DCGM refresh is failing and it is serving a last-good
+// snapshot of unbounded age) is NOT ingested — the node is still emitted from
+// its (ready) node section, but with no GPU fields, matching main's behavior of
+// emitting a gap rather than arbitrarily old GPU values stamped as current.
+func TestCollectAllNodeResources_StaleGPUDropped(t *testing.T) {
+	node := testNode("gpu-node")
+	informer, stopCh := newSyncedNodeInformer(t, node)
+	defer close(stopCh)
+
+	collectedAt := time.Now().Add(-45 * time.Second) // deliberately old
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != nodeSnapshotPath {
+			w.WriteHeader(http.StatusNotFound)
+			return
+		}
+		resp := nodeSnapshotResponse{
+			SchemaVersion: snapshotSchemaVersion,
+			NodeMetrics: &UnifiedNodeMetric{
+				NodeName: node.Name, Timestamp: time.Now(),
+				CPUUsageNanoCores: 1_000_000_000, MemoryWorkingSet: 2 * 1024 * 1024 * 1024,
+			},
+			GPUSummary: &nodeGPUSummary{GPUCount: 4, GPUUtilizationAvg: 88}, // last-good, but stale
+			Sections: nodeSnapshotSections{
+				Node: snapshotSectionStatus{State: snapshotStateReady, CollectedAt: &collectedAt},
+				GPU:  snapshotSectionStatus{State: snapshotStateStale, CollectedAt: &collectedAt},
+			},
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(resp)
+	}))
+	defer server.Close()
+
+	nmClient := newNodemonClientForServer(t, server, node.Name)
+	fakeLogger := &fakeTelemetryLogger{}
+	c := newNodeCollectorForTest(nmClient, informer)
+	c.telemetryLogger = fakeLogger
+
+	c.collectAllNodeResources(context.Background())
+
+	select {
+	case res := <-c.batchChan:
+		require.Equal(t, node.Name, res.Key)
+		data := res.Object.(map[string]interface{})
+		require.NotContains(t, data, "gpuCount", "stale GPU must not be ingested")
+		require.NotContains(t, data, "gpuUtilizationAvg", "stale GPU must not be ingested")
+		require.EqualValues(t, 1000, data["cpuUsageMillis"], "the ready node section is still emitted")
+	case <-time.After(time.Second):
+		t.Fatal("expected the node to still be emitted (from its ready node section)")
+	}
+
+	// The dropped-because-stale GPU must be visible as DAKR telemetry, not just
+	// a nodemon-side log.
+	staleWarns := fakeLogger.reportsWithEventType("gpu_dropped_stale")
+	require.Len(t, staleWarns, 1, "expected one gpu_dropped_stale WARN summary")
+	require.Equal(t, gen.LogLevel_LOG_LEVEL_WARN, staleWarns[0].level)
+	require.Equal(t, "1", staleWarns[0].fields["gpu_dropped_stale"])
+}
+
+// TestCollectAllNodeResources_LegacyFallbackEmitsTelemetry asserts that when a
+// nodemon pod predates the composite endpoint (404 on /v2/node/snapshot) and
+// the collector falls back to the legacy /node/metrics + /container/metrics
+// pair, a WARN telemetry summary is emitted so a stalled rollout on the old
+// 2-calls-per-node path is observable.
+func TestCollectAllNodeResources_LegacyFallbackEmitsTelemetry(t *testing.T) {
+	node := testNode("legacy-node")
+	informer, stopCh := newSyncedNodeInformer(t, node)
+	defer close(stopCh)
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case legacyNodeMetricsPath:
+			_ = json.NewEncoder(w).Encode(UnifiedNodeMetric{
+				NodeName: node.Name, Timestamp: time.Now(),
+				CPUUsageNanoCores: 500_000_000, MemoryWorkingSet: 1024 * 1024 * 1024,
+			})
+		case legacyNodeGPUMetricsPath:
+			_ = json.NewEncoder(w).Encode([]NodemonMetric{})
+		default: // /v2/node/snapshot → 404, forcing the legacy fallback
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	defer server.Close()
+
+	nmClient := newNodemonClientForServer(t, server, node.Name)
+	fakeLogger := &fakeTelemetryLogger{}
+	c := &NodeCollector{
+		metricsClient:   &metricsv1.Clientset{},
+		nodemonClient:   nmClient,
+		kubeletClient:   NewKubeletSummaryClient(k8sfake.NewSimpleClientset(), logr.Discard(), 0),
+		nodeInformer:    informer,
+		batchChan:       make(chan CollectedResource, 10),
+		config:          NodeCollectorConfig{DisableGPUMetrics: false},
+		excludedNodes:   map[string]bool{},
+		logger:          logr.Discard(),
+		telemetryLogger: fakeLogger,
+		nodeToPodsMap:   make(map[string]map[string]*corev1.Pod),
+	}
+
+	c.collectAllNodeResources(context.Background())
+
+	warns := fakeLogger.reportsWithEventType("nodemon_legacy_fallback")
+	require.Len(t, warns, 1, "expected one legacy-fallback WARN summary for the sweep")
+	require.Equal(t, gen.LogLevel_LOG_LEVEL_WARN, warns[0].level)
+	require.Equal(t, "1", warns[0].fields["legacy_fallback"])
+
+	// The success summary should also carry the legacy_fallback count.
+	success := fakeLogger.reportsWithEventType("node_metrics_query_success")
+	require.Len(t, success, 1)
+	require.Equal(t, "1", success[0].fields["legacy_fallback"])
+}
 
 // fakeTelemetryLogger captures Report calls for assertions instead of sending
 // them anywhere, mirroring the shape of telemetry_logger.Logger.
@@ -126,20 +433,27 @@ func TestCollectAllNodeResources_SurvivesNodeDeletedDuringNodemonFetch(t *testin
 	defer close(stopCh)
 
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if r.URL.Path == "/node/metrics" {
+		if r.URL.Path == nodeSnapshotPath {
 			// Simulate a watch event removing the node from the informer's
 			// indexer while we're blocked in this "network" call — the
 			// window the TOCTOU race lived in.
 			_ = informer.GetIndexer().Delete(node)
 
-			metric := UnifiedNodeMetric{
-				NodeName:          node.Name,
-				Timestamp:         time.Now(),
-				CPUUsageNanoCores: 500_000_000,
-				MemoryWorkingSet:  1024 * 1024 * 1024,
+			resp := nodeSnapshotResponse{
+				SchemaVersion: snapshotSchemaVersion,
+				NodeMetrics: &UnifiedNodeMetric{
+					NodeName:          node.Name,
+					Timestamp:         time.Now(),
+					CPUUsageNanoCores: 500_000_000,
+					MemoryWorkingSet:  1024 * 1024 * 1024,
+				},
+				Sections: nodeSnapshotSections{
+					Node: snapshotSectionStatus{State: snapshotStateReady},
+					GPU:  snapshotSectionStatus{State: snapshotStateNotReady},
+				},
 			}
 			w.Header().Set("Content-Type", "application/json")
-			_ = json.NewEncoder(w).Encode(metric)
+			_ = json.NewEncoder(w).Encode(resp)
 			return
 		}
 		w.WriteHeader(http.StatusNotFound)

--- a/internal/collector/nodemon_container_snapshot_client.go
+++ b/internal/collector/nodemon_container_snapshot_client.go
@@ -1,0 +1,179 @@
+package collector
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net/http"
+	"sort"
+
+	"golang.org/x/sync/errgroup"
+)
+
+const (
+	containerSnapshotPath          = "/v2/container/snapshot"
+	containerSnapshotResponseLimit = 32 << 20
+)
+
+// ContainerCollectionSnapshot is the cluster-wide result of one bounded
+// composite request wave.
+type ContainerCollectionSnapshot struct {
+	ContainerMetrics     []UnifiedContainerMetric
+	RuntimeMetrics       NodemonRuntimeMetrics
+	FailedContainerNodes map[string]struct{}
+	CompositeCount       int
+	LegacyFallbackCount  int
+}
+
+type containerNodeSnapshot struct {
+	containerMetrics []UnifiedContainerMetric
+	runtimeMetrics   NodemonRuntimeMetrics
+	containerFailed  bool
+	usedLegacy       bool
+	containerErr     error
+	runtimeErr       error
+}
+
+// FetchAllContainerSnapshots fetches one composite cache snapshot from every
+// discovered nodemon pod with the existing bounded concurrency limit.
+func (c *NodemonClient) FetchAllContainerSnapshots(
+	ctx context.Context,
+) (ContainerCollectionSnapshot, error) {
+	nodeToIP, err := c.refreshCache(ctx)
+	if err != nil {
+		return ContainerCollectionSnapshot{}, err
+	}
+
+	output := ContainerCollectionSnapshot{
+		FailedContainerNodes: make(map[string]struct{}),
+		CompositeCount:       len(nodeToIP),
+	}
+	if len(nodeToIP) == 0 {
+		return output, nil
+	}
+
+	results := fetchAllNodesConcurrently(ctx, nodeToIP, func(ctx context.Context, podIP string) (containerNodeSnapshot, error) {
+		baseURL := fmt.Sprintf("http://%s:%d", podIP, c.port)
+		return c.fetchContainerSnapshot(ctx, baseURL)
+	})
+	sort.Slice(results, func(i, j int) bool {
+		return results[i].nodeName < results[j].nodeName
+	})
+
+	for _, result := range results {
+		if result.err != nil {
+			output.FailedContainerNodes[result.nodeName] = struct{}{}
+			c.log.Error(result.err, "Failed to fetch container snapshot from nodemon pod",
+				"node", result.nodeName, "podIP", result.podIP)
+			continue
+		}
+
+		value := result.value
+		if value.usedLegacy {
+			output.LegacyFallbackCount++
+		}
+		if value.containerFailed {
+			output.FailedContainerNodes[result.nodeName] = struct{}{}
+		} else {
+			output.ContainerMetrics = append(output.ContainerMetrics, value.containerMetrics...)
+		}
+		output.RuntimeMetrics.JVM = append(output.RuntimeMetrics.JVM, value.runtimeMetrics.JVM...)
+		output.RuntimeMetrics.Runtimes = append(output.RuntimeMetrics.Runtimes, value.runtimeMetrics.Runtimes...)
+
+		if value.containerErr != nil {
+			c.log.Error(value.containerErr, "Legacy container snapshot fallback failed",
+				"node", result.nodeName, "podIP", result.podIP)
+		}
+		if value.runtimeErr != nil && !errors.Is(value.runtimeErr, errRuntimeMetricsDisabled) {
+			c.log.Error(value.runtimeErr, "Legacy runtime snapshot fallback failed",
+				"node", result.nodeName, "podIP", result.podIP)
+		}
+	}
+	return output, nil
+}
+
+func (c *NodemonClient) fetchContainerSnapshot(
+	ctx context.Context,
+	baseURL string,
+) (containerNodeSnapshot, error) {
+	snapshot, err := c.fetchCompositeContainerSnapshot(ctx, baseURL)
+	if err == nil {
+		return snapshot, nil
+	}
+	if _, fallback := fallbackReasonFromError(err); !fallback {
+		return containerNodeSnapshot{}, err
+	}
+	return c.fetchLegacyContainerSnapshot(ctx, baseURL), nil
+}
+
+func (c *NodemonClient) fetchCompositeContainerSnapshot(
+	ctx context.Context,
+	baseURL string,
+) (containerNodeSnapshot, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, baseURL+containerSnapshotPath, nil)
+	if err != nil {
+		return containerNodeSnapshot{}, fmt.Errorf("creating container snapshot request: %w", err)
+	}
+
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return containerNodeSnapshot{}, fmt.Errorf("HTTP request to nodemon container snapshot failed: %w", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	switch resp.StatusCode {
+	case http.StatusOK:
+	case http.StatusNotFound:
+		return containerNodeSnapshot{}, &snapshotFallbackError{reason: fallbackNotFound}
+	case http.StatusServiceUnavailable:
+		return containerNodeSnapshot{}, &snapshotFallbackError{reason: fallbackNotReady}
+	default:
+		return containerNodeSnapshot{}, fmt.Errorf("nodemon container snapshot returned status %d", resp.StatusCode)
+	}
+
+	var response containerSnapshotResponse
+	if err := decodeLimitedSnapshotJSON(resp.Body, containerSnapshotResponseLimit, &response); err != nil {
+		return containerNodeSnapshot{}, err
+	}
+	if response.SchemaVersion != snapshotSchemaVersion {
+		return containerNodeSnapshot{}, &snapshotFallbackError{
+			reason: fallbackUnsupportedSchema,
+			cause:  fmt.Errorf("got schema version %d", response.SchemaVersion),
+		}
+	}
+
+	result := containerNodeSnapshot{}
+	if snapshotSectionHasData(response.Sections.Containers.State) {
+		result.containerMetrics = response.ContainerMetrics
+	} else {
+		result.containerFailed = true
+	}
+	if snapshotSectionHasData(response.Sections.Runtime.State) {
+		result.runtimeMetrics = response.RuntimeMetrics
+	}
+	return result, nil
+}
+
+func (c *NodemonClient) fetchLegacyContainerSnapshot(
+	ctx context.Context,
+	baseURL string,
+) containerNodeSnapshot {
+	result := containerNodeSnapshot{usedLegacy: true}
+	var group errgroup.Group
+	group.Go(func() error {
+		result.containerMetrics, result.containerErr = c.fetchContainerMetrics(ctx, baseURL)
+		return nil
+	})
+	group.Go(func() error {
+		result.runtimeMetrics, result.runtimeErr = c.fetchRuntimeMetrics(ctx, baseURL+"/container/runtime-metrics")
+		return nil
+	})
+	_ = group.Wait()
+
+	result.containerFailed = result.containerErr != nil
+	if errors.Is(result.runtimeErr, errRuntimeMetricsDisabled) {
+		result.runtimeErr = nil
+		result.runtimeMetrics = NodemonRuntimeMetrics{}
+	}
+	return result
+}

--- a/internal/collector/nodemon_container_snapshot_client_test.go
+++ b/internal/collector/nodemon_container_snapshot_client_test.go
@@ -1,0 +1,328 @@
+package collector
+
+import (
+	"context"
+	"errors"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strconv"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/go-logr/logr"
+	"github.com/stretchr/testify/require"
+)
+
+func TestFetchAllContainerSnapshots_UsesOneBoundedCompositeWave(t *testing.T) {
+	const nodeCount = 25
+	var calls atomic.Int32
+	var active atomic.Int32
+	var maxActive atomic.Int32
+	timestamp := time.Date(2026, time.July, 30, 12, 0, 0, 0, time.UTC)
+	wantContainer := UnifiedContainerMetric{
+		NodeName: "node", Namespace: "ns", Pod: "pod", Container: "app", Timestamp: timestamp,
+		CPUUsageNanoCores: 42, MemoryWorkingSet: 84, MemoryUsageBytes: 85, MemoryRSSBytes: 86,
+		NetworkRxBytes: 87, NetworkTxBytes: 88, MemoryCacheBytes: 89, MemorySwapBytes: 90,
+		NetworkRxPacketsPerSec: 1, NetworkTxPacketsPerSec: 2,
+		NetworkRxErrorsPerSec: 3, NetworkTxErrorsPerSec: 4,
+		NetworkRxDropsPerSec: 5, NetworkTxDropsPerSec: 6,
+		DiskReadBytesPerSec: 7, DiskWriteBytesPerSec: 8,
+		DiskReadOpsPerSec: 9, DiskWriteOpsPerSec: 10, CPUThrottleFraction: 0.25,
+		CfsPeriods: 11, CfsThrottledPeriods: 12, CfsThrottledUsec: 13,
+		MemoryEventsMax: 14, CPUPressureSomeUsec: 15,
+		MemoryPressureSomeUsec: 16, MemoryPressureFullUsec: 17,
+		GPUUtilization: 18, GPUMemoryUsedMiB: 19, GPUMemoryFreeMiB: 20,
+		GPUPowerWatts: 21, GPUTemperature: 22,
+	}
+	wantJVM := NodemonJVMMetrics{
+		NodeName: "node", Pod: "pod", Namespace: "ns", Container: "app", ContainerID: "cid",
+		PidHost: 100, PidNS: 1, JavaCommand: "java -jar app.jar", JavaVersion: "26",
+		HeapSizeBytes: 122, HeapUsedBytes: 123, HeapMaxSizeBytes: 124,
+		FlagsExtracted: map[string]any{"xmx_bytes": float64(124)},
+		FlagSources:    map[string]any{"xmx_bytes": "cmdline"},
+		RawCmdline:     "-Xmx124", Timestamp: timestamp,
+	}
+	wantRuntime := NodemonRuntimeProcessMetrics{
+		Runtime: "go", NodeName: "node", Pod: "pod", Namespace: "ns", Container: "app",
+		ContainerID: "cid", PidHost: 200, PidNS: 2, Version: "go1.26",
+		VersionSource: "buildinfo", RawCmdline: "./app", Timestamp: timestamp,
+	}
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		require.Equal(t, containerSnapshotPath, r.URL.Path)
+		calls.Add(1)
+		now := active.Add(1)
+		updateAtomicMax(&maxActive, now)
+		time.Sleep(10 * time.Millisecond)
+		active.Add(-1)
+		writeNodeSnapshotTestJSON(t, w, map[string]any{
+			"schema_version":    1,
+			"container_metrics": []UnifiedContainerMetric{wantContainer},
+			"runtime_metrics": NodemonRuntimeMetrics{
+				JVM:      []NodemonJVMMetrics{wantJVM},
+				Runtimes: []NodemonRuntimeProcessMetrics{wantRuntime},
+			},
+			"sections": map[string]any{
+				"containers": map[string]any{"state": "ready"},
+				"runtime":    map[string]any{"state": "stale"},
+			},
+		})
+	}))
+	defer srv.Close()
+
+	client := newContainerSnapshotTestClient(t, srv, srv.Client(), nodeCount)
+	got, err := client.FetchAllContainerSnapshots(t.Context())
+	require.NoError(t, err)
+	require.Equal(t, nodeCount, got.CompositeCount)
+	require.Zero(t, got.LegacyFallbackCount)
+	require.Equal(t, int32(nodeCount), calls.Load())
+	require.LessOrEqual(t, maxActive.Load(), int32(maxConcurrentNodemonFetches))
+	require.Greater(t, maxActive.Load(), int32(1))
+	require.Len(t, got.ContainerMetrics, nodeCount)
+	require.Len(t, got.RuntimeMetrics.JVM, nodeCount)
+	require.Len(t, got.RuntimeMetrics.Runtimes, nodeCount)
+	require.Empty(t, got.FailedContainerNodes)
+	require.Equal(t, wantContainer, got.ContainerMetrics[0])
+	require.Equal(t, wantJVM, got.RuntimeMetrics.JVM[0])
+	require.Equal(t, wantRuntime, got.RuntimeMetrics.Runtimes[0])
+}
+
+func TestFetchAllContainerSnapshots_HandlesSectionStatesIndependently(t *testing.T) {
+	tests := []struct {
+		name           string
+		containerState string
+		runtimeState   string
+		wantContainers int
+		wantRuntime    int
+		wantFailedNode bool
+	}{
+		{
+			name: "disabled runtime", containerState: "ready", runtimeState: "disabled",
+			wantContainers: 1,
+		},
+		{
+			name: "failed containers keep runtime", containerState: "not_ready", runtimeState: "ready",
+			wantRuntime: 1, wantFailedNode: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+				writeNodeSnapshotTestJSON(t, w, map[string]any{
+					"schema_version":    1,
+					"container_metrics": []UnifiedContainerMetric{{NodeName: "node-a"}},
+					"runtime_metrics": NodemonRuntimeMetrics{
+						Runtimes: []NodemonRuntimeProcessMetrics{{Runtime: "go"}},
+					},
+					"sections": map[string]any{
+						"containers": map[string]any{"state": tt.containerState},
+						"runtime":    map[string]any{"state": tt.runtimeState},
+					},
+				})
+			}))
+			defer srv.Close()
+
+			got, err := newContainerSnapshotTestClient(t, srv, srv.Client(), 1).
+				FetchAllContainerSnapshots(t.Context())
+			require.NoError(t, err)
+			require.Len(t, got.ContainerMetrics, tt.wantContainers)
+			require.Len(t, got.RuntimeMetrics.Runtimes, tt.wantRuntime)
+			_, failed := got.FailedContainerNodes["node-00"]
+			require.Equal(t, tt.wantFailedNode, failed)
+		})
+	}
+}
+
+func TestFetchAllContainerSnapshots_FallsBackForCompatibilityFailures(t *testing.T) {
+	tests := []struct {
+		name      string
+		composite func(http.ResponseWriter)
+	}{
+		{name: "not found", composite: func(w http.ResponseWriter) {
+			http.Error(w, "missing", http.StatusNotFound)
+		}},
+		{name: "not ready", composite: func(w http.ResponseWriter) {
+			http.Error(w, "warming", http.StatusServiceUnavailable)
+		}},
+		{name: "unsupported schema", composite: func(w http.ResponseWriter) {
+			writeNodeSnapshotTestJSON(t, w, map[string]any{"schema_version": 2})
+		}},
+		{name: "malformed", composite: func(w http.ResponseWriter) {
+			_, _ = io.WriteString(w, `{"schema_version":`)
+		}},
+		{name: "oversized", composite: func(w http.ResponseWriter) {
+			_, _ = w.Write(make([]byte, containerSnapshotResponseLimit+1))
+		}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var legacyContainerCalls atomic.Int32
+			var legacyRuntimeCalls atomic.Int32
+			var active atomic.Int32
+			var maxActive atomic.Int32
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				switch r.URL.Path {
+				case containerSnapshotPath:
+					tt.composite(w)
+				case "/v2/container/metrics":
+					legacyContainerCalls.Add(1)
+					trackConcurrentLegacyRequest(&active, &maxActive)
+					writeNodeSnapshotTestJSON(t, w, []UnifiedContainerMetric{{NodeName: "legacy"}})
+				case "/container/runtime-metrics":
+					legacyRuntimeCalls.Add(1)
+					trackConcurrentLegacyRequest(&active, &maxActive)
+					writeNodeSnapshotTestJSON(t, w, NodemonRuntimeMetrics{
+						Runtimes: []NodemonRuntimeProcessMetrics{{Runtime: "go"}},
+					})
+				default:
+					http.NotFound(w, r)
+				}
+			}))
+			defer srv.Close()
+
+			got, err := newContainerSnapshotTestClient(t, srv, srv.Client(), 1).
+				FetchAllContainerSnapshots(t.Context())
+			require.NoError(t, err)
+			require.Equal(t, 1, got.CompositeCount)
+			require.Equal(t, 1, got.LegacyFallbackCount)
+			require.Len(t, got.ContainerMetrics, 1)
+			require.Len(t, got.RuntimeMetrics.Runtimes, 1)
+			require.Empty(t, got.FailedContainerNodes)
+			require.Equal(t, int32(1), legacyContainerCalls.Load())
+			require.Equal(t, int32(1), legacyRuntimeCalls.Load())
+			require.Equal(t, int32(2), maxActive.Load())
+		})
+	}
+}
+
+func TestFetchAllContainerSnapshots_LegacyRuntime404IsDisabled(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case containerSnapshotPath:
+			http.NotFound(w, r)
+		case "/v2/container/metrics":
+			writeNodeSnapshotTestJSON(t, w, []UnifiedContainerMetric{{NodeName: "legacy"}})
+		case "/container/runtime-metrics":
+			http.NotFound(w, r)
+		}
+	}))
+	defer srv.Close()
+
+	got, err := newContainerSnapshotTestClient(t, srv, srv.Client(), 1).
+		FetchAllContainerSnapshots(t.Context())
+	require.NoError(t, err)
+	require.Len(t, got.ContainerMetrics, 1)
+	require.Empty(t, got.RuntimeMetrics)
+	require.Empty(t, got.FailedContainerNodes)
+}
+
+func TestFetchAllContainerSnapshots_DoesNotRetryTransportFailures(t *testing.T) {
+	tests := []struct {
+		name    string
+		context func(t *testing.T) context.Context
+		client  *http.Client
+	}{
+		{
+			name: "connection failure",
+			context: func(t *testing.T) context.Context {
+				return t.Context()
+			},
+			client: &http.Client{Transport: roundTripFunc(func(*http.Request) (*http.Response, error) {
+				return nil, errors.New("connection refused")
+			})},
+		},
+		{
+			name: "canceled context",
+			context: func(t *testing.T) context.Context {
+				ctx, cancel := context.WithCancel(t.Context())
+				cancel()
+				return ctx
+			},
+			client: &http.Client{Transport: roundTripFunc(func(r *http.Request) (*http.Response, error) {
+				return nil, r.Context().Err()
+			})},
+		},
+		{
+			name: "timeout",
+			context: func(t *testing.T) context.Context {
+				return t.Context()
+			},
+			client: &http.Client{
+				Timeout: time.Millisecond,
+				Transport: roundTripFunc(func(r *http.Request) (*http.Response, error) {
+					<-r.Context().Done()
+					return nil, r.Context().Err()
+				}),
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var calls atomic.Int32
+			transport := tt.client.Transport
+			tt.client.Transport = roundTripFunc(func(r *http.Request) (*http.Response, error) {
+				calls.Add(1)
+				return transport.RoundTrip(r)
+			})
+			client := &NodemonClient{
+				port:          6061,
+				httpClient:    tt.client,
+				log:           logr.Discard(),
+				nodeToIP:      map[string]string{"node-a": "127.0.0.1"},
+				lastRefreshed: time.Now(),
+			}
+
+			got, err := client.FetchAllContainerSnapshots(tt.context(t))
+			require.NoError(t, err)
+			require.Equal(t, int32(1), calls.Load())
+			require.Contains(t, got.FailedContainerNodes, "node-a")
+			require.Zero(t, got.LegacyFallbackCount)
+		})
+	}
+}
+
+func newContainerSnapshotTestClient(
+	t *testing.T,
+	srv *httptest.Server,
+	httpClient *http.Client,
+	nodeCount int,
+) *NodemonClient {
+	t.Helper()
+	parsed, err := url.Parse(srv.URL)
+	require.NoError(t, err)
+	port, err := strconv.Atoi(parsed.Port())
+	require.NoError(t, err)
+	nodeToIP := make(map[string]string, nodeCount)
+	for i := 0; i < nodeCount; i++ {
+		nodeToIP["node-"+leftPadTwoDigits(i)] = parsed.Hostname()
+	}
+	return &NodemonClient{
+		port:          port,
+		httpClient:    httpClient,
+		log:           logr.Discard(),
+		nodeToIP:      nodeToIP,
+		lastRefreshed: time.Now(),
+	}
+}
+
+func leftPadTwoDigits(value int) string {
+	if value < 10 {
+		return "0" + strconv.Itoa(value)
+	}
+	return strconv.Itoa(value)
+}
+
+func updateAtomicMax(maxValue *atomic.Int32, value int32) {
+	for {
+		old := maxValue.Load()
+		if value <= old || maxValue.CompareAndSwap(old, value) {
+			return
+		}
+	}
+}

--- a/internal/collector/nodemon_node_snapshot_client.go
+++ b/internal/collector/nodemon_node_snapshot_client.go
@@ -1,0 +1,153 @@
+package collector
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net/http"
+
+	"golang.org/x/sync/errgroup"
+)
+
+const (
+	nodeSnapshotPath          = "/v2/node/snapshot"
+	nodeSnapshotResponseLimit = 1 << 20
+)
+
+// NodeCollectionSnapshot contains the independently usable node and GPU
+// sections returned by one nodemon request.
+type NodeCollectionSnapshot struct {
+	NodeMetric     *UnifiedNodeMetric
+	GPUMetrics     map[string]interface{}
+	UsedLegacy     bool
+	FallbackReason string
+	// GPUStale is true when the composite GPU section came back stale — nodemon
+	// is serving a last-good snapshot because its DCGM refresh is failing — so we
+	// dropped it rather than ingesting unbounded-age data. Surfaced so the
+	// collector can emit a per-sweep telemetry signal (the DCGM problem is only
+	// otherwise visible in nodemon's own logs).
+	GPUStale bool
+}
+
+// FetchNodeSnapshotByNode fetches one composite cache snapshot for nodeName.
+// Legacy endpoints are queried only when the nodemon does not support a usable
+// composite contract; transport failures are returned without another request.
+func (c *NodemonClient) FetchNodeSnapshotByNode(
+	ctx context.Context,
+	nodeName string,
+) (*NodeCollectionSnapshot, error) {
+	nodeToIP, err := c.refreshCache(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	podIP, ok := nodeToIP[nodeName]
+	if !ok {
+		return nil, nil
+	}
+
+	baseURL := fmt.Sprintf("http://%s:%d", podIP, c.port)
+	snapshot, err := c.fetchNodeSnapshot(ctx, baseURL)
+	if err == nil {
+		return snapshot, nil
+	}
+
+	reason, fallback := fallbackReasonFromError(err)
+	if !fallback {
+		return nil, err
+	}
+	return c.fetchLegacyNodeSnapshot(ctx, baseURL, reason)
+}
+
+func (c *NodemonClient) fetchNodeSnapshot(
+	ctx context.Context,
+	baseURL string,
+) (*NodeCollectionSnapshot, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, baseURL+nodeSnapshotPath, nil)
+	if err != nil {
+		return nil, fmt.Errorf("creating node snapshot request: %w", err)
+	}
+
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("HTTP request to nodemon node snapshot failed: %w", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	switch resp.StatusCode {
+	case http.StatusOK:
+	case http.StatusNotFound:
+		return nil, &snapshotFallbackError{reason: fallbackNotFound}
+	case http.StatusServiceUnavailable:
+		return nil, &snapshotFallbackError{reason: fallbackNotReady}
+	default:
+		return nil, fmt.Errorf("nodemon node snapshot returned status %d", resp.StatusCode)
+	}
+
+	var response nodeSnapshotResponse
+	if err := decodeLimitedSnapshotJSON(resp.Body, nodeSnapshotResponseLimit, &response); err != nil {
+		return nil, err
+	}
+	if response.SchemaVersion != snapshotSchemaVersion {
+		return nil, &snapshotFallbackError{
+			reason: fallbackUnsupportedSchema,
+			cause:  fmt.Errorf("got schema version %d", response.SchemaVersion),
+		}
+	}
+
+	result := &NodeCollectionSnapshot{GPUMetrics: map[string]interface{}{}}
+	if snapshotSectionHasData(response.Sections.Node.State) {
+		result.NodeMetric = response.NodeMetrics
+	}
+	// Ingest GPU only when the section is fresh (ready), never stale. A stale
+	// section means nodemon's DCGM refresh is failing and it is serving a
+	// last-good snapshot of UNBOUNDED age (the state is a flag, not a max age).
+	// Matching main's behavior during a DCGM outage, we emit no GPU for this
+	// node rather than ingesting arbitrarily old values stamped as current. The
+	// node section is never stale (the unified exporter always publishes ready),
+	// so only GPU needs this guard.
+	if response.Sections.GPU.State == snapshotStateReady {
+		result.GPUMetrics = response.GPUSummary.downstreamMetrics()
+	} else if response.Sections.GPU.State == snapshotStateStale {
+		result.GPUStale = true
+	}
+	return result, nil
+}
+
+func (c *NodemonClient) fetchLegacyNodeSnapshot(
+	ctx context.Context,
+	baseURL string,
+	reason snapshotFallbackReason,
+) (*NodeCollectionSnapshot, error) {
+	result := &NodeCollectionSnapshot{
+		GPUMetrics:     map[string]interface{}{},
+		UsedLegacy:     true,
+		FallbackReason: string(reason),
+	}
+
+	var nodeMetric *UnifiedNodeMetric
+	var gpuMetrics []NodemonMetric
+	var nodeErr error
+	var gpuErr error
+	var group errgroup.Group
+	group.Go(func() error {
+		nodeMetric, nodeErr = c.fetchNodeMetrics(ctx, baseURL)
+		return nil
+	})
+	group.Go(func() error {
+		gpuMetrics, gpuErr = c.fetchMetrics(ctx, baseURL+"/container/metrics")
+		return nil
+	})
+	_ = group.Wait()
+
+	if nodeErr == nil {
+		result.NodeMetric = nodeMetric
+	}
+	if gpuErr == nil {
+		result.GPUMetrics = NodeGPUMetricsFromNodemon(gpuMetrics)
+	}
+	if nodeErr != nil || gpuErr != nil {
+		return result, errors.Join(nodeErr, gpuErr)
+	}
+	return result, nil
+}

--- a/internal/collector/nodemon_node_snapshot_client_test.go
+++ b/internal/collector/nodemon_node_snapshot_client_test.go
@@ -1,0 +1,367 @@
+package collector
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strconv"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/go-logr/logr"
+	"github.com/stretchr/testify/require"
+)
+
+func TestFetchNodeSnapshotByNode_UsesCompositeResponse(t *testing.T) {
+	var compositeCalls atomic.Int32
+	var legacyNodeCalls atomic.Int32
+	var legacyGPUCalls atomic.Int32
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/v2/node/snapshot":
+			compositeCalls.Add(1)
+			writeNodeSnapshotTestJSON(t, w, map[string]any{
+				"schema_version": 1,
+				"node_metrics": map[string]any{
+					"node_name":                  "node-a",
+					"timestamp":                  "2026-07-30T12:00:00Z",
+					"cpu_usage_nanocores":        1_000_000_000,
+					"memory_working_set_bytes":   4_294_967_296,
+					"network_rx_bytes_per_sec":   11.0,
+					"network_tx_bytes_per_sec":   12.0,
+					"network_rx_packets_per_sec": 13.0,
+					"network_tx_packets_per_sec": 14.0,
+					"network_rx_errors_per_sec":  15.0,
+					"network_tx_errors_per_sec":  16.0,
+					"network_rx_drops_per_sec":   17.0,
+					"network_tx_drops_per_sec":   18.0,
+					"disk_read_bytes_per_sec":    19.0,
+					"disk_write_bytes_per_sec":   20.0,
+					"disk_read_ops_per_sec":      21.0,
+					"disk_write_ops_per_sec":     22.0,
+				},
+				"gpu_summary": map[string]any{
+					"gpu_count":                    2.0,
+					"gpu_utilization_avg":          73.5,
+					"gpu_utilization_max":          91.0,
+					"gpu_memory_used_total":        32_768.0,
+					"gpu_memory_free_total":        16_384.0,
+					"gpu_memory_total_mb":          49_152.0,
+					"gpu_power_usage_total":        500.0,
+					"gpu_temperature_avg":          65.0,
+					"gpu_temperature_max":          70.0,
+					"gpu_memory_temperature_avg":   60.0,
+					"gpu_memory_temperature_max":   64.0,
+					"gpu_tensor_utilization_avg":   0.8,
+					"gpu_dram_utilization_avg":     0.7,
+					"gpu_pcie_tx_bytes_total":      100.0,
+					"gpu_pcie_rx_bytes_total":      200.0,
+					"gpu_graphics_utilization_avg": 0.6,
+					"gpu_usage":                    1.47,
+					"gpu_models":                   []string{"2x A100"},
+					"gpu_uuids":                    []string{"GPU-1", "GPU-2"},
+				},
+				"sections": map[string]any{
+					"node": map[string]any{"state": "ready", "collected_at": "2026-07-30T12:00:00Z"},
+					// ready (not stale): the collector ingests GPU only when fresh,
+					// and this case asserts the full summary is parsed and mapped.
+					"gpu": map[string]any{"state": "ready", "collected_at": "2026-07-30T12:00:05Z"},
+				},
+			})
+		case "/node/metrics":
+			legacyNodeCalls.Add(1)
+			http.Error(w, "unexpected legacy request", http.StatusInternalServerError)
+		case "/container/metrics":
+			legacyGPUCalls.Add(1)
+			http.Error(w, "unexpected legacy request", http.StatusInternalServerError)
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer srv.Close()
+
+	client := newNodeSnapshotTestClient(t, srv, srv.Client())
+	got, err := client.FetchNodeSnapshotByNode(t.Context(), "node-a")
+	require.NoError(t, err)
+	require.NotNil(t, got)
+	require.False(t, got.UsedLegacy)
+	require.Empty(t, got.FallbackReason)
+	require.Equal(t, int32(1), compositeCalls.Load())
+	require.Zero(t, legacyNodeCalls.Load())
+	require.Zero(t, legacyGPUCalls.Load())
+
+	require.Equal(t, &UnifiedNodeMetric{
+		NodeName:               "node-a",
+		Timestamp:              time.Date(2026, time.July, 30, 12, 0, 0, 0, time.UTC),
+		CPUUsageNanoCores:      1_000_000_000,
+		MemoryWorkingSet:       4_294_967_296,
+		NetworkRxBytesPerSec:   11,
+		NetworkTxBytesPerSec:   12,
+		NetworkRxPacketsPerSec: 13,
+		NetworkTxPacketsPerSec: 14,
+		NetworkRxErrorsPerSec:  15,
+		NetworkTxErrorsPerSec:  16,
+		NetworkRxDropsPerSec:   17,
+		NetworkTxDropsPerSec:   18,
+		DiskReadBytesPerSec:    19,
+		DiskWriteBytesPerSec:   20,
+		DiskReadOpsPerSec:      21,
+		DiskWriteOpsPerSec:     22,
+	}, got.NodeMetric)
+	require.Equal(t, map[string]interface{}{
+		"GPUCount":                  2.0,
+		"GPUUtilizationAvg":         73.5,
+		"GPUUtilizationMax":         91.0,
+		"GPUMemoryUsedTotal":        32_768.0,
+		"GPUMemoryFreeTotal":        16_384.0,
+		"GPUMemoryTotalMb":          49_152.0,
+		"GPUPowerUsageTotal":        500.0,
+		"GPUTemperatureAvg":         65.0,
+		"GPUTemperatureMax":         70.0,
+		"GPUMemoryTemperatureAvg":   60.0,
+		"GPUMemoryTemperatureMax":   64.0,
+		"GPUTensorUtilizationAvg":   0.8,
+		"GPUDramUtilizationAvg":     0.7,
+		"GPUPCIeTxBytesTotal":       100.0,
+		"GPUPCIeRxBytesTotal":       200.0,
+		"GPUGraphicsUtilizationAvg": 0.6,
+		"GPUUsage":                  1.47,
+		"GPUModels":                 []string{"2x A100"},
+		"GPUUUIDs":                  []string{"GPU-1", "GPU-2"},
+	}, got.GPUMetrics)
+}
+
+func TestFetchNodeSnapshotByNode_AcceptsReadyEmptyGPU(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		writeNodeSnapshotTestJSON(t, w, map[string]any{
+			"schema_version": 1,
+			"node_metrics":   map[string]any{"node_name": "node-a"},
+			"sections": map[string]any{
+				"node": map[string]any{"state": "ready"},
+				"gpu":  map[string]any{"state": "ready"},
+			},
+		})
+	}))
+	defer srv.Close()
+
+	got, err := newNodeSnapshotTestClient(t, srv, srv.Client()).
+		FetchNodeSnapshotByNode(t.Context(), "node-a")
+	require.NoError(t, err)
+	require.NotNil(t, got.NodeMetric)
+	require.Empty(t, got.GPUMetrics)
+	require.False(t, got.UsedLegacy)
+}
+
+func TestFetchNodeSnapshotByNode_PreservesUsableSectionsIndependently(t *testing.T) {
+	tests := []struct {
+		name         string
+		nodeState    string
+		gpuState     string
+		wantNode     bool
+		wantGPUCount bool
+	}{
+		{name: "node usable", nodeState: "stale", gpuState: "not_ready", wantNode: true},
+		{name: "gpu usable", nodeState: "not_ready", gpuState: "ready", wantGPUCount: true},
+		// A stale GPU section is dropped, not ingested: it can be of unbounded
+		// age during a DCGM outage, so we emit no GPU rather than stale values.
+		{name: "gpu stale dropped", nodeState: "ready", gpuState: "stale", wantNode: true, wantGPUCount: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+				writeNodeSnapshotTestJSON(t, w, map[string]any{
+					"schema_version": 1,
+					"node_metrics":   map[string]any{"node_name": "node-a"},
+					"gpu_summary":    map[string]any{"gpu_count": 1.0},
+					"sections": map[string]any{
+						"node": map[string]any{"state": tt.nodeState},
+						"gpu":  map[string]any{"state": tt.gpuState},
+					},
+				})
+			}))
+			defer srv.Close()
+
+			got, err := newNodeSnapshotTestClient(t, srv, srv.Client()).
+				FetchNodeSnapshotByNode(t.Context(), "node-a")
+			require.NoError(t, err)
+			require.Equal(t, tt.wantNode, got.NodeMetric != nil)
+			_, hasGPUCount := got.GPUMetrics["GPUCount"]
+			require.Equal(t, tt.wantGPUCount, hasGPUCount)
+		})
+	}
+}
+
+func TestFetchNodeSnapshotByNode_FallsBackForCompatibilityFailures(t *testing.T) {
+	tests := []struct {
+		name      string
+		composite func(http.ResponseWriter)
+		reason    string
+	}{
+		{name: "not found", reason: "not_found", composite: func(w http.ResponseWriter) {
+			http.Error(w, "missing", http.StatusNotFound)
+		}},
+		{name: "not ready", reason: "not_ready", composite: func(w http.ResponseWriter) {
+			http.Error(w, "warming", http.StatusServiceUnavailable)
+		}},
+		{name: "unsupported schema", reason: "unsupported_schema", composite: func(w http.ResponseWriter) {
+			writeNodeSnapshotTestJSON(t, w, map[string]any{"schema_version": 2})
+		}},
+		{name: "malformed", reason: "malformed", composite: func(w http.ResponseWriter) {
+			_, _ = io.WriteString(w, `{"schema_version":`)
+		}},
+		{name: "trailing JSON", reason: "malformed", composite: func(w http.ResponseWriter) {
+			_, _ = io.WriteString(w, `{"schema_version":1,"sections":{"node":{"state":"ready"},"gpu":{"state":"ready"}}} {}`)
+		}},
+		{name: "oversized", reason: "oversized", composite: func(w http.ResponseWriter) {
+			_, _ = w.Write(make([]byte, nodeSnapshotResponseLimit+1))
+		}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var legacyNodeCalls atomic.Int32
+			var legacyGPUCalls atomic.Int32
+			var active atomic.Int32
+			var maxActive atomic.Int32
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				switch r.URL.Path {
+				case "/v2/node/snapshot":
+					tt.composite(w)
+				case "/node/metrics":
+					legacyNodeCalls.Add(1)
+					trackConcurrentLegacyRequest(&active, &maxActive)
+					writeNodeSnapshotTestJSON(t, w, UnifiedNodeMetric{NodeName: "legacy-node"})
+				case "/container/metrics":
+					legacyGPUCalls.Add(1)
+					trackConcurrentLegacyRequest(&active, &maxActive)
+					writeNodeSnapshotTestJSON(t, w, []NodemonMetric{{GPUUtilization: 50}})
+				default:
+					http.NotFound(w, r)
+				}
+			}))
+			defer srv.Close()
+
+			got, err := newNodeSnapshotTestClient(t, srv, srv.Client()).
+				FetchNodeSnapshotByNode(t.Context(), "node-a")
+			require.NoError(t, err)
+			require.True(t, got.UsedLegacy)
+			require.Equal(t, tt.reason, got.FallbackReason)
+			require.Equal(t, "legacy-node", got.NodeMetric.NodeName)
+			require.Equal(t, 0.5, got.GPUMetrics["GPUUsage"])
+			require.Equal(t, int32(1), legacyNodeCalls.Load())
+			require.Equal(t, int32(1), legacyGPUCalls.Load())
+			require.Equal(t, int32(2), maxActive.Load(), "legacy requests must overlap")
+		})
+	}
+}
+
+func TestFetchNodeSnapshotByNode_DoesNotRetryTransportFailures(t *testing.T) {
+	tests := []struct {
+		name    string
+		context func(t *testing.T) context.Context
+		client  *http.Client
+	}{
+		{
+			name: "connection failure",
+			context: func(t *testing.T) context.Context {
+				return t.Context()
+			},
+			client: &http.Client{Transport: roundTripFunc(func(*http.Request) (*http.Response, error) {
+				return nil, errors.New("connection refused")
+			})},
+		},
+		{
+			name: "canceled context",
+			context: func(t *testing.T) context.Context {
+				ctx, cancel := context.WithCancel(t.Context())
+				cancel()
+				return ctx
+			},
+			client: &http.Client{Transport: roundTripFunc(func(r *http.Request) (*http.Response, error) {
+				return nil, r.Context().Err()
+			})},
+		},
+		{
+			name: "request timeout",
+			context: func(t *testing.T) context.Context {
+				return t.Context()
+			},
+			client: &http.Client{
+				Timeout: time.Millisecond,
+				Transport: roundTripFunc(func(r *http.Request) (*http.Response, error) {
+					<-r.Context().Done()
+					return nil, r.Context().Err()
+				}),
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var calls atomic.Int32
+			transport := tt.client.Transport
+			tt.client.Transport = roundTripFunc(func(r *http.Request) (*http.Response, error) {
+				calls.Add(1)
+				return transport.RoundTrip(r)
+			})
+			client := &NodemonClient{
+				port:          6061,
+				httpClient:    tt.client,
+				log:           logr.Discard(),
+				nodeToIP:      map[string]string{"node-a": "127.0.0.1"},
+				lastRefreshed: time.Now(),
+			}
+
+			got, err := client.FetchNodeSnapshotByNode(tt.context(t), "node-a")
+			require.Error(t, err)
+			require.Nil(t, got)
+			require.Equal(t, int32(1), calls.Load(), "transport failures must not retry legacy routes")
+		})
+	}
+}
+
+func newNodeSnapshotTestClient(t *testing.T, srv *httptest.Server, httpClient *http.Client) *NodemonClient {
+	t.Helper()
+	parsed, err := url.Parse(srv.URL)
+	require.NoError(t, err)
+	port, err := strconv.Atoi(parsed.Port())
+	require.NoError(t, err)
+	return &NodemonClient{
+		port:          port,
+		httpClient:    httpClient,
+		log:           logr.Discard(),
+		nodeToIP:      map[string]string{"node-a": parsed.Hostname()},
+		lastRefreshed: time.Now(),
+	}
+}
+
+func writeNodeSnapshotTestJSON(t *testing.T, w http.ResponseWriter, value any) {
+	t.Helper()
+	w.Header().Set("Content-Type", "application/json")
+	require.NoError(t, json.NewEncoder(w).Encode(value))
+}
+
+func trackConcurrentLegacyRequest(active, maxActive *atomic.Int32) {
+	now := active.Add(1)
+	for {
+		old := maxActive.Load()
+		if now <= old || maxActive.CompareAndSwap(old, now) {
+			break
+		}
+	}
+	time.Sleep(20 * time.Millisecond)
+	active.Add(-1)
+}
+
+type roundTripFunc func(*http.Request) (*http.Response, error)
+
+func (f roundTripFunc) RoundTrip(r *http.Request) (*http.Response, error) {
+	return f(r)
+}

--- a/internal/collector/nodemon_snapshot_types.go
+++ b/internal/collector/nodemon_snapshot_types.go
@@ -1,0 +1,183 @@
+package collector
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"time"
+)
+
+const snapshotSchemaVersion = 1
+
+type snapshotSectionState string
+
+const (
+	snapshotStateReady    snapshotSectionState = "ready"
+	snapshotStateStale    snapshotSectionState = "stale"
+	snapshotStateNotReady snapshotSectionState = "not_ready"
+	snapshotStateDisabled snapshotSectionState = "disabled"
+)
+
+type snapshotSectionStatus struct {
+	State       snapshotSectionState `json:"state"`
+	CollectedAt *time.Time           `json:"collected_at,omitempty"`
+}
+
+type nodeSnapshotSections struct {
+	Node snapshotSectionStatus `json:"node"`
+	GPU  snapshotSectionStatus `json:"gpu"`
+}
+
+type nodeGPUSummary struct {
+	GPUCount                  float64  `json:"gpu_count"`
+	GPUUtilizationAvg         float64  `json:"gpu_utilization_avg"`
+	GPUUtilizationMax         float64  `json:"gpu_utilization_max"`
+	GPUMemoryUsedTotal        float64  `json:"gpu_memory_used_total"`
+	GPUMemoryFreeTotal        float64  `json:"gpu_memory_free_total"`
+	GPUMemoryTotalMb          float64  `json:"gpu_memory_total_mb"`
+	GPUPowerUsageTotal        float64  `json:"gpu_power_usage_total"`
+	GPUTemperatureAvg         float64  `json:"gpu_temperature_avg"`
+	GPUTemperatureMax         float64  `json:"gpu_temperature_max"`
+	GPUMemoryTemperatureAvg   float64  `json:"gpu_memory_temperature_avg"`
+	GPUMemoryTemperatureMax   float64  `json:"gpu_memory_temperature_max"`
+	GPUTensorUtilizationAvg   float64  `json:"gpu_tensor_utilization_avg"`
+	GPUDramUtilizationAvg     float64  `json:"gpu_dram_utilization_avg"`
+	GPUPCIeTxBytesTotal       float64  `json:"gpu_pcie_tx_bytes_total"`
+	GPUPCIeRxBytesTotal       float64  `json:"gpu_pcie_rx_bytes_total"`
+	GPUGraphicsUtilizationAvg float64  `json:"gpu_graphics_utilization_avg"`
+	GPUUsage                  float64  `json:"gpu_usage"`
+	GPUModels                 []string `json:"gpu_models"`
+	GPUUUIDs                  []string `json:"gpu_uuids"`
+}
+
+type nodeSnapshotResponse struct {
+	SchemaVersion int                  `json:"schema_version"`
+	NodeMetrics   *UnifiedNodeMetric   `json:"node_metrics,omitempty"`
+	GPUSummary    *nodeGPUSummary      `json:"gpu_summary,omitempty"`
+	Sections      nodeSnapshotSections `json:"sections"`
+}
+
+type containerSnapshotSections struct {
+	Containers snapshotSectionStatus `json:"containers"`
+	Runtime    snapshotSectionStatus `json:"runtime"`
+}
+
+type containerSnapshotResponse struct {
+	SchemaVersion    int                       `json:"schema_version"`
+	ContainerMetrics []UnifiedContainerMetric  `json:"container_metrics"`
+	RuntimeMetrics   NodemonRuntimeMetrics     `json:"runtime_metrics"`
+	Sections         containerSnapshotSections `json:"sections"`
+}
+
+type snapshotFallbackReason string
+
+const (
+	fallbackNotFound          snapshotFallbackReason = "not_found"
+	fallbackNotReady          snapshotFallbackReason = "not_ready"
+	fallbackUnsupportedSchema snapshotFallbackReason = "unsupported_schema"
+	fallbackMalformed         snapshotFallbackReason = "malformed"
+	fallbackOversized         snapshotFallbackReason = "oversized"
+)
+
+type snapshotFallbackError struct {
+	reason snapshotFallbackReason
+	cause  error
+}
+
+func (e *snapshotFallbackError) Error() string {
+	if e.cause == nil {
+		return fmt.Sprintf("composite snapshot fallback required: %s", e.reason)
+	}
+	return fmt.Sprintf("composite snapshot fallback required: %s: %v", e.reason, e.cause)
+}
+
+func (e *snapshotFallbackError) Unwrap() error {
+	return e.cause
+}
+
+func fallbackReasonFromError(err error) (snapshotFallbackReason, bool) {
+	var fallbackErr *snapshotFallbackError
+	if !errors.As(err, &fallbackErr) {
+		return "", false
+	}
+	return fallbackErr.reason, true
+}
+
+func decodeLimitedSnapshotJSON(body io.Reader, limit int64, dst any) error {
+	// Stream-decode straight off the reader without buffering the whole body
+	// (matching the legacy per-metric endpoints' memory profile — no io.ReadAll
+	// "photocopy" of the payload). The LimitedReader permits up to limit+1 bytes:
+	// the underlying reader can never yield more than the body actually holds, so
+	// a body of <= limit bytes always leaves at least one byte of budget, and
+	// draining the budget to zero unambiguously means the body exceeded limit.
+	lr := &io.LimitedReader{R: body, N: limit + 1}
+	decoder := json.NewDecoder(lr)
+
+	if err := decoder.Decode(dst); err != nil {
+		return classifyLimitedDecodeError(lr, err)
+	}
+
+	// Reject trailing data after the single JSON value.
+	if err := decoder.Decode(&struct{}{}); !errors.Is(err, io.EOF) {
+		if err == nil {
+			err = errors.New("multiple JSON values")
+		}
+		return classifyLimitedDecodeError(lr, err)
+	}
+
+	// A clean single value — but the body itself may still have exceeded the cap
+	// (e.g. a valid value of exactly limit+1 bytes).
+	if lr.N <= 0 {
+		return &snapshotFallbackError{reason: fallbackOversized}
+	}
+	return nil
+}
+
+// classifyLimitedDecodeError decides whether a decode/limit failure was caused
+// by the body exceeding limit (oversized) or by genuinely malformed JSON. It
+// drains any bytes the decoder left unread into io.Discard — which copies
+// through a small pooled buffer and never retains the payload — so the size
+// check stays content-agnostic (matching the original io.ReadAll length check,
+// e.g. a limit+1 blob of non-JSON bytes is oversized, not malformed) without
+// buffering the whole body on the valid hot path, where this is never reached.
+func classifyLimitedDecodeError(lr *io.LimitedReader, cause error) error {
+	if lr.N > 0 {
+		_, _ = io.Copy(io.Discard, lr)
+	}
+	if lr.N <= 0 {
+		return &snapshotFallbackError{reason: fallbackOversized, cause: cause}
+	}
+	return &snapshotFallbackError{reason: fallbackMalformed, cause: cause}
+}
+
+func snapshotSectionHasData(state snapshotSectionState) bool {
+	return state == snapshotStateReady || state == snapshotStateStale
+}
+
+func (summary *nodeGPUSummary) downstreamMetrics() map[string]interface{} {
+	if summary == nil {
+		return map[string]interface{}{}
+	}
+	return map[string]interface{}{
+		"GPUCount":                  summary.GPUCount,
+		"GPUUtilizationAvg":         summary.GPUUtilizationAvg,
+		"GPUUtilizationMax":         summary.GPUUtilizationMax,
+		"GPUMemoryUsedTotal":        summary.GPUMemoryUsedTotal,
+		"GPUMemoryFreeTotal":        summary.GPUMemoryFreeTotal,
+		"GPUMemoryTotalMb":          summary.GPUMemoryTotalMb,
+		"GPUPowerUsageTotal":        summary.GPUPowerUsageTotal,
+		"GPUTemperatureAvg":         summary.GPUTemperatureAvg,
+		"GPUTemperatureMax":         summary.GPUTemperatureMax,
+		"GPUMemoryTemperatureAvg":   summary.GPUMemoryTemperatureAvg,
+		"GPUMemoryTemperatureMax":   summary.GPUMemoryTemperatureMax,
+		"GPUTensorUtilizationAvg":   summary.GPUTensorUtilizationAvg,
+		"GPUDramUtilizationAvg":     summary.GPUDramUtilizationAvg,
+		"GPUPCIeTxBytesTotal":       summary.GPUPCIeTxBytesTotal,
+		"GPUPCIeRxBytesTotal":       summary.GPUPCIeRxBytesTotal,
+		"GPUGraphicsUtilizationAvg": summary.GPUGraphicsUtilizationAvg,
+		"GPUUsage":                  summary.GPUUsage,
+		"GPUModels":                 append([]string(nil), summary.GPUModels...),
+		"GPUUUIDs":                  append([]string(nil), summary.GPUUUIDs...),
+	}
+}

--- a/internal/nodemon/gpu_cache.go
+++ b/internal/nodemon/gpu_cache.go
@@ -1,0 +1,208 @@
+package nodemon
+
+import (
+	"context"
+	"slices"
+	"sync"
+	"time"
+
+	"github.com/go-logr/logr"
+)
+
+// Bounds for the GPU snapshot refresh interval. Refreshing faster than DCGM
+// updates (DCGM_EXPORTER_INTERVAL, 5s by default) yields no new data; the
+// upper bound keeps the snapshot fresh enough for the container collector,
+// which polls /container/metrics every ~10s.
+const (
+	MinGPURefreshInterval     = 5 * time.Second
+	DefaultGPURefreshInterval = 10 * time.Second
+
+	// minGPUStalenessThreshold is the floor for how old a cached snapshot may be
+	// and still be served as fresh. The effective threshold is
+	// max(2*interval, minGPUStalenessThreshold), so at the default 10s interval a
+	// single dropped or slow refresh tick (a GC pause, CPU starvation, one failed
+	// DCGM scrape) does NOT blank GPU data — the last-good snapshot is served for
+	// up to 20s. Only a sustained gap beyond the threshold marks the snapshot
+	// stale everywhere (QueryMetrics returns nil, QueryGPUSnapshot reports stale),
+	// so arbitrarily-old data is never served as current — this is what protects
+	// both the node path (QueryGPUSnapshot) and the container/legacy path
+	// (QueryMetrics, read by the unified exporter's per-container GPU merge).
+	minGPUStalenessThreshold = 20 * time.Second
+
+	// gpuRefreshCycleTimeout bounds a single refresh (getDCGMUrls' k8s List +
+	// the DCGM scrape). It is comfortably above the per-URL scrape timeout (10s)
+	// so a legitimately slow refresh is never cut short; it exists only so a
+	// hung k8s API cannot wedge the refresher forever.
+	gpuRefreshCycleTimeout = 30 * time.Second
+)
+
+// CachedGPUExporter wraps a MetricsQuerier (the DCGM-scraping *Exporter) with a
+// single periodically-refreshed snapshot. It exists to collapse what used to be
+// many independent DCGM scrapes — the background collection loop plus a fresh
+// scrape+parse on every /container/metrics request — into exactly one
+// scrape+parse per interval. The full DCGM parse is the nodemon's dominant heap
+// allocation on GPU nodes, so removing overlapping/per-request parses is the
+// primary defence against OOM at the 256Mi cap.
+//
+// QueryMetrics is a non-blocking read of the last snapshot, so it is safe to
+// call from any number of concurrent HTTP handlers without triggering work.
+type CachedGPUExporter struct {
+	source             MetricsQuerier
+	interval           time.Duration
+	stalenessThreshold time.Duration
+	log                logr.Logger
+
+	mu          sync.RWMutex
+	snapshot    []GPUMetric
+	summary     *NodeGPUSummary
+	lastSuccess time.Time
+}
+
+// NewCachedGPUExporter wraps source with a snapshot cache. interval is clamped
+// to at least MinGPURefreshInterval; a non-positive interval selects the
+// default.
+func NewCachedGPUExporter(source MetricsQuerier, interval time.Duration, log logr.Logger) *CachedGPUExporter {
+	if interval <= 0 {
+		interval = DefaultGPURefreshInterval
+	}
+	if interval < MinGPURefreshInterval {
+		interval = MinGPURefreshInterval
+	}
+	// Tolerate one dropped/slow refresh tick (2*interval) but never less than
+	// the 20s floor, so a brief latency hiccup in the refresher does not blank
+	// GPU data.
+	stalenessThreshold := 2 * interval
+	if stalenessThreshold < minGPUStalenessThreshold {
+		stalenessThreshold = minGPUStalenessThreshold
+	}
+	return &CachedGPUExporter{
+		source:             source,
+		interval:           interval,
+		stalenessThreshold: stalenessThreshold,
+		log:                log.WithName("gpu-cache"),
+	}
+}
+
+// Start runs an initial refresh and then refreshes on a ticker until ctx is
+// cancelled. Call it once in its own goroutine.
+func (c *CachedGPUExporter) Start(ctx context.Context) {
+	c.log.Info("Starting GPU snapshot refresher", "interval", c.interval.String())
+	c.refreshCycle(ctx)
+
+	ticker := time.NewTicker(c.interval)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			c.refreshCycle(ctx)
+		}
+	}
+}
+
+// refreshCycle bounds a single refresh with a per-cycle deadline so a hung
+// dependency cannot wedge the refresher indefinitely. In particular
+// getDCGMUrls' k8s List is otherwise unbounded (the per-URL scrape already has
+// its own 10s timeout); gpuRefreshCycleTimeout is generous relative to that
+// scrape budget, so only a genuine hang trips it, not a slow-but-legitimate
+// refresh. Mirrors the per-cycle timeout the JVM/runtime collectors use.
+func (c *CachedGPUExporter) refreshCycle(parentCtx context.Context) {
+	cycleCtx, cancel := context.WithTimeout(parentCtx, gpuRefreshCycleTimeout)
+	defer cancel()
+	c.Refresh(cycleCtx)
+}
+
+// Refresh performs one DCGM scrape+parse via the wrapped source and atomically
+// swaps in the new snapshot. On error it keeps the previous snapshot (serving
+// slightly stale data beats serving nothing) and, once refreshes have been
+// failing for gpuStalenessFactor intervals, logs a staleness warning so the
+// gap is visible rather than silent.
+func (c *CachedGPUExporter) Refresh(ctx context.Context) {
+	metrics, err := c.source.QueryMetrics(ctx)
+	var summary *NodeGPUSummary
+	if err == nil {
+		summary = SummarizeNodeGPU(metrics)
+	}
+
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	if err != nil {
+		age := time.Since(c.lastSuccess)
+		if !c.lastSuccess.IsZero() && age > c.stalenessThreshold {
+			c.log.Error(err, "GPU snapshot is stale; DCGM refresh has been failing",
+				"staleFor", age.String())
+		} else {
+			c.log.V(1).Info("GPU refresh failed; serving previous snapshot", "error", err.Error())
+		}
+		return
+	}
+
+	c.snapshot = metrics
+	c.summary = summary
+	c.lastSuccess = time.Now()
+}
+
+// staleLocked reports whether the cached snapshot has aged past the staleness
+// threshold (or was never populated). Callers must hold at least the read lock.
+func (c *CachedGPUExporter) staleLocked() bool {
+	if c.lastSuccess.IsZero() {
+		return true
+	}
+	return time.Since(c.lastSuccess) > c.stalenessThreshold
+}
+
+// QueryMetrics returns the most recent snapshot without scraping, or nil once
+// the snapshot has aged past the staleness threshold. It satisfies
+// MetricsQuerier so it drops in wherever the raw *Exporter was used, and the
+// unified exporter's per-container GPU merge reads through it — so returning nil
+// when stale is what stops the container path from emitting arbitrarily-old GPU
+// values during a sustained DCGM outage (a gap, matching a live scrape's
+// failure, rather than frozen last-good data). The error return is always nil:
+// staleness is a nil result plus a log, not a per-reader error.
+func (c *CachedGPUExporter) QueryMetrics(_ context.Context) ([]GPUMetric, error) {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+	if c.staleLocked() {
+		return nil, nil
+	}
+	return c.snapshot, nil
+}
+
+// QueryGPUSnapshot returns the cached node-level GPU summary and its
+// publication state without scraping DCGM.
+func (c *CachedGPUExporter) QueryGPUSnapshot() (*NodeGPUSummary, SnapshotSectionStatus) {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+
+	if c.lastSuccess.IsZero() {
+		return nil, SnapshotSectionStatus{State: SnapshotStateNotReady}
+	}
+
+	// Fresh within the grace window (age <= threshold); stale beyond it. A
+	// single failed/slow refresh keeps the snapshot young, so it stays ready —
+	// only a sustained gap marks it stale, which the node collector then drops.
+	state := SnapshotStateReady
+	if c.staleLocked() {
+		state = SnapshotStateStale
+	}
+	collectedAt := c.lastSuccess
+
+	return cloneNodeGPUSummary(c.summary), SnapshotSectionStatus{
+		State:       state,
+		CollectedAt: &collectedAt,
+	}
+}
+
+func cloneNodeGPUSummary(summary *NodeGPUSummary) *NodeGPUSummary {
+	if summary == nil {
+		return nil
+	}
+
+	cloned := *summary
+	cloned.GPUModels = slices.Clone(summary.GPUModels)
+	cloned.GPUUUIDs = slices.Clone(summary.GPUUUIDs)
+	return &cloned
+}

--- a/internal/nodemon/gpu_cache_internal_test.go
+++ b/internal/nodemon/gpu_cache_internal_test.go
@@ -1,0 +1,89 @@
+package nodemon
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/go-logr/logr"
+	"github.com/stretchr/testify/require"
+)
+
+// staleTestQuerier is a minimal MetricsQuerier returning a fixed snapshot.
+type staleTestQuerier struct{}
+
+func (staleTestQuerier) QueryMetrics(_ context.Context) ([]GPUMetric, error) {
+	return []GPUMetric{{Pod: "train", GPUUtilization: 90}}, nil
+}
+
+// deadlineCapturingQuerier records whether the context it was called with
+// carried a deadline — used to prove refreshCycle bounds each refresh.
+type deadlineCapturingQuerier struct{ hadDeadline bool }
+
+func (q *deadlineCapturingQuerier) QueryMetrics(ctx context.Context) ([]GPUMetric, error) {
+	_, q.hadDeadline = ctx.Deadline()
+	return nil, nil
+}
+
+// TestCachedGPUExporter_RefreshCycleBoundsEachRefresh proves refreshCycle wraps
+// the refresh in a per-cycle deadline, so a hung dependency (e.g. getDCGMUrls'
+// otherwise-unbounded k8s List) cannot wedge the refresher. The parent context
+// has no deadline; the one the source sees must.
+func TestCachedGPUExporter_RefreshCycleBoundsEachRefresh(t *testing.T) {
+	src := &deadlineCapturingQuerier{}
+	c := NewCachedGPUExporter(src, DefaultGPURefreshInterval, logr.Discard())
+
+	_, parentHasDeadline := context.Background().Deadline()
+	require.False(t, parentHasDeadline, "sanity: the parent context has no deadline")
+
+	c.refreshCycle(context.Background())
+	require.True(t, src.hadDeadline, "refreshCycle must give each refresh a per-cycle deadline")
+}
+
+// TestCachedGPUExporter_AgeBasedStaleness exercises the grace window
+// deterministically by aging lastSuccess (only reachable from the in-package
+// test). It confirms both reader paths agree: within the threshold the snapshot
+// is served (ready / non-nil), beyond it the snapshot is withheld everywhere
+// (QueryMetrics -> nil for the container/legacy path, QueryGPUSnapshot -> stale
+// for the node path).
+func TestCachedGPUExporter_AgeBasedStaleness(t *testing.T) {
+	c := NewCachedGPUExporter(staleTestQuerier{}, DefaultGPURefreshInterval, logr.Discard())
+	require.Equal(t, 20*time.Second, c.stalenessThreshold, "default 10s interval -> 20s threshold")
+
+	c.Refresh(context.Background())
+
+	// Within the grace window (aged 15s < 20s): served on both paths.
+	c.mu.Lock()
+	c.lastSuccess = time.Now().Add(-15 * time.Second)
+	c.mu.Unlock()
+
+	metrics, err := c.QueryMetrics(context.Background())
+	require.NoError(t, err)
+	require.Len(t, metrics, 1, "within grace, QueryMetrics serves the snapshot")
+	_, status := c.QueryGPUSnapshot()
+	require.Equal(t, SnapshotStateReady, status.State, "within grace, node path is ready")
+
+	// Aged past the threshold (25s > 20s): withheld on both paths.
+	c.mu.Lock()
+	c.lastSuccess = time.Now().Add(-25 * time.Second)
+	c.mu.Unlock()
+
+	metrics, err = c.QueryMetrics(context.Background())
+	require.NoError(t, err)
+	require.Nil(t, metrics, "past threshold, QueryMetrics withholds (container/legacy path gaps)")
+	_, status = c.QueryGPUSnapshot()
+	require.Equal(t, SnapshotStateStale, status.State, "past threshold, node path is stale (dropped by collector)")
+}
+
+// TestCachedGPUExporter_StalenessThresholdFloor confirms the 20s floor holds
+// even when the interval is clamped to its 5s minimum, and that a larger
+// interval widens the threshold to 2x interval.
+func TestCachedGPUExporter_StalenessThresholdFloor(t *testing.T) {
+	atFloor := NewCachedGPUExporter(staleTestQuerier{}, MinGPURefreshInterval, logr.Discard())
+	require.Equal(t, minGPUStalenessThreshold, atFloor.stalenessThreshold,
+		"2*5s=10s is below the 20s floor, so the floor applies")
+
+	wide := NewCachedGPUExporter(staleTestQuerier{}, 30*time.Second, logr.Discard())
+	require.Equal(t, 60*time.Second, wide.stalenessThreshold,
+		"a 30s interval must widen the threshold to 2x so normal operation is never stale")
+}

--- a/internal/nodemon/gpu_cache_test.go
+++ b/internal/nodemon/gpu_cache_test.go
@@ -1,0 +1,435 @@
+package nodemon_test
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"sync"
+	"sync/atomic"
+	"testing"
+
+	"github.com/go-logr/logr"
+	"github.com/go-logr/zapr"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+
+	"github.com/devzero-inc/zxporter/internal/collector"
+	"github.com/devzero-inc/zxporter/internal/nodemon"
+)
+
+// mutatedMarker is the sentinel written into a returned snapshot slice to prove
+// snapshot reads hand back copies, not the cache's backing arrays.
+const mutatedMarker = "mutated"
+
+// countingQuerier is a MetricsQuerier double that records how many times the
+// underlying (expensive) scrape would run.
+type countingQuerier struct {
+	mu      sync.Mutex
+	calls   int32
+	metrics []nodemon.GPUMetric
+	err     error
+}
+
+func (q *countingQuerier) QueryMetrics(_ context.Context) ([]nodemon.GPUMetric, error) {
+	atomic.AddInt32(&q.calls, 1)
+	q.mu.Lock()
+	defer q.mu.Unlock()
+	return q.metrics, q.err
+}
+
+func (q *countingQuerier) set(metrics []nodemon.GPUMetric, err error) {
+	q.mu.Lock()
+	defer q.mu.Unlock()
+	q.metrics, q.err = metrics, err
+}
+
+func testLogger() logr.Logger {
+	zapLog, _ := zap.NewDevelopment()
+	return zapr.NewLogger(zapLog)
+}
+
+func TestCachedGPUExporter_ReadsDoNotScrape(t *testing.T) {
+	r := require.New(t)
+	src := &countingQuerier{metrics: []nodemon.GPUMetric{{Pod: "train", GPUUtilization: 90}}}
+
+	cache := nodemon.NewCachedGPUExporter(src, 0, testLogger())
+
+	// One refresh (as the ticker would do) then many concurrent reads.
+	cache.Refresh(context.Background())
+
+	var wg sync.WaitGroup
+	for i := 0; i < 50; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			got, err := cache.QueryMetrics(context.Background())
+			require.NoError(t, err)
+			require.Len(t, got, 1)
+			require.Equal(t, "train", got[0].Pod)
+		}()
+	}
+	wg.Wait()
+
+	// The whole point: 50 reads triggered zero extra scrapes.
+	r.Equal(int32(1), atomic.LoadInt32(&src.calls),
+		"reads must serve the cached snapshot, not re-scrape DCGM")
+}
+
+func TestCachedGPUExporter_RetainsSnapshotOnRefreshError(t *testing.T) {
+	r := require.New(t)
+	good := []nodemon.GPUMetric{{Pod: "train", GPUUtilization: 90}}
+	src := &countingQuerier{metrics: good}
+
+	cache := nodemon.NewCachedGPUExporter(src, 0, testLogger())
+	cache.Refresh(context.Background())
+
+	// Next refresh fails — the previous good snapshot must survive.
+	src.set(nil, errors.New("dcgm unreachable"))
+	cache.Refresh(context.Background())
+
+	got, err := cache.QueryMetrics(context.Background())
+	r.NoError(err)
+	r.Len(got, 1)
+	r.Equal("train", got[0].Pod)
+}
+
+func TestCachedGPUExporter_EmptyBeforeFirstRefresh(t *testing.T) {
+	r := require.New(t)
+	src := &countingQuerier{metrics: []nodemon.GPUMetric{{Pod: "train"}}}
+
+	cache := nodemon.NewCachedGPUExporter(src, 0, testLogger())
+
+	got, err := cache.QueryMetrics(context.Background())
+	r.NoError(err)
+	r.Nil(got)
+	r.Equal(int32(0), atomic.LoadInt32(&src.calls), "no scrape until first refresh")
+}
+
+func TestCachedGPUExporter_ClampsInterval(t *testing.T) {
+	// A sub-minimum interval must be clamped up so we never hammer DCGM faster
+	// than it produces data. Verified indirectly: construction must not panic
+	// and reads must still work with a tiny requested interval.
+	r := require.New(t)
+	src := &countingQuerier{}
+	cache := nodemon.NewCachedGPUExporter(src, 1, testLogger())
+	got, err := cache.QueryMetrics(context.Background())
+	r.NoError(err)
+	r.Nil(got)
+}
+
+func TestCachedGPUExporter_SnapshotState(t *testing.T) {
+	r := require.New(t)
+	src := &countingQuerier{}
+	cache := nodemon.NewCachedGPUExporter(src, 0, testLogger())
+
+	summary, status := cache.QueryGPUSnapshot()
+	r.Nil(summary)
+	r.Equal(nodemon.SnapshotStateNotReady, status.State)
+	r.Nil(status.CollectedAt)
+	r.Equal(int32(0), atomic.LoadInt32(&src.calls), "snapshot reads must not scrape DCGM")
+
+	cache.Refresh(context.Background())
+
+	summary, status = cache.QueryGPUSnapshot()
+	r.Nil(summary)
+	r.Equal(nodemon.SnapshotStateReady, status.State)
+	r.NotNil(status.CollectedAt)
+
+	metrics := []nodemon.GPUMetric{{
+		ModelName:            "NVIDIA A100",
+		DeviceUUID:           "GPU-a100-1",
+		GPUUtilization:       40,
+		FramebufferUsed:      10_000,
+		FramebufferFree:      30_000,
+		PowerUsage:           200,
+		Temperature:          60,
+		MemoryTemperature:    75,
+		TensorActive:         0.60,
+		DRAMActive:           0.30,
+		PCIeTXBytes:          1_000_000,
+		PCIeRXBytes:          2_000_000,
+		GraphicsEngineActive: 0.70,
+	}}
+	want := &nodemon.NodeGPUSummary{
+		GPUCount:                  1,
+		GPUUtilizationAvg:         40,
+		GPUUtilizationMax:         40,
+		GPUMemoryUsedTotal:        10_000,
+		GPUMemoryFreeTotal:        30_000,
+		GPUMemoryTotalMb:          40_000,
+		GPUPowerUsageTotal:        200,
+		GPUTemperatureAvg:         60,
+		GPUTemperatureMax:         60,
+		GPUMemoryTemperatureAvg:   75,
+		GPUMemoryTemperatureMax:   75,
+		GPUTensorUtilizationAvg:   0.60,
+		GPUDramUtilizationAvg:     0.30,
+		GPUPCIeTxBytesTotal:       1_000_000,
+		GPUPCIeRxBytesTotal:       2_000_000,
+		GPUGraphicsUtilizationAvg: 0.70,
+		GPUUsage:                  0.40,
+		GPUModels:                 []string{"1x NVIDIA A100"},
+		GPUUUIDs:                  []string{"GPU-a100-1"},
+	}
+	src.set(metrics, nil)
+	cache.Refresh(context.Background())
+
+	summary, status = cache.QueryGPUSnapshot()
+	r.Equal(want, summary)
+	r.Equal(nodemon.SnapshotStateReady, status.State)
+	r.NotNil(status.CollectedAt)
+	successfulAt := *status.CollectedAt
+
+	summary.GPUModels[0] = mutatedMarker
+	summary.GPUUUIDs[0] = mutatedMarker
+	summary, _ = cache.QueryGPUSnapshot()
+	r.Equal(want, summary, "snapshot reads must copy mutable summary slices")
+
+	// A single failed refresh keeps the last-good snapshot young (well within the
+	// grace window), so it stays ready rather than flipping to stale — that is
+	// the whole point of the grace window. The aged-past-threshold -> stale
+	// transition is covered deterministically in gpu_cache_internal_test.go.
+	src.set(nil, errors.New("dcgm unavailable"))
+	cache.Refresh(context.Background())
+
+	summary, status = cache.QueryGPUSnapshot()
+	r.Equal(want, summary)
+	r.Equal(nodemon.SnapshotStateReady, status.State)
+	r.NotNil(status.CollectedAt)
+	r.Equal(successfulAt, *status.CollectedAt)
+	r.Equal(int32(3), atomic.LoadInt32(&src.calls), "snapshot reads must not add source queries")
+}
+
+func TestSummarizeNodeGPUParity(t *testing.T) {
+	tests := []struct {
+		name    string
+		metrics []nodemon.GPUMetric
+	}{
+		{
+			name: "empty input",
+		},
+		{
+			name: "one GPU",
+			metrics: []nodemon.GPUMetric{
+				{
+					ModelName: "NVIDIA T4", DeviceUUID: "GPU-t4", GPUUtilization: 30,
+					FramebufferUsed: 2_000, FramebufferFree: 13_095, PowerUsage: 14.5,
+					Temperature: 38, MemoryTemperature: 48, TensorActive: 0.25,
+					DRAMActive: 0.40, PCIeTXBytes: 1_000, PCIeRXBytes: 2_000,
+					GraphicsEngineActive: 0.35,
+				},
+			},
+		},
+		{
+			name: "multiple GPUs",
+			metrics: []nodemon.GPUMetric{
+				{
+					ModelName: "NVIDIA A100", DeviceUUID: "GPU-a100-1", GPUUtilization: 40,
+					FramebufferUsed: 10_000, FramebufferFree: 30_000, PowerUsage: 200,
+					Temperature: 60, MemoryTemperature: 75, TensorActive: 0.60,
+					DRAMActive: 0.30, PCIeTXBytes: 1_000_000, PCIeRXBytes: 2_000_000,
+					GraphicsEngineActive: 0.70,
+				},
+				{
+					ModelName: "NVIDIA A100", DeviceUUID: "GPU-a100-2", GPUUtilization: 80,
+					FramebufferUsed: 20_000, FramebufferFree: 20_000, PowerUsage: 300,
+					Temperature: 75, MemoryTemperature: 90, TensorActive: 0.80,
+					DRAMActive: 0.50, PCIeTXBytes: 3_000_000, PCIeRXBytes: 4_000_000,
+					GraphicsEngineActive: 0.30,
+				},
+			},
+		},
+		{
+			name: "mixed models",
+			metrics: []nodemon.GPUMetric{
+				{
+					ModelName: "NVIDIA A100", DeviceUUID: "GPU-a100", GPUUtilization: 90,
+					FramebufferUsed: 30_000, FramebufferFree: 10_000, PowerUsage: 350,
+					Temperature: 78, MemoryTemperature: 92, TensorActive: 0.90,
+					DRAMActive: 0.75, PCIeTXBytes: 5_000_000, PCIeRXBytes: 6_000_000,
+					GraphicsEngineActive: 0.85,
+				},
+				{
+					ModelName: "NVIDIA V100", DeviceUUID: "GPU-v100", GPUUtilization: 20,
+					FramebufferUsed: 4_000, FramebufferFree: 12_000, PowerUsage: 125,
+					Temperature: 52, MemoryTemperature: 64, TensorActive: 0.15,
+					DRAMActive: 0.25, PCIeTXBytes: 7_000, PCIeRXBytes: 8_000,
+					GraphicsEngineActive: 0.10,
+				},
+			},
+		},
+		{
+			name: "MIG-labelled inputs",
+			metrics: []nodemon.GPUMetric{
+				{
+					ModelName: "NVIDIA A100-SXM4-40GB", DeviceUUID: "MIG-GPU-1/1/0",
+					MIGProfile: "1g.5gb", MIGInstanceID: "1", GPUUtilization: 55,
+					FramebufferUsed: 3_000, FramebufferFree: 2_000, PowerUsage: 80,
+					Temperature: 62, MemoryTemperature: 72, TensorActive: 0.45,
+					DRAMActive: 0.35, PCIeTXBytes: 11_000, PCIeRXBytes: 12_000,
+					GraphicsEngineActive: 0.50,
+				},
+				{
+					ModelName: "NVIDIA A100-SXM4-40GB", DeviceUUID: "MIG-GPU-1/2/0",
+					MIGProfile: "2g.10gb", MIGInstanceID: "2", GPUUtilization: 65,
+					FramebufferUsed: 7_000, FramebufferFree: 3_000, PowerUsage: 110,
+					Temperature: 67, MemoryTemperature: 79, TensorActive: 0.65,
+					DRAMActive: 0.55, PCIeTXBytes: 13_000, PCIeRXBytes: 14_000,
+					GraphicsEngineActive: 0.60,
+				},
+			},
+		},
+	}
+
+	numericKeys := []string{
+		"GPUCount",
+		"GPUUtilizationAvg",
+		"GPUUtilizationMax",
+		"GPUMemoryUsedTotal",
+		"GPUMemoryFreeTotal",
+		"GPUMemoryTotalMb",
+		"GPUPowerUsageTotal",
+		"GPUTemperatureAvg",
+		"GPUTemperatureMax",
+		"GPUMemoryTemperatureAvg",
+		"GPUMemoryTemperatureMax",
+		"GPUTensorUtilizationAvg",
+		"GPUDramUtilizationAvg",
+		"GPUPCIeTxBytesTotal",
+		"GPUPCIeRxBytesTotal",
+		"GPUGraphicsUtilizationAvg",
+		"GPUUsage",
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			typed := nodemon.SummarizeNodeGPU(tt.metrics)
+			legacy := collector.NodeGPUMetricsFromNodemon(toCollectorMetrics(tt.metrics))
+
+			if len(tt.metrics) == 0 {
+				require.Nil(t, typed)
+				require.Empty(t, legacy)
+				return
+			}
+
+			downstream := summaryToDownstream(typed)
+			require.Len(t, downstream, len(numericKeys)+2)
+			require.Len(t, legacy, len(numericKeys)+2)
+
+			for _, key := range numericKeys {
+				require.Equal(t, legacy[key], downstream[key], key)
+			}
+			require.ElementsMatch(t, legacy["GPUModels"], downstream["GPUModels"], "GPUModels")
+			require.ElementsMatch(t, legacy["GPUUUIDs"], downstream["GPUUUIDs"], "GPUUUIDs")
+		})
+	}
+}
+
+func TestSnapshotResponseJSON(t *testing.T) {
+	type section struct {
+		State string `json:"state"`
+	}
+	type contract struct {
+		SchemaVersion int                `json:"schema_version"`
+		Sections      map[string]section `json:"sections"`
+	}
+
+	tests := []struct {
+		name         string
+		response     any
+		wantSections map[string]section
+	}{
+		{
+			name: "node snapshot",
+			response: nodemon.NodeSnapshotResponse{
+				SchemaVersion: nodemon.SnapshotSchemaVersion,
+				Sections: nodemon.NodeSnapshotSections{
+					Node: nodemon.SnapshotSectionStatus{State: nodemon.SnapshotStateReady},
+					GPU:  nodemon.SnapshotSectionStatus{State: nodemon.SnapshotStateStale},
+				},
+			},
+			wantSections: map[string]section{
+				"node": {State: "ready"},
+				"gpu":  {State: "stale"},
+			},
+		},
+		{
+			name: "container snapshot",
+			response: nodemon.ContainerSnapshotResponse{
+				SchemaVersion: nodemon.SnapshotSchemaVersion,
+				Sections: nodemon.ContainerSnapshotSections{
+					Containers: nodemon.SnapshotSectionStatus{State: nodemon.SnapshotStateNotReady},
+					Runtime:    nodemon.SnapshotSectionStatus{State: nodemon.SnapshotStateDisabled},
+				},
+			},
+			wantSections: map[string]section{
+				"containers": {State: "not_ready"},
+				"runtime":    {State: "disabled"},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			data, err := json.Marshal(tt.response)
+			require.NoError(t, err)
+
+			var got contract
+			require.NoError(t, json.Unmarshal(data, &got))
+			require.Equal(t, 1, got.SchemaVersion, `{"schema_version":1}`)
+			require.Equal(t, tt.wantSections, got.Sections)
+		})
+	}
+}
+
+func toCollectorMetrics(metrics []nodemon.GPUMetric) []collector.NodemonMetric {
+	result := make([]collector.NodemonMetric, 0, len(metrics))
+	for _, metric := range metrics {
+		result = append(result, collector.NodemonMetric{
+			ModelName:            metric.ModelName,
+			DeviceUUID:           metric.DeviceUUID,
+			MIGProfile:           metric.MIGProfile,
+			MIGInstanceID:        metric.MIGInstanceID,
+			TensorActive:         metric.TensorActive,
+			DRAMActive:           metric.DRAMActive,
+			PCIeTXBytes:          metric.PCIeTXBytes,
+			PCIeRXBytes:          metric.PCIeRXBytes,
+			GraphicsEngineActive: metric.GraphicsEngineActive,
+			FramebufferUsed:      metric.FramebufferUsed,
+			FramebufferFree:      metric.FramebufferFree,
+			Temperature:          metric.Temperature,
+			MemoryTemperature:    metric.MemoryTemperature,
+			PowerUsage:           metric.PowerUsage,
+			GPUUtilization:       metric.GPUUtilization,
+		})
+	}
+	return result
+}
+
+func summaryToDownstream(summary *nodemon.NodeGPUSummary) map[string]interface{} {
+	if summary == nil {
+		return map[string]interface{}{}
+	}
+
+	return map[string]interface{}{
+		"GPUCount":                  summary.GPUCount,
+		"GPUUtilizationAvg":         summary.GPUUtilizationAvg,
+		"GPUUtilizationMax":         summary.GPUUtilizationMax,
+		"GPUMemoryUsedTotal":        summary.GPUMemoryUsedTotal,
+		"GPUMemoryFreeTotal":        summary.GPUMemoryFreeTotal,
+		"GPUMemoryTotalMb":          summary.GPUMemoryTotalMb,
+		"GPUPowerUsageTotal":        summary.GPUPowerUsageTotal,
+		"GPUTemperatureAvg":         summary.GPUTemperatureAvg,
+		"GPUTemperatureMax":         summary.GPUTemperatureMax,
+		"GPUMemoryTemperatureAvg":   summary.GPUMemoryTemperatureAvg,
+		"GPUMemoryTemperatureMax":   summary.GPUMemoryTemperatureMax,
+		"GPUTensorUtilizationAvg":   summary.GPUTensorUtilizationAvg,
+		"GPUDramUtilizationAvg":     summary.GPUDramUtilizationAvg,
+		"GPUPCIeTxBytesTotal":       summary.GPUPCIeTxBytesTotal,
+		"GPUPCIeRxBytesTotal":       summary.GPUPCIeRxBytesTotal,
+		"GPUGraphicsUtilizationAvg": summary.GPUGraphicsUtilizationAvg,
+		"GPUUsage":                  summary.GPUUsage,
+		"GPUModels":                 summary.GPUModels,
+		"GPUUUIDs":                  summary.GPUUUIDs,
+	}
+}

--- a/internal/nodemon/jvm_collector_test.go
+++ b/internal/nodemon/jvm_collector_test.go
@@ -139,7 +139,20 @@ func TestJVMCollector_StartCollectionLoop_RefreshesPeriodically(t *testing.T) {
 		return nil, nil
 	}
 
-	go c.StartCollectionLoop(t.Context(), 10*time.Millisecond)
+	// Join the background loop before the test returns: otherwise it can still
+	// be inside a Collect() → logger.Info() call (writing to the testr logger's
+	// *testing.T) while the framework tears the test down, which the race
+	// detector flags as a write-after-test race on testing internals.
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		c.StartCollectionLoop(ctx, 10*time.Millisecond)
+	}()
+	t.Cleanup(func() {
+		cancel()
+		<-done
+	})
 
 	require.Eventually(t, func() bool {
 		return atomic.LoadInt32(&calls) >= 3
@@ -164,7 +177,19 @@ func TestJVMCollector_StartCollectionLoop_BoundsEachCycle(t *testing.T) {
 		return nil, ctx.Err()
 	}
 
-	go c.StartCollectionLoop(t.Context(), 20*time.Millisecond)
+	// Join the background loop before the test returns (see the sibling
+	// RefreshesPeriodically test for why — avoids a testr write-after-teardown
+	// race).
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		c.StartCollectionLoop(ctx, 20*time.Millisecond)
+	}()
+	t.Cleanup(func() {
+		cancel()
+		<-done
+	})
 
 	require.Eventually(t, func() bool {
 		return atomic.LoadInt32(&calls) >= 2

--- a/internal/nodemon/runtime_collector.go
+++ b/internal/nodemon/runtime_collector.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"maps"
+	"slices"
 	"sync"
 	"time"
 
@@ -72,6 +73,9 @@ type RuntimeCollector struct {
 	// pays for a live /proc walk.
 	cachedMetrics RuntimeMetrics
 	cachedErr     error
+	cachedAt      time.Time
+	hasPublished  bool
+	cachedStale   bool
 
 	// buildJVM and buildRuntime are seams over the package-level build
 	// functions, overridable in tests to prove the two builds run
@@ -104,6 +108,50 @@ func (c *RuntimeCollector) QueryRuntimeMetrics(_ context.Context) (RuntimeMetric
 	c.mu.RLock()
 	defer c.mu.RUnlock()
 	return c.cachedMetrics, c.cachedErr
+}
+
+// QueryRuntimeSnapshot returns the last published runtime payload and its
+// collection state without walking /proc.
+func (c *RuntimeCollector) QueryRuntimeSnapshot() (RuntimeMetrics, SnapshotSectionStatus) {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+
+	if !c.hasPublished {
+		return RuntimeMetrics{}, SnapshotSectionStatus{State: SnapshotStateNotReady}
+	}
+
+	state := SnapshotStateReady
+	if c.cachedStale {
+		state = SnapshotStateStale
+	}
+	collectedAt := c.cachedAt
+	return RuntimeMetrics{
+			JVM:      cloneJVMMetrics(c.cachedMetrics.JVM),
+			Runtimes: slices.Clone(c.cachedMetrics.Runtimes),
+		}, SnapshotSectionStatus{
+			State:       state,
+			CollectedAt: &collectedAt,
+		}
+}
+
+func cloneJVMMetrics(metrics []JVMMetric) []JVMMetric {
+	cloned := slices.Clone(metrics)
+	for i := range cloned {
+		cloned[i].GCTimeSecondsTotal = maps.Clone(metrics[i].GCTimeSecondsTotal)
+		cloned[i].FlagsExtracted.XmsBytes = cloneValuePointer(metrics[i].FlagsExtracted.XmsBytes)
+		cloned[i].FlagsExtracted.XmxBytes = cloneValuePointer(metrics[i].FlagsExtracted.XmxBytes)
+		cloned[i].FlagsExtracted.MaxRamPercentage = cloneValuePointer(metrics[i].FlagsExtracted.MaxRamPercentage)
+		cloned[i].FlagsExtracted.UseContainerSupport = cloneValuePointer(metrics[i].FlagsExtracted.UseContainerSupport)
+	}
+	return cloned
+}
+
+func cloneValuePointer[T any](value *T) *T {
+	if value == nil {
+		return nil
+	}
+	cloned := *value
+	return &cloned
 }
 
 // StartCollectionLoop runs Collect immediately, then on every tick. Call in a
@@ -154,9 +202,15 @@ func (c *RuntimeCollector) Collect(ctx context.Context) {
 	defer c.mu.Unlock()
 	c.cachedErr = err
 	if err != nil && len(metrics.JVM) == 0 && len(metrics.Runtimes) == 0 {
+		if c.hasPublished {
+			c.cachedStale = true
+		}
 		return
 	}
 	c.cachedMetrics = metrics
+	c.cachedAt = time.Now()
+	c.hasPublished = true
+	c.cachedStale = false
 }
 
 // collect performs the live /proc walk and build. Only Collect should call

--- a/internal/nodemon/runtime_collector_test.go
+++ b/internal/nodemon/runtime_collector_test.go
@@ -243,7 +243,19 @@ func TestRuntimeCollector_StartCollectionLoop_RefreshesPeriodically(t *testing.T
 		return nil, cache, nil
 	}
 
-	go c.StartCollectionLoop(t.Context(), 10*time.Millisecond)
+	// Join the background loop before the test returns: otherwise it can still
+	// be inside a Collect() → logger.Info() call (writing to the testr logger's
+	// *testing.T) during teardown, which the race detector flags.
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		c.StartCollectionLoop(ctx, 10*time.Millisecond)
+	}()
+	t.Cleanup(func() {
+		cancel()
+		<-done
+	})
 
 	require.Eventually(t, func() bool {
 		return atomic.LoadInt32(&calls) >= 3
@@ -271,7 +283,18 @@ func TestRuntimeCollector_StartCollectionLoop_BoundsEachCycle(t *testing.T) {
 		return nil, cache, ctx.Err()
 	}
 
-	go c.StartCollectionLoop(t.Context(), 20*time.Millisecond)
+	// Join the background loop before the test returns (see the sibling
+	// RefreshesPeriodically test for why).
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		c.StartCollectionLoop(ctx, 20*time.Millisecond)
+	}()
+	t.Cleanup(func() {
+		cancel()
+		<-done
+	})
 
 	require.Eventually(t, func() bool {
 		return atomic.LoadInt32(&calls) >= 2

--- a/internal/nodemon/runtime_handler_test.go
+++ b/internal/nodemon/runtime_handler_test.go
@@ -1,27 +1,154 @@
-package nodemon_test
+package nodemon
 
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"net/http"
 	"net/http/httptest"
+	"sync/atomic"
 	"testing"
 
+	"github.com/go-logr/logr"
 	"github.com/go-logr/zapr"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/zap"
-
-	"github.com/devzero-inc/zxporter/internal/nodemon"
 )
 
 // fakeRuntimeQuerier is a test double for RuntimeMetricsQuerier.
 type fakeRuntimeQuerier struct {
-	metrics nodemon.RuntimeMetrics
+	metrics RuntimeMetrics
 	err     error
 }
 
-func (f *fakeRuntimeQuerier) QueryRuntimeMetrics(_ context.Context) (nodemon.RuntimeMetrics, error) {
+func (f *fakeRuntimeQuerier) QueryRuntimeMetrics(_ context.Context) (RuntimeMetrics, error) {
 	return f.metrics, f.err
+}
+
+func TestRuntimeCollector_SnapshotState(t *testing.T) {
+	r := require.New(t)
+	zapLog, _ := zap.NewDevelopment()
+	log := zapr.NewLogger(zapLog)
+
+	collector := NewRuntimeCollector("node-1", nil, log)
+	collector.procRoot = t.TempDir()
+
+	metrics, status := collector.QueryRuntimeSnapshot()
+	r.Empty(metrics.JVM)
+	r.Empty(metrics.Runtimes)
+	r.Equal(SnapshotStateNotReady, status.State)
+	r.Nil(status.CollectedAt)
+
+	var buildCalls int32
+	collector.buildJVM = func(_ context.Context, _ []JavaProcess, _ *PodContainerIndex, _ string, _ logr.Logger) ([]JVMMetric, error) {
+		atomic.AddInt32(&buildCalls, 1)
+		return nil, nil
+	}
+	collector.buildRuntime = func(_ context.Context, _ []RuntimeProcess, _ *PodContainerIndex, _ string, cache map[string]versionResolveInfo, _ logr.Logger) ([]RuntimeProcessMetric, map[string]versionResolveInfo, error) {
+		return nil, cache, nil
+	}
+	collector.Collect(context.Background())
+
+	metrics, status = collector.QueryRuntimeSnapshot()
+	r.Empty(metrics.JVM)
+	r.Empty(metrics.Runtimes)
+	r.Equal(SnapshotStateReady, status.State)
+	r.NotNil(status.CollectedAt)
+	r.Equal(int32(1), atomic.LoadInt32(&buildCalls), "snapshot reads must not rebuild runtime metrics")
+
+	xmsBytes := int64(512)
+	xmxBytes := int64(1_024)
+	maxRAMPercentage := 75.0
+	useContainerSupport := true
+	wantPopulated := RuntimeMetrics{
+		JVM: []JVMMetric{{
+			NodeName: "node-1",
+			Pod:      "java-app",
+			GCTimeSecondsTotal: map[string]float64{
+				"G1 Young Generation": 1.5,
+			},
+			FlagsExtracted: JVMFlagsExtracted{
+				XmsBytes:            &xmsBytes,
+				XmxBytes:            &xmxBytes,
+				MaxRamPercentage:    &maxRAMPercentage,
+				UseContainerSupport: &useContainerSupport,
+			},
+		}},
+		Runtimes: []RuntimeProcessMetric{{Runtime: "go", NodeName: "node-1", Pod: "go-app"}},
+	}
+	collector.buildJVM = func(_ context.Context, _ []JavaProcess, _ *PodContainerIndex, _ string, _ logr.Logger) ([]JVMMetric, error) {
+		return wantPopulated.JVM, nil
+	}
+	collector.buildRuntime = func(_ context.Context, _ []RuntimeProcess, _ *PodContainerIndex, _ string, cache map[string]versionResolveInfo, _ logr.Logger) ([]RuntimeProcessMetric, map[string]versionResolveInfo, error) {
+		return wantPopulated.Runtimes, cache, nil
+	}
+	collector.Collect(context.Background())
+
+	metrics, status = collector.QueryRuntimeSnapshot()
+	r.Equal(wantPopulated, metrics)
+	r.Equal(SnapshotStateReady, status.State)
+	r.NotNil(status.CollectedAt)
+
+	metrics.JVM[0].Pod = "mutated"
+	metrics.JVM[0].GCTimeSecondsTotal["G1 Young Generation"] = 99
+	*metrics.JVM[0].FlagsExtracted.XmsBytes = 99
+	*metrics.JVM[0].FlagsExtracted.XmxBytes = 99
+	*metrics.JVM[0].FlagsExtracted.MaxRamPercentage = 99
+	*metrics.JVM[0].FlagsExtracted.UseContainerSupport = false
+	metrics.Runtimes[0].Pod = "mutated"
+	metrics, _ = collector.QueryRuntimeSnapshot()
+	r.Equal("java-app", metrics.JVM[0].Pod)
+	r.Equal(float64(1.5), metrics.JVM[0].GCTimeSecondsTotal["G1 Young Generation"])
+	r.Equal(int64(512), *metrics.JVM[0].FlagsExtracted.XmsBytes)
+	r.Equal(int64(1_024), *metrics.JVM[0].FlagsExtracted.XmxBytes)
+	r.Equal(75.0, *metrics.JVM[0].FlagsExtracted.MaxRamPercentage)
+	r.True(*metrics.JVM[0].FlagsExtracted.UseContainerSupport)
+	r.Equal("go-app", metrics.Runtimes[0].Pod, "snapshot reads must deep-copy runtime payloads")
+
+	partial := RuntimeMetrics{
+		Runtimes: []RuntimeProcessMetric{{Runtime: "python", NodeName: "node-1", Pod: "worker"}},
+	}
+	collector.buildJVM = func(_ context.Context, _ []JavaProcess, _ *PodContainerIndex, _ string, _ logr.Logger) ([]JVMMetric, error) {
+		return nil, errors.New("jvm collection failed")
+	}
+	collector.buildRuntime = func(_ context.Context, _ []RuntimeProcess, _ *PodContainerIndex, _ string, cache map[string]versionResolveInfo, _ logr.Logger) ([]RuntimeProcessMetric, map[string]versionResolveInfo, error) {
+		return partial.Runtimes, cache, nil
+	}
+	collector.Collect(context.Background())
+
+	metrics, status = collector.QueryRuntimeSnapshot()
+	r.Equal(partial, metrics)
+	r.Equal(SnapshotStateReady, status.State)
+	r.NotNil(status.CollectedAt)
+	partialCollectedAt := *status.CollectedAt
+	_, err := collector.QueryRuntimeMetrics(context.Background())
+	r.ErrorContains(err, "jvm collection failed", "legacy query must still surface partial collection errors")
+
+	collector.buildJVM = func(_ context.Context, _ []JavaProcess, _ *PodContainerIndex, _ string, _ logr.Logger) ([]JVMMetric, error) {
+		return nil, errors.New("jvm collection failed")
+	}
+	collector.buildRuntime = func(_ context.Context, _ []RuntimeProcess, _ *PodContainerIndex, _ string, cache map[string]versionResolveInfo, _ logr.Logger) ([]RuntimeProcessMetric, map[string]versionResolveInfo, error) {
+		return nil, cache, errors.New("runtime collection failed")
+	}
+	collector.Collect(context.Background())
+
+	metrics, status = collector.QueryRuntimeSnapshot()
+	r.Equal(partial, metrics)
+	r.Equal(SnapshotStateStale, status.State)
+	r.NotNil(status.CollectedAt)
+	r.Equal(partialCollectedAt, *status.CollectedAt)
+
+	unpublished := NewRuntimeCollector("node-1", nil, log)
+	unpublished.procRoot = t.TempDir()
+	unpublished.buildJVM = collector.buildJVM
+	unpublished.buildRuntime = collector.buildRuntime
+	unpublished.Collect(context.Background())
+
+	metrics, status = unpublished.QueryRuntimeSnapshot()
+	r.Empty(metrics.JVM)
+	r.Empty(metrics.Runtimes)
+	r.Equal(SnapshotStateNotReady, status.State)
+	r.Nil(status.CollectedAt)
 }
 
 // TestRuntimeMetricsHandler_CompactJSON asserts the response body is compact
@@ -32,15 +159,15 @@ func TestRuntimeMetricsHandler_CompactJSON(t *testing.T) {
 	zapLog, _ := zap.NewDevelopment()
 	log := zapr.NewLogger(zapLog)
 
-	metrics := nodemon.RuntimeMetrics{
-		JVM: []nodemon.JVMMetric{
+	metrics := RuntimeMetrics{
+		JVM: []JVMMetric{
 			{NodeName: "node-1", Pod: "app", Namespace: "default", Container: "main"},
 		},
-		Runtimes: []nodemon.RuntimeProcessMetric{
+		Runtimes: []RuntimeProcessMetric{
 			{Runtime: "python", NodeName: "node-1", Pod: "worker", Namespace: "default", Container: "main"},
 		},
 	}
-	handler := nodemon.NewRuntimeMetricsHandler(&fakeRuntimeQuerier{metrics: metrics}, log, 0)
+	handler := NewRuntimeMetricsHandler(&fakeRuntimeQuerier{metrics: metrics}, log, 0)
 
 	req := httptest.NewRequest(http.MethodGet, "/container/runtime-metrics", nil)
 	rec := httptest.NewRecorder()

--- a/internal/nodemon/scraper_test.go
+++ b/internal/nodemon/scraper_test.go
@@ -61,9 +61,7 @@ func TestScraper_Scrape(t *testing.T) {
 	})
 
 	t.Run("partially scrapes metrics when some exporter returns non-200", func(t *testing.T) {
-		callCount := 0
 		httpClient := newMockHTTPClient(func(req *http.Request) (*http.Response, error) {
-			callCount++
 			if req.URL.Host == "localhost:9410" {
 				return &http.Response{
 					StatusCode: http.StatusInternalServerError,

--- a/internal/nodemon/snapshot_handler.go
+++ b/internal/nodemon/snapshot_handler.go
@@ -1,0 +1,174 @@
+package nodemon
+
+import (
+	"encoding/json"
+	"net/http"
+
+	"github.com/go-logr/logr"
+)
+
+// NodeSnapshotQuerier reads the last published node snapshot.
+type NodeSnapshotQuerier interface {
+	QueryNodeSnapshot() (*NodeMetricsResponse, SnapshotSectionStatus)
+}
+
+// GPUSnapshotQuerier reads the last published node GPU summary.
+type GPUSnapshotQuerier interface {
+	QueryGPUSnapshot() (*NodeGPUSummary, SnapshotSectionStatus)
+}
+
+// ContainerSnapshotQuerier reads the last published container snapshot.
+type ContainerSnapshotQuerier interface {
+	QueryContainerSnapshot() ([]ContainerMetricsResponse, SnapshotSectionStatus)
+}
+
+// RuntimeSnapshotQuerier reads the last published process-runtime snapshot.
+type RuntimeSnapshotQuerier interface {
+	QueryRuntimeSnapshot() (RuntimeMetrics, SnapshotSectionStatus)
+}
+
+type nodeSnapshotHandler struct {
+	node NodeSnapshotQuerier
+	gpu  GPUSnapshotQuerier
+	log  logr.Logger
+}
+
+// NewNodeSnapshotHandler serves cache-only node and GPU snapshot responses.
+func NewNodeSnapshotHandler(
+	node NodeSnapshotQuerier,
+	gpu GPUSnapshotQuerier,
+	log logr.Logger,
+) http.Handler {
+	return &nodeSnapshotHandler{
+		node: node,
+		gpu:  gpu,
+		log:  log.WithName("node-snapshot-handler"),
+	}
+}
+
+func (h *nodeSnapshotHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	w.Header().Set("Content-Type", "application/json")
+	if r.Method != http.MethodGet {
+		writeSnapshotError(w, http.StatusMethodNotAllowed, "method not allowed")
+		return
+	}
+
+	nodeMetrics, nodeStatus := h.node.QueryNodeSnapshot()
+	gpuSummary, gpuStatus := h.gpu.QueryGPUSnapshot()
+	response := NodeSnapshotResponse{
+		SchemaVersion: SnapshotSchemaVersion,
+		Sections: NodeSnapshotSections{
+			Node: nodeStatus,
+			GPU:  gpuStatus,
+		},
+	}
+	if snapshotSectionHasPayload(nodeStatus.State) {
+		response.NodeMetrics = nodeMetrics
+	}
+	if snapshotSectionHasPayload(gpuStatus.State) {
+		response.GPUSummary = gpuSummary
+	}
+
+	status := http.StatusOK
+	if !snapshotSectionUsable(nodeStatus.State) && !snapshotSectionUsable(gpuStatus.State) {
+		status = http.StatusServiceUnavailable
+	}
+	writeSnapshotJSON(w, status, response, h.log)
+}
+
+type containerSnapshotHandler struct {
+	containers ContainerSnapshotQuerier
+	runtime    RuntimeSnapshotQuerier
+	log        logr.Logger
+}
+
+// NewContainerSnapshotHandler serves cache-only container and runtime snapshot responses.
+func NewContainerSnapshotHandler(
+	containers ContainerSnapshotQuerier,
+	runtime RuntimeSnapshotQuerier,
+	log logr.Logger,
+) http.Handler {
+	return &containerSnapshotHandler{
+		containers: containers,
+		runtime:    runtime,
+		log:        log.WithName("container-snapshot-handler"),
+	}
+}
+
+type containerSnapshotWireResponse struct {
+	SchemaVersion    int                         `json:"schema_version"`
+	ContainerMetrics *[]ContainerMetricsResponse `json:"container_metrics,omitempty"`
+	RuntimeMetrics   *RuntimeMetrics             `json:"runtime_metrics,omitempty"`
+	Sections         ContainerSnapshotSections   `json:"sections"`
+}
+
+func (h *containerSnapshotHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	w.Header().Set("Content-Type", "application/json")
+	if r.Method != http.MethodGet {
+		writeSnapshotError(w, http.StatusMethodNotAllowed, "method not allowed")
+		return
+	}
+
+	containerMetrics, containerStatus := h.containers.QueryContainerSnapshot()
+	runtimeStatus := SnapshotSectionStatus{State: SnapshotStateDisabled}
+	var runtimeMetrics RuntimeMetrics
+	if h.runtime != nil {
+		runtimeMetrics, runtimeStatus = h.runtime.QueryRuntimeSnapshot()
+	}
+
+	response := containerSnapshotWireResponse{
+		SchemaVersion: SnapshotSchemaVersion,
+		Sections: ContainerSnapshotSections{
+			Containers: containerStatus,
+			Runtime:    runtimeStatus,
+		},
+	}
+	if snapshotSectionHasPayload(containerStatus.State) {
+		if containerMetrics == nil {
+			containerMetrics = []ContainerMetricsResponse{}
+		}
+		response.ContainerMetrics = &containerMetrics
+	}
+	if snapshotSectionHasPayload(runtimeStatus.State) {
+		if runtimeMetrics.JVM == nil {
+			runtimeMetrics.JVM = []JVMMetric{}
+		}
+		if runtimeMetrics.Runtimes == nil {
+			runtimeMetrics.Runtimes = []RuntimeProcessMetric{}
+		}
+		response.RuntimeMetrics = &runtimeMetrics
+	}
+
+	status := http.StatusOK
+	if !snapshotSectionUsable(containerStatus.State) && !snapshotSectionUsable(runtimeStatus.State) {
+		status = http.StatusServiceUnavailable
+	}
+	writeSnapshotJSON(w, status, response, h.log)
+}
+
+func snapshotSectionHasPayload(state SnapshotSectionState) bool {
+	return state == SnapshotStateReady || state == SnapshotStateStale
+}
+
+func snapshotSectionUsable(state SnapshotSectionState) bool {
+	return snapshotSectionHasPayload(state) || state == SnapshotStateDisabled
+}
+
+func writeSnapshotJSON(w http.ResponseWriter, status int, response any, log logr.Logger) {
+	data, err := json.Marshal(response)
+	if err != nil {
+		log.Error(err, "Failed to encode snapshot response")
+		writeSnapshotError(w, http.StatusInternalServerError, "internal server error")
+		return
+	}
+
+	w.WriteHeader(status)
+	if _, err := w.Write(data); err != nil {
+		log.Error(err, "Failed to write snapshot response")
+	}
+}
+
+func writeSnapshotError(w http.ResponseWriter, status int, message string) {
+	w.WriteHeader(status)
+	_ = json.NewEncoder(w).Encode(map[string]string{"error": message})
+}

--- a/internal/nodemon/snapshot_handler_test.go
+++ b/internal/nodemon/snapshot_handler_test.go
@@ -1,0 +1,308 @@
+package nodemon
+
+import (
+	"encoding/json"
+	"math"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/go-logr/logr"
+	"github.com/stretchr/testify/require"
+)
+
+type fakeNodeSnapshotQuerier struct {
+	metrics *NodeMetricsResponse
+	status  SnapshotSectionStatus
+	calls   int
+}
+
+func (f *fakeNodeSnapshotQuerier) QueryNodeSnapshot() (*NodeMetricsResponse, SnapshotSectionStatus) {
+	f.calls++
+	return f.metrics, f.status
+}
+
+type fakeGPUSnapshotQuerier struct {
+	summary *NodeGPUSummary
+	status  SnapshotSectionStatus
+	calls   int
+}
+
+func (f *fakeGPUSnapshotQuerier) QueryGPUSnapshot() (*NodeGPUSummary, SnapshotSectionStatus) {
+	f.calls++
+	return f.summary, f.status
+}
+
+type fakeContainerSnapshotQuerier struct {
+	metrics []ContainerMetricsResponse
+	status  SnapshotSectionStatus
+	calls   int
+}
+
+func (f *fakeContainerSnapshotQuerier) QueryContainerSnapshot() ([]ContainerMetricsResponse, SnapshotSectionStatus) {
+	f.calls++
+	return f.metrics, f.status
+}
+
+type fakeRuntimeSnapshotQuerier struct {
+	metrics RuntimeMetrics
+	status  SnapshotSectionStatus
+	calls   int
+}
+
+func (f *fakeRuntimeSnapshotQuerier) QueryRuntimeSnapshot() (RuntimeMetrics, SnapshotSectionStatus) {
+	f.calls++
+	return f.metrics, f.status
+}
+
+func TestNodeSnapshotHandler_CombinesCacheSections(t *testing.T) {
+	nodeCollectedAt := time.Date(2026, time.July, 30, 12, 0, 0, 0, time.UTC)
+	gpuCollectedAt := nodeCollectedAt.Add(5 * time.Second)
+	node := &fakeNodeSnapshotQuerier{
+		metrics: &NodeMetricsResponse{NodeName: "node-a", CPUUsageNanoCores: 1_000_000_000},
+		status:  SnapshotSectionStatus{State: SnapshotStateReady, CollectedAt: &nodeCollectedAt},
+	}
+	gpu := &fakeGPUSnapshotQuerier{
+		summary: &NodeGPUSummary{GPUCount: 2, GPUUtilizationAvg: 73.5},
+		status:  SnapshotSectionStatus{State: SnapshotStateReady, CollectedAt: &gpuCollectedAt},
+	}
+
+	rec := serveSnapshotRequest(t, NewNodeSnapshotHandler(node, gpu, logr.Discard()), http.MethodGet)
+
+	require.Equal(t, http.StatusOK, rec.Code)
+	require.Equal(t, "application/json", rec.Header().Get("Content-Type"))
+	var got NodeSnapshotResponse
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &got))
+	require.Equal(t, SnapshotSchemaVersion, got.SchemaVersion)
+	require.Equal(t, node.metrics, got.NodeMetrics)
+	require.Equal(t, gpu.summary, got.GPUSummary)
+	require.Equal(t, node.status, got.Sections.Node)
+	require.Equal(t, gpu.status, got.Sections.GPU)
+	require.Equal(t, 1, node.calls)
+	require.Equal(t, 1, gpu.calls)
+}
+
+func TestNodeSnapshotHandler_ReadySectionPreservesNotReadyPeer(t *testing.T) {
+	collectedAt := time.Date(2026, time.July, 30, 12, 0, 0, 0, time.UTC)
+	node := &fakeNodeSnapshotQuerier{
+		metrics: &NodeMetricsResponse{NodeName: "node-a"},
+		status:  SnapshotSectionStatus{State: SnapshotStateReady, CollectedAt: &collectedAt},
+	}
+	gpu := &fakeGPUSnapshotQuerier{
+		summary: &NodeGPUSummary{GPUCount: 99},
+		status:  SnapshotSectionStatus{State: SnapshotStateNotReady},
+	}
+
+	rec := serveSnapshotRequest(t, NewNodeSnapshotHandler(node, gpu, logr.Discard()), http.MethodGet)
+
+	require.Equal(t, http.StatusOK, rec.Code)
+	var got NodeSnapshotResponse
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &got))
+	require.Equal(t, node.metrics, got.NodeMetrics)
+	require.Nil(t, got.GPUSummary)
+	require.Equal(t, SnapshotStateNotReady, got.Sections.GPU.State)
+	require.NotContains(t, rec.Body.String(), `"gpu_summary"`)
+	require.Equal(t, 1, node.calls)
+	require.Equal(t, 1, gpu.calls)
+}
+
+func TestNodeSnapshotHandler_IncludesStaleDataAndTimestamp(t *testing.T) {
+	collectedAt := time.Date(2026, time.July, 30, 11, 58, 0, 0, time.UTC)
+	node := &fakeNodeSnapshotQuerier{
+		metrics: &NodeMetricsResponse{NodeName: "unusable"},
+		status:  SnapshotSectionStatus{State: SnapshotStateNotReady},
+	}
+	gpu := &fakeGPUSnapshotQuerier{
+		summary: &NodeGPUSummary{GPUCount: 1, GPUUtilizationMax: 91},
+		status:  SnapshotSectionStatus{State: SnapshotStateStale, CollectedAt: &collectedAt},
+	}
+
+	rec := serveSnapshotRequest(t, NewNodeSnapshotHandler(node, gpu, logr.Discard()), http.MethodGet)
+
+	require.Equal(t, http.StatusOK, rec.Code)
+	var got NodeSnapshotResponse
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &got))
+	require.Nil(t, got.NodeMetrics)
+	require.Equal(t, gpu.summary, got.GPUSummary)
+	require.Equal(t, SnapshotStateStale, got.Sections.GPU.State)
+	require.Equal(t, &collectedAt, got.Sections.GPU.CollectedAt)
+	require.Equal(t, 1, node.calls)
+	require.Equal(t, 1, gpu.calls)
+}
+
+func TestNodeSnapshotHandler_AllSectionsNotReadyReturnsStatusEnvelope(t *testing.T) {
+	node := &fakeNodeSnapshotQuerier{
+		metrics: &NodeMetricsResponse{NodeName: "unusable"},
+		status:  SnapshotSectionStatus{State: SnapshotStateNotReady},
+	}
+	gpu := &fakeGPUSnapshotQuerier{
+		summary: &NodeGPUSummary{GPUCount: 99},
+		status:  SnapshotSectionStatus{State: SnapshotStateNotReady},
+	}
+
+	rec := serveSnapshotRequest(t, NewNodeSnapshotHandler(node, gpu, logr.Discard()), http.MethodGet)
+
+	require.Equal(t, http.StatusServiceUnavailable, rec.Code)
+	require.Equal(t, "application/json", rec.Header().Get("Content-Type"))
+	var got NodeSnapshotResponse
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &got))
+	require.Equal(t, SnapshotSchemaVersion, got.SchemaVersion)
+	require.Nil(t, got.NodeMetrics)
+	require.Nil(t, got.GPUSummary)
+	require.Equal(t, SnapshotStateNotReady, got.Sections.Node.State)
+	require.Equal(t, SnapshotStateNotReady, got.Sections.GPU.State)
+	require.Equal(t, 1, node.calls)
+	require.Equal(t, 1, gpu.calls)
+}
+
+func TestNodeSnapshotHandler_RejectsNonGETWithoutQueryingCaches(t *testing.T) {
+	node := &fakeNodeSnapshotQuerier{}
+	gpu := &fakeGPUSnapshotQuerier{}
+
+	rec := serveSnapshotRequest(t, NewNodeSnapshotHandler(node, gpu, logr.Discard()), http.MethodPost)
+
+	require.Equal(t, http.StatusMethodNotAllowed, rec.Code)
+	require.Equal(t, "application/json", rec.Header().Get("Content-Type"))
+	require.JSONEq(t, `{"error":"method not allowed"}`, rec.Body.String())
+	require.Zero(t, node.calls)
+	require.Zero(t, gpu.calls)
+}
+
+func TestNodeSnapshotHandler_DoesNotExposeEncodingErrors(t *testing.T) {
+	node := &fakeNodeSnapshotQuerier{
+		metrics: &NodeMetricsResponse{NodeName: "node-a", NetworkRxBytesPerSec: math.NaN()},
+		status:  SnapshotSectionStatus{State: SnapshotStateReady},
+	}
+	gpu := &fakeGPUSnapshotQuerier{status: SnapshotSectionStatus{State: SnapshotStateNotReady}}
+
+	rec := serveSnapshotRequest(t, NewNodeSnapshotHandler(node, gpu, logr.Discard()), http.MethodGet)
+
+	require.Equal(t, http.StatusInternalServerError, rec.Code)
+	require.Equal(t, "application/json", rec.Header().Get("Content-Type"))
+	require.JSONEq(t, `{"error":"internal server error"}`, rec.Body.String())
+	require.NotContains(t, rec.Body.String(), "unsupported value")
+	require.Equal(t, 1, node.calls)
+	require.Equal(t, 1, gpu.calls)
+}
+
+func TestContainerSnapshotHandler_CombinesCacheSections(t *testing.T) {
+	containerCollectedAt := time.Date(2026, time.July, 30, 12, 0, 0, 0, time.UTC)
+	runtimeCollectedAt := containerCollectedAt.Add(2 * time.Second)
+	containers := &fakeContainerSnapshotQuerier{
+		metrics: []ContainerMetricsResponse{{NodeName: "node-a", Pod: "web", Container: "app"}},
+		status:  SnapshotSectionStatus{State: SnapshotStateReady, CollectedAt: &containerCollectedAt},
+	}
+	runtime := &fakeRuntimeSnapshotQuerier{
+		metrics: RuntimeMetrics{
+			JVM:      []JVMMetric{},
+			Runtimes: []RuntimeProcessMetric{{Runtime: "go", Pod: "web"}},
+		},
+		status: SnapshotSectionStatus{State: SnapshotStateReady, CollectedAt: &runtimeCollectedAt},
+	}
+
+	rec := serveSnapshotRequest(t, NewContainerSnapshotHandler(containers, runtime, logr.Discard()), http.MethodGet)
+
+	require.Equal(t, http.StatusOK, rec.Code)
+	require.Equal(t, "application/json", rec.Header().Get("Content-Type"))
+	var got ContainerSnapshotResponse
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &got))
+	require.Equal(t, SnapshotSchemaVersion, got.SchemaVersion)
+	require.Equal(t, containers.metrics, got.ContainerMetrics)
+	require.Equal(t, runtime.metrics, got.RuntimeMetrics)
+	require.Equal(t, containers.status, got.Sections.Containers)
+	require.Equal(t, runtime.status, got.Sections.Runtime)
+	require.Equal(t, 1, containers.calls)
+	require.Equal(t, 1, runtime.calls)
+}
+
+func TestContainerSnapshotHandler_NilRuntimeIsDisabled(t *testing.T) {
+	collectedAt := time.Date(2026, time.July, 30, 12, 0, 0, 0, time.UTC)
+	containers := &fakeContainerSnapshotQuerier{
+		metrics: []ContainerMetricsResponse{{NodeName: "node-a", Pod: "web"}},
+		status:  SnapshotSectionStatus{State: SnapshotStateReady, CollectedAt: &collectedAt},
+	}
+
+	rec := serveSnapshotRequest(t, NewContainerSnapshotHandler(containers, nil, logr.Discard()), http.MethodGet)
+
+	require.Equal(t, http.StatusOK, rec.Code)
+	var got ContainerSnapshotResponse
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &got))
+	require.Equal(t, containers.metrics, got.ContainerMetrics)
+	require.Equal(t, SnapshotStateDisabled, got.Sections.Runtime.State)
+	require.NotContains(t, rec.Body.String(), `"runtime_metrics"`)
+	require.Equal(t, 1, containers.calls)
+}
+
+func TestContainerSnapshotHandler_NotReadyRuntimeDoesNotHideContainers(t *testing.T) {
+	containers := &fakeContainerSnapshotQuerier{
+		metrics: []ContainerMetricsResponse{{NodeName: "node-a", Pod: "web"}},
+		status:  SnapshotSectionStatus{State: SnapshotStateReady},
+	}
+	runtime := &fakeRuntimeSnapshotQuerier{
+		metrics: RuntimeMetrics{Runtimes: []RuntimeProcessMetric{{Runtime: "unusable"}}},
+		status:  SnapshotSectionStatus{State: SnapshotStateNotReady},
+	}
+
+	rec := serveSnapshotRequest(t, NewContainerSnapshotHandler(containers, runtime, logr.Discard()), http.MethodGet)
+
+	require.Equal(t, http.StatusOK, rec.Code)
+	var got ContainerSnapshotResponse
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &got))
+	require.Equal(t, containers.metrics, got.ContainerMetrics)
+	require.Empty(t, got.RuntimeMetrics)
+	require.Equal(t, SnapshotStateNotReady, got.Sections.Runtime.State)
+	require.NotContains(t, rec.Body.String(), `"runtime_metrics"`)
+	require.Equal(t, 1, containers.calls)
+	require.Equal(t, 1, runtime.calls)
+}
+
+func TestContainerSnapshotHandler_AllEnabledSectionsNotReadyReturns503(t *testing.T) {
+	containers := &fakeContainerSnapshotQuerier{
+		metrics: []ContainerMetricsResponse{{NodeName: "unusable"}},
+		status:  SnapshotSectionStatus{State: SnapshotStateNotReady},
+	}
+	runtime := &fakeRuntimeSnapshotQuerier{
+		metrics: RuntimeMetrics{Runtimes: []RuntimeProcessMetric{{Runtime: "unusable"}}},
+		status:  SnapshotSectionStatus{State: SnapshotStateNotReady},
+	}
+
+	rec := serveSnapshotRequest(t, NewContainerSnapshotHandler(containers, runtime, logr.Discard()), http.MethodGet)
+
+	require.Equal(t, http.StatusServiceUnavailable, rec.Code)
+	require.Equal(t, "application/json", rec.Header().Get("Content-Type"))
+	var got ContainerSnapshotResponse
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &got))
+	require.Equal(t, SnapshotSchemaVersion, got.SchemaVersion)
+	require.Empty(t, got.ContainerMetrics)
+	require.Empty(t, got.RuntimeMetrics)
+	require.Equal(t, SnapshotStateNotReady, got.Sections.Containers.State)
+	require.Equal(t, SnapshotStateNotReady, got.Sections.Runtime.State)
+	require.NotContains(t, rec.Body.String(), `"container_metrics"`)
+	require.NotContains(t, rec.Body.String(), `"runtime_metrics"`)
+	require.Equal(t, 1, containers.calls)
+	require.Equal(t, 1, runtime.calls)
+}
+
+func TestContainerSnapshotHandler_RejectsNonGETWithoutQueryingCaches(t *testing.T) {
+	containers := &fakeContainerSnapshotQuerier{}
+	runtime := &fakeRuntimeSnapshotQuerier{}
+
+	rec := serveSnapshotRequest(t, NewContainerSnapshotHandler(containers, runtime, logr.Discard()), http.MethodPost)
+
+	require.Equal(t, http.StatusMethodNotAllowed, rec.Code)
+	require.Equal(t, "application/json", rec.Header().Get("Content-Type"))
+	require.JSONEq(t, `{"error":"method not allowed"}`, rec.Body.String())
+	require.Zero(t, containers.calls)
+	require.Zero(t, runtime.calls)
+}
+
+func serveSnapshotRequest(t *testing.T, handler http.Handler, method string) *httptest.ResponseRecorder {
+	t.Helper()
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(method, "/snapshot", strings.NewReader(""))
+	handler.ServeHTTP(rec, req)
+	return rec
+}

--- a/internal/nodemon/snapshot_types.go
+++ b/internal/nodemon/snapshot_types.go
@@ -1,0 +1,153 @@
+package nodemon
+
+import (
+	"fmt"
+	"time"
+)
+
+const SnapshotSchemaVersion = 1
+
+type SnapshotSectionState string
+
+const (
+	SnapshotStateReady    SnapshotSectionState = "ready"
+	SnapshotStateStale    SnapshotSectionState = "stale"
+	SnapshotStateNotReady SnapshotSectionState = "not_ready"
+	SnapshotStateDisabled SnapshotSectionState = "disabled"
+)
+
+type SnapshotSectionStatus struct {
+	State       SnapshotSectionState `json:"state"`
+	CollectedAt *time.Time           `json:"collected_at,omitempty"`
+}
+
+type NodeSnapshotSections struct {
+	Node SnapshotSectionStatus `json:"node"`
+	GPU  SnapshotSectionStatus `json:"gpu"`
+}
+
+type ContainerSnapshotSections struct {
+	Containers SnapshotSectionStatus `json:"containers"`
+	Runtime    SnapshotSectionStatus `json:"runtime"`
+}
+
+type NodeSnapshotResponse struct {
+	SchemaVersion int                  `json:"schema_version"`
+	NodeMetrics   *NodeMetricsResponse `json:"node_metrics,omitempty"`
+	GPUSummary    *NodeGPUSummary      `json:"gpu_summary,omitempty"`
+	Sections      NodeSnapshotSections `json:"sections"`
+}
+
+type ContainerSnapshotResponse struct {
+	SchemaVersion    int                        `json:"schema_version"`
+	ContainerMetrics []ContainerMetricsResponse `json:"container_metrics"`
+	RuntimeMetrics   RuntimeMetrics             `json:"runtime_metrics"`
+	Sections         ContainerSnapshotSections  `json:"sections"`
+}
+
+type NodeGPUSummary struct {
+	GPUCount                  float64  `json:"gpu_count"`
+	GPUUtilizationAvg         float64  `json:"gpu_utilization_avg"`
+	GPUUtilizationMax         float64  `json:"gpu_utilization_max"`
+	GPUMemoryUsedTotal        float64  `json:"gpu_memory_used_total"`
+	GPUMemoryFreeTotal        float64  `json:"gpu_memory_free_total"`
+	GPUMemoryTotalMb          float64  `json:"gpu_memory_total_mb"`
+	GPUPowerUsageTotal        float64  `json:"gpu_power_usage_total"`
+	GPUTemperatureAvg         float64  `json:"gpu_temperature_avg"`
+	GPUTemperatureMax         float64  `json:"gpu_temperature_max"`
+	GPUMemoryTemperatureAvg   float64  `json:"gpu_memory_temperature_avg"`
+	GPUMemoryTemperatureMax   float64  `json:"gpu_memory_temperature_max"`
+	GPUTensorUtilizationAvg   float64  `json:"gpu_tensor_utilization_avg"`
+	GPUDramUtilizationAvg     float64  `json:"gpu_dram_utilization_avg"`
+	GPUPCIeTxBytesTotal       float64  `json:"gpu_pcie_tx_bytes_total"`
+	GPUPCIeRxBytesTotal       float64  `json:"gpu_pcie_rx_bytes_total"`
+	GPUGraphicsUtilizationAvg float64  `json:"gpu_graphics_utilization_avg"`
+	GPUUsage                  float64  `json:"gpu_usage"`
+	GPUModels                 []string `json:"gpu_models"`
+	GPUUUIDs                  []string `json:"gpu_uuids"`
+}
+
+// SummarizeNodeGPU aggregates per-GPU metrics using the controller's existing
+// node-level metric semantics.
+func SummarizeNodeGPU(metrics []GPUMetric) *NodeGPUSummary {
+	if len(metrics) == 0 {
+		return nil
+	}
+
+	gpuCount := float64(len(metrics))
+
+	var totalUtil, maxUtil float64
+	var totalMemUsed, totalMemFree, totalPower float64
+	var totalTemp, maxTemp, totalMemTemp, maxMemTemp float64
+	var totalTensor, totalDram float64
+	var totalPCIeTx, totalPCIeRx float64
+	var totalGraphics float64
+
+	gpuUUIDSet := make(map[string]bool)
+	gpuModels := make(map[string]int)
+
+	for i, metric := range metrics {
+		totalUtil += metric.GPUUtilization
+		if i == 0 || metric.GPUUtilization > maxUtil {
+			maxUtil = metric.GPUUtilization
+		}
+
+		totalMemUsed += metric.FramebufferUsed
+		totalMemFree += metric.FramebufferFree
+		totalPower += metric.PowerUsage
+
+		totalTemp += metric.Temperature
+		if i == 0 || metric.Temperature > maxTemp {
+			maxTemp = metric.Temperature
+		}
+
+		totalMemTemp += metric.MemoryTemperature
+		if i == 0 || metric.MemoryTemperature > maxMemTemp {
+			maxMemTemp = metric.MemoryTemperature
+		}
+
+		totalTensor += metric.TensorActive
+		totalDram += metric.DRAMActive
+		totalPCIeTx += metric.PCIeTXBytes
+		totalPCIeRx += metric.PCIeRXBytes
+		totalGraphics += metric.GraphicsEngineActive
+
+		if metric.DeviceUUID != "" {
+			gpuUUIDSet[metric.DeviceUUID] = true
+		}
+		if metric.ModelName != "" {
+			gpuModels[metric.ModelName]++
+		}
+	}
+
+	gpuUUIDs := make([]string, 0, len(gpuUUIDSet))
+	for uuid := range gpuUUIDSet {
+		gpuUUIDs = append(gpuUUIDs, uuid)
+	}
+	modelSummary := make([]string, 0, len(gpuModels))
+	for model, count := range gpuModels {
+		modelSummary = append(modelSummary, fmt.Sprintf("%dx %s", count, model))
+	}
+
+	return &NodeGPUSummary{
+		GPUCount:                  gpuCount,
+		GPUUtilizationAvg:         totalUtil / gpuCount,
+		GPUUtilizationMax:         maxUtil,
+		GPUMemoryUsedTotal:        totalMemUsed,
+		GPUMemoryFreeTotal:        totalMemFree,
+		GPUMemoryTotalMb:          totalMemUsed + totalMemFree,
+		GPUPowerUsageTotal:        totalPower,
+		GPUTemperatureAvg:         totalTemp / gpuCount,
+		GPUTemperatureMax:         maxTemp,
+		GPUMemoryTemperatureAvg:   totalMemTemp / gpuCount,
+		GPUMemoryTemperatureMax:   maxMemTemp,
+		GPUTensorUtilizationAvg:   totalTensor / gpuCount,
+		GPUDramUtilizationAvg:     totalDram / gpuCount,
+		GPUPCIeTxBytesTotal:       totalPCIeTx,
+		GPUPCIeRxBytesTotal:       totalPCIeRx,
+		GPUGraphicsUtilizationAvg: totalGraphics / gpuCount,
+		GPUUsage:                  totalUtil / 100.0,
+		GPUModels:                 modelSummary,
+		GPUUUIDs:                  gpuUUIDs,
+	}
+}

--- a/internal/nodemon/unified_exporter.go
+++ b/internal/nodemon/unified_exporter.go
@@ -2,6 +2,7 @@ package nodemon
 
 import (
 	"context"
+	"slices"
 	"sync"
 	"time"
 
@@ -13,8 +14,8 @@ import (
 type UnifiedExporter struct {
 	statsPoller     *StatsPoller
 	cadvisorScraper *CAdvisorScraper
-	gpuExporter     *Exporter     // existing GPU exporter, may be nil
-	cgroupReader    *CgroupReader // direct /sys/fs/cgroup reader, may be nil
+	gpuExporter     MetricsQuerier // cached GPU snapshot reader, may be nil
+	cgroupReader    *CgroupReader  // direct /sys/fs/cgroup reader, may be nil
 	nodeName        string
 	log             logr.Logger
 
@@ -31,7 +32,7 @@ type UnifiedExporter struct {
 func NewUnifiedExporter(
 	statsPoller *StatsPoller,
 	cadvisorScraper *CAdvisorScraper,
-	gpuExporter *Exporter,
+	gpuExporter MetricsQuerier,
 	cgroupReader *CgroupReader,
 	nodeName string,
 	log logr.Logger,
@@ -370,4 +371,43 @@ func (u *UnifiedExporter) QueryPVCMetrics() []PVCMetricsResponse {
 	u.mu.RLock()
 	defer u.mu.RUnlock()
 	return u.pvcMetrics
+}
+
+// QueryNodeSnapshot returns the currently published node metrics and
+// collection metadata without polling any source.
+func (u *UnifiedExporter) QueryNodeSnapshot() (*NodeMetricsResponse, SnapshotSectionStatus) {
+	u.mu.RLock()
+	defer u.mu.RUnlock()
+
+	if u.lastCollected.IsZero() {
+		return nil, SnapshotSectionStatus{State: SnapshotStateNotReady}
+	}
+
+	var metrics *NodeMetricsResponse
+	if u.nodeMetrics != nil {
+		cloned := *u.nodeMetrics
+		metrics = &cloned
+	}
+	collectedAt := u.lastCollected
+	return metrics, SnapshotSectionStatus{
+		State:       SnapshotStateReady,
+		CollectedAt: &collectedAt,
+	}
+}
+
+// QueryContainerSnapshot returns the currently published container metrics and
+// collection metadata without polling any source.
+func (u *UnifiedExporter) QueryContainerSnapshot() ([]ContainerMetricsResponse, SnapshotSectionStatus) {
+	u.mu.RLock()
+	defer u.mu.RUnlock()
+
+	if u.lastCollected.IsZero() {
+		return nil, SnapshotSectionStatus{State: SnapshotStateNotReady}
+	}
+
+	collectedAt := u.lastCollected
+	return slices.Clone(u.containerMetrics), SnapshotSectionStatus{
+		State:       SnapshotStateReady,
+		CollectedAt: &collectedAt,
+	}
 }

--- a/internal/nodemon/unified_handler_test.go
+++ b/internal/nodemon/unified_handler_test.go
@@ -1,9 +1,11 @@
 package nodemon_test
 
 import (
+	"context"
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -102,6 +104,63 @@ func samplePVCMetrics() []nodemon.PVCMetricsResponse {
 func newTestLogger() logr.Logger {
 	zapLog, _ := zap.NewDevelopment()
 	return zapr.NewLogger(zapLog)
+}
+
+func TestUnifiedExporter_SnapshotState(t *testing.T) {
+	r := require.New(t)
+	var sourceQueries int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		atomic.AddInt32(&sourceQueries, 1)
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(fullStatsSummaryJSON))
+	}))
+	defer srv.Close()
+
+	log := newTestLogger()
+	exporter := nodemon.NewUnifiedExporter(
+		nodemon.NewStatsPoller(srv.URL, srv.Client(), log),
+		nil,
+		nil,
+		nil,
+		"node-1",
+		log,
+	)
+
+	node, nodeStatus := exporter.QueryNodeSnapshot()
+	r.Nil(node)
+	r.Equal(nodemon.SnapshotStateNotReady, nodeStatus.State)
+	r.Nil(nodeStatus.CollectedAt)
+
+	containers, containerStatus := exporter.QueryContainerSnapshot()
+	r.Nil(containers)
+	r.Equal(nodemon.SnapshotStateNotReady, containerStatus.State)
+	r.Nil(containerStatus.CollectedAt)
+	r.Equal(int32(0), atomic.LoadInt32(&sourceQueries), "snapshot reads must not poll sources")
+
+	exporter.Collect(context.Background())
+
+	node, nodeStatus = exporter.QueryNodeSnapshot()
+	r.NotNil(node)
+	r.Equal("node-1", node.NodeName)
+	r.Equal(nodemon.SnapshotStateReady, nodeStatus.State)
+	r.NotNil(nodeStatus.CollectedAt)
+
+	containers, containerStatus = exporter.QueryContainerSnapshot()
+	r.Len(containers, 1)
+	r.Equal("my-pod", containers[0].Pod)
+	r.Equal(nodemon.SnapshotStateReady, containerStatus.State)
+	r.NotNil(containerStatus.CollectedAt)
+	r.Equal(*nodeStatus.CollectedAt, *containerStatus.CollectedAt)
+
+	node.NodeName = mutatedMarker
+	containers[0].Pod = mutatedMarker
+
+	node, _ = exporter.QueryNodeSnapshot()
+	containers, _ = exporter.QueryContainerSnapshot()
+	r.Equal("node-1", node.NodeName)
+	r.Equal("my-pod", containers[0].Pod, "snapshot reads must copy mutable container slices")
+	r.Equal(int32(1), atomic.LoadInt32(&sourceQueries), "snapshot reads must not add source queries")
 }
 
 // TestUnifiedContainerHandler_ReturnsJSON verifies the handler encodes ContainerMetricsResponse correctly.


### PR DESCRIPTION
Release v0.1.5 of zxporter, published from the internal services monorepo.

The `v0.1.5` tag has already been created and points at this branch's tip — ArgoCD and other tag consumers can use it immediately. This PR is only to advance public main to the released commit for browser convenience.