### PR TITLE
chore(release): v0.1.6

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -582,6 +582,18 @@ YQ ?= $(LOCALBIN)/yq
 HELMIFY ?= helmify
 
 ## Tool Versions
+# Build helper tools with the toolchain this module targets, not whatever `go`
+# the caller happens to resolve. golangci-lint refuses to start when the Go it
+# was built with is older than the target module's go directive:
+#
+#   can't load config: the Go language version (go1.24) used to build
+#   golangci-lint is lower than the targeted Go version (1.26.0)
+#
+# `go install pkg@version` builds in the tool's own module context, so it does
+# not inherit this module's go directive — without the pin, the binary silently
+# takes whatever toolchain the environment resolves and `make lint` breaks on
+# some machines but not others. Derived from go.mod so a Go bump carries it.
+GO_MOD_TOOLCHAIN ?= go$(shell awk '/^go [0-9]/{print $$2; exit}' go.mod)
 KUSTOMIZE_VERSION ?= v5.4.3
 CONTROLLER_TOOLS_VERSION ?= v0.16.5
 ENVTEST_VERSION ?= release-0.19
@@ -629,9 +641,9 @@ define go-install-tool
 @[ -f "$(1)-$(3)" ] || { \
 set -e; \
 package=$(2)@$(3) ;\
-echo "Downloading $${package}" ;\
+echo "Downloading $${package} (toolchain $(GO_MOD_TOOLCHAIN))" ;\
 rm -f $(1) || true ;\
-GOBIN=$(LOCALBIN) go install $${package} ;\
+GOTOOLCHAIN=$(GO_MOD_TOOLCHAIN) GOBIN=$(LOCALBIN) go install $${package} ;\
 mv $(1) $(1)-$(3) ;\
 } ;\
 ln -sf $(1)-$(3) $(1)

--- a/dist/backend-install-gcp-lowpriv.yaml
+++ b/dist/backend-install-gcp-lowpriv.yaml
@@ -833,10 +833,10 @@ metadata:
   name: zxporter-nodemon
   namespace: {{.zxporter_namespace}}
   labels:
-    helm.sh/chart: zxporter-nodemon-0.1.5
+    helm.sh/chart: zxporter-nodemon-0.1.6
     app.kubernetes.io/name: zxporter-nodemon
     app.kubernetes.io/instance: zxporter-nodemon
-    app.kubernetes.io/version: "0.1.5"
+    app.kubernetes.io/version: "0.1.6"
     app.kubernetes.io/managed-by: Helm
 ---
 # Source: zxporter-nodemon/templates/dcgm-exporter-configmap.yaml
@@ -909,10 +909,10 @@ kind: ClusterRole
 metadata:
   name: zxporter-nodemon
   labels:
-    helm.sh/chart: zxporter-nodemon-0.1.5
+    helm.sh/chart: zxporter-nodemon-0.1.6
     app.kubernetes.io/name: zxporter-nodemon
     app.kubernetes.io/instance: zxporter-nodemon
-    app.kubernetes.io/version: "0.1.5"
+    app.kubernetes.io/version: "0.1.6"
     app.kubernetes.io/managed-by: Helm
 rules:
   - apiGroups:
@@ -959,10 +959,10 @@ kind: ClusterRoleBinding
 metadata:
   name: zxporter-nodemon
   labels:
-    helm.sh/chart: zxporter-nodemon-0.1.5
+    helm.sh/chart: zxporter-nodemon-0.1.6
     app.kubernetes.io/name: zxporter-nodemon
     app.kubernetes.io/instance: zxporter-nodemon
-    app.kubernetes.io/version: "0.1.5"
+    app.kubernetes.io/version: "0.1.6"
     app.kubernetes.io/managed-by: Helm
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -980,10 +980,10 @@ metadata:
   name: zxporter-nodemon
   namespace: {{.zxporter_namespace}}
   labels:
-    helm.sh/chart: zxporter-nodemon-0.1.5
+    helm.sh/chart: zxporter-nodemon-0.1.6
     app.kubernetes.io/name: zxporter-nodemon
     app.kubernetes.io/instance: zxporter-nodemon
-    app.kubernetes.io/version: "0.1.5"
+    app.kubernetes.io/version: "0.1.6"
     app.kubernetes.io/managed-by: Helm
   annotations:
     ignore-check.kube-linter.io/privileged-container: "This daemon set needs to run DCGM Exporter as privileged to access the GPU metrics."
@@ -1137,10 +1137,10 @@ metadata:
   name: zxporter-nodemon-gpu
   namespace: {{.zxporter_namespace}}
   labels:
-    helm.sh/chart: zxporter-nodemon-0.1.5
+    helm.sh/chart: zxporter-nodemon-0.1.6
     app.kubernetes.io/name: zxporter-nodemon
     app.kubernetes.io/instance: zxporter-nodemon-gpu
-    app.kubernetes.io/version: "0.1.5"
+    app.kubernetes.io/version: "0.1.6"
     app.kubernetes.io/managed-by: Helm
   annotations:
     ignore-check.kube-linter.io/privileged-container: "This daemon set needs to run DCGM Exporter as privileged to access the GPU metrics."

--- a/dist/backend-install-gcp.yaml
+++ b/dist/backend-install-gcp.yaml
@@ -833,10 +833,10 @@ metadata:
   name: zxporter-nodemon
   namespace: {{.zxporter_namespace}}
   labels:
-    helm.sh/chart: zxporter-nodemon-0.1.5
+    helm.sh/chart: zxporter-nodemon-0.1.6
     app.kubernetes.io/name: zxporter-nodemon
     app.kubernetes.io/instance: zxporter-nodemon
-    app.kubernetes.io/version: "0.1.5"
+    app.kubernetes.io/version: "0.1.6"
     app.kubernetes.io/managed-by: Helm
 ---
 # Source: zxporter-nodemon/templates/dcgm-exporter-configmap.yaml
@@ -909,10 +909,10 @@ kind: ClusterRole
 metadata:
   name: zxporter-nodemon
   labels:
-    helm.sh/chart: zxporter-nodemon-0.1.5
+    helm.sh/chart: zxporter-nodemon-0.1.6
     app.kubernetes.io/name: zxporter-nodemon
     app.kubernetes.io/instance: zxporter-nodemon
-    app.kubernetes.io/version: "0.1.5"
+    app.kubernetes.io/version: "0.1.6"
     app.kubernetes.io/managed-by: Helm
 rules:
   - apiGroups:
@@ -960,10 +960,10 @@ kind: ClusterRoleBinding
 metadata:
   name: zxporter-nodemon
   labels:
-    helm.sh/chart: zxporter-nodemon-0.1.5
+    helm.sh/chart: zxporter-nodemon-0.1.6
     app.kubernetes.io/name: zxporter-nodemon
     app.kubernetes.io/instance: zxporter-nodemon
-    app.kubernetes.io/version: "0.1.5"
+    app.kubernetes.io/version: "0.1.6"
     app.kubernetes.io/managed-by: Helm
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -981,10 +981,10 @@ metadata:
   name: zxporter-nodemon
   namespace: {{.zxporter_namespace}}
   labels:
-    helm.sh/chart: zxporter-nodemon-0.1.5
+    helm.sh/chart: zxporter-nodemon-0.1.6
     app.kubernetes.io/name: zxporter-nodemon
     app.kubernetes.io/instance: zxporter-nodemon
-    app.kubernetes.io/version: "0.1.5"
+    app.kubernetes.io/version: "0.1.6"
     app.kubernetes.io/managed-by: Helm
   annotations:
     ignore-check.kube-linter.io/privileged-container: "This daemon set needs to run DCGM Exporter as privileged to access the GPU metrics."
@@ -1143,10 +1143,10 @@ metadata:
   name: zxporter-nodemon-gpu
   namespace: {{.zxporter_namespace}}
   labels:
-    helm.sh/chart: zxporter-nodemon-0.1.5
+    helm.sh/chart: zxporter-nodemon-0.1.6
     app.kubernetes.io/name: zxporter-nodemon
     app.kubernetes.io/instance: zxporter-nodemon-gpu
-    app.kubernetes.io/version: "0.1.5"
+    app.kubernetes.io/version: "0.1.6"
     app.kubernetes.io/managed-by: Helm
   annotations:
     ignore-check.kube-linter.io/privileged-container: "This daemon set needs to run DCGM Exporter as privileged to access the GPU metrics."

--- a/dist/backend-install-lowpriv.yaml
+++ b/dist/backend-install-lowpriv.yaml
@@ -833,10 +833,10 @@ metadata:
   name: zxporter-nodemon
   namespace: {{.zxporter_namespace}}
   labels:
-    helm.sh/chart: zxporter-nodemon-0.1.5
+    helm.sh/chart: zxporter-nodemon-0.1.6
     app.kubernetes.io/name: zxporter-nodemon
     app.kubernetes.io/instance: zxporter-nodemon
-    app.kubernetes.io/version: "0.1.5"
+    app.kubernetes.io/version: "0.1.6"
     app.kubernetes.io/managed-by: Helm
 ---
 # Source: zxporter-nodemon/templates/dcgm-exporter-configmap.yaml
@@ -909,10 +909,10 @@ kind: ClusterRole
 metadata:
   name: zxporter-nodemon
   labels:
-    helm.sh/chart: zxporter-nodemon-0.1.5
+    helm.sh/chart: zxporter-nodemon-0.1.6
     app.kubernetes.io/name: zxporter-nodemon
     app.kubernetes.io/instance: zxporter-nodemon
-    app.kubernetes.io/version: "0.1.5"
+    app.kubernetes.io/version: "0.1.6"
     app.kubernetes.io/managed-by: Helm
 rules:
   - apiGroups:
@@ -959,10 +959,10 @@ kind: ClusterRoleBinding
 metadata:
   name: zxporter-nodemon
   labels:
-    helm.sh/chart: zxporter-nodemon-0.1.5
+    helm.sh/chart: zxporter-nodemon-0.1.6
     app.kubernetes.io/name: zxporter-nodemon
     app.kubernetes.io/instance: zxporter-nodemon
-    app.kubernetes.io/version: "0.1.5"
+    app.kubernetes.io/version: "0.1.6"
     app.kubernetes.io/managed-by: Helm
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -980,10 +980,10 @@ metadata:
   name: zxporter-nodemon
   namespace: {{.zxporter_namespace}}
   labels:
-    helm.sh/chart: zxporter-nodemon-0.1.5
+    helm.sh/chart: zxporter-nodemon-0.1.6
     app.kubernetes.io/name: zxporter-nodemon
     app.kubernetes.io/instance: zxporter-nodemon
-    app.kubernetes.io/version: "0.1.5"
+    app.kubernetes.io/version: "0.1.6"
     app.kubernetes.io/managed-by: Helm
   annotations:
     ignore-check.kube-linter.io/privileged-container: "This daemon set needs to run DCGM Exporter as privileged to access the GPU metrics."
@@ -1127,10 +1127,10 @@ metadata:
   name: zxporter-nodemon-gpu
   namespace: {{.zxporter_namespace}}
   labels:
-    helm.sh/chart: zxporter-nodemon-0.1.5
+    helm.sh/chart: zxporter-nodemon-0.1.6
     app.kubernetes.io/name: zxporter-nodemon
     app.kubernetes.io/instance: zxporter-nodemon-gpu
-    app.kubernetes.io/version: "0.1.5"
+    app.kubernetes.io/version: "0.1.6"
     app.kubernetes.io/managed-by: Helm
   annotations:
     ignore-check.kube-linter.io/privileged-container: "This daemon set needs to run DCGM Exporter as privileged to access the GPU metrics."

--- a/dist/backend-install.yaml
+++ b/dist/backend-install.yaml
@@ -833,10 +833,10 @@ metadata:
   name: zxporter-nodemon
   namespace: {{.zxporter_namespace}}
   labels:
-    helm.sh/chart: zxporter-nodemon-0.1.5
+    helm.sh/chart: zxporter-nodemon-0.1.6
     app.kubernetes.io/name: zxporter-nodemon
     app.kubernetes.io/instance: zxporter-nodemon
-    app.kubernetes.io/version: "0.1.5"
+    app.kubernetes.io/version: "0.1.6"
     app.kubernetes.io/managed-by: Helm
 ---
 # Source: zxporter-nodemon/templates/dcgm-exporter-configmap.yaml
@@ -909,10 +909,10 @@ kind: ClusterRole
 metadata:
   name: zxporter-nodemon
   labels:
-    helm.sh/chart: zxporter-nodemon-0.1.5
+    helm.sh/chart: zxporter-nodemon-0.1.6
     app.kubernetes.io/name: zxporter-nodemon
     app.kubernetes.io/instance: zxporter-nodemon
-    app.kubernetes.io/version: "0.1.5"
+    app.kubernetes.io/version: "0.1.6"
     app.kubernetes.io/managed-by: Helm
 rules:
   - apiGroups:
@@ -960,10 +960,10 @@ kind: ClusterRoleBinding
 metadata:
   name: zxporter-nodemon
   labels:
-    helm.sh/chart: zxporter-nodemon-0.1.5
+    helm.sh/chart: zxporter-nodemon-0.1.6
     app.kubernetes.io/name: zxporter-nodemon
     app.kubernetes.io/instance: zxporter-nodemon
-    app.kubernetes.io/version: "0.1.5"
+    app.kubernetes.io/version: "0.1.6"
     app.kubernetes.io/managed-by: Helm
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -981,10 +981,10 @@ metadata:
   name: zxporter-nodemon
   namespace: {{.zxporter_namespace}}
   labels:
-    helm.sh/chart: zxporter-nodemon-0.1.5
+    helm.sh/chart: zxporter-nodemon-0.1.6
     app.kubernetes.io/name: zxporter-nodemon
     app.kubernetes.io/instance: zxporter-nodemon
-    app.kubernetes.io/version: "0.1.5"
+    app.kubernetes.io/version: "0.1.6"
     app.kubernetes.io/managed-by: Helm
   annotations:
     ignore-check.kube-linter.io/privileged-container: "This daemon set needs to run DCGM Exporter as privileged to access the GPU metrics."
@@ -1133,10 +1133,10 @@ metadata:
   name: zxporter-nodemon-gpu
   namespace: {{.zxporter_namespace}}
   labels:
-    helm.sh/chart: zxporter-nodemon-0.1.5
+    helm.sh/chart: zxporter-nodemon-0.1.6
     app.kubernetes.io/name: zxporter-nodemon
     app.kubernetes.io/instance: zxporter-nodemon-gpu
-    app.kubernetes.io/version: "0.1.5"
+    app.kubernetes.io/version: "0.1.6"
     app.kubernetes.io/managed-by: Helm
   annotations:
     ignore-check.kube-linter.io/privileged-container: "This daemon set needs to run DCGM Exporter as privileged to access the GPU metrics."

--- a/dist/install-gcp-lowpriv.yaml
+++ b/dist/install-gcp-lowpriv.yaml
@@ -833,10 +833,10 @@ metadata:
   name: zxporter-nodemon
   namespace: devzero-system
   labels:
-    helm.sh/chart: zxporter-nodemon-0.1.5
+    helm.sh/chart: zxporter-nodemon-0.1.6
     app.kubernetes.io/name: zxporter-nodemon
     app.kubernetes.io/instance: zxporter-nodemon
-    app.kubernetes.io/version: "0.1.5"
+    app.kubernetes.io/version: "0.1.6"
     app.kubernetes.io/managed-by: Helm
 ---
 # Source: zxporter-nodemon/templates/dcgm-exporter-configmap.yaml
@@ -909,10 +909,10 @@ kind: ClusterRole
 metadata:
   name: zxporter-nodemon
   labels:
-    helm.sh/chart: zxporter-nodemon-0.1.5
+    helm.sh/chart: zxporter-nodemon-0.1.6
     app.kubernetes.io/name: zxporter-nodemon
     app.kubernetes.io/instance: zxporter-nodemon
-    app.kubernetes.io/version: "0.1.5"
+    app.kubernetes.io/version: "0.1.6"
     app.kubernetes.io/managed-by: Helm
 rules:
 - apiGroups:
@@ -959,10 +959,10 @@ kind: ClusterRoleBinding
 metadata:
   name: zxporter-nodemon
   labels:
-    helm.sh/chart: zxporter-nodemon-0.1.5
+    helm.sh/chart: zxporter-nodemon-0.1.6
     app.kubernetes.io/name: zxporter-nodemon
     app.kubernetes.io/instance: zxporter-nodemon
-    app.kubernetes.io/version: "0.1.5"
+    app.kubernetes.io/version: "0.1.6"
     app.kubernetes.io/managed-by: Helm
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -980,10 +980,10 @@ metadata:
   name: zxporter-nodemon
   namespace: devzero-system
   labels:
-    helm.sh/chart: zxporter-nodemon-0.1.5
+    helm.sh/chart: zxporter-nodemon-0.1.6
     app.kubernetes.io/name: zxporter-nodemon
     app.kubernetes.io/instance: zxporter-nodemon
-    app.kubernetes.io/version: "0.1.5"
+    app.kubernetes.io/version: "0.1.6"
     app.kubernetes.io/managed-by: Helm
   annotations:
     ignore-check.kube-linter.io/privileged-container: "This daemon set needs to run DCGM Exporter as privileged to access the GPU metrics."
@@ -1137,10 +1137,10 @@ metadata:
   name: zxporter-nodemon-gpu
   namespace: devzero-system
   labels:
-    helm.sh/chart: zxporter-nodemon-0.1.5
+    helm.sh/chart: zxporter-nodemon-0.1.6
     app.kubernetes.io/name: zxporter-nodemon
     app.kubernetes.io/instance: zxporter-nodemon-gpu
-    app.kubernetes.io/version: "0.1.5"
+    app.kubernetes.io/version: "0.1.6"
     app.kubernetes.io/managed-by: Helm
   annotations:
     ignore-check.kube-linter.io/privileged-container: "This daemon set needs to run DCGM Exporter as privileged to access the GPU metrics."

--- a/dist/install-gcp.yaml
+++ b/dist/install-gcp.yaml
@@ -833,10 +833,10 @@ metadata:
   name: zxporter-nodemon
   namespace: devzero-system
   labels:
-    helm.sh/chart: zxporter-nodemon-0.1.5
+    helm.sh/chart: zxporter-nodemon-0.1.6
     app.kubernetes.io/name: zxporter-nodemon
     app.kubernetes.io/instance: zxporter-nodemon
-    app.kubernetes.io/version: "0.1.5"
+    app.kubernetes.io/version: "0.1.6"
     app.kubernetes.io/managed-by: Helm
 ---
 # Source: zxporter-nodemon/templates/dcgm-exporter-configmap.yaml
@@ -909,10 +909,10 @@ kind: ClusterRole
 metadata:
   name: zxporter-nodemon
   labels:
-    helm.sh/chart: zxporter-nodemon-0.1.5
+    helm.sh/chart: zxporter-nodemon-0.1.6
     app.kubernetes.io/name: zxporter-nodemon
     app.kubernetes.io/instance: zxporter-nodemon
-    app.kubernetes.io/version: "0.1.5"
+    app.kubernetes.io/version: "0.1.6"
     app.kubernetes.io/managed-by: Helm
 rules:
 - apiGroups:
@@ -960,10 +960,10 @@ kind: ClusterRoleBinding
 metadata:
   name: zxporter-nodemon
   labels:
-    helm.sh/chart: zxporter-nodemon-0.1.5
+    helm.sh/chart: zxporter-nodemon-0.1.6
     app.kubernetes.io/name: zxporter-nodemon
     app.kubernetes.io/instance: zxporter-nodemon
-    app.kubernetes.io/version: "0.1.5"
+    app.kubernetes.io/version: "0.1.6"
     app.kubernetes.io/managed-by: Helm
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -981,10 +981,10 @@ metadata:
   name: zxporter-nodemon
   namespace: devzero-system
   labels:
-    helm.sh/chart: zxporter-nodemon-0.1.5
+    helm.sh/chart: zxporter-nodemon-0.1.6
     app.kubernetes.io/name: zxporter-nodemon
     app.kubernetes.io/instance: zxporter-nodemon
-    app.kubernetes.io/version: "0.1.5"
+    app.kubernetes.io/version: "0.1.6"
     app.kubernetes.io/managed-by: Helm
   annotations:
     ignore-check.kube-linter.io/privileged-container: "This daemon set needs to run DCGM Exporter as privileged to access the GPU metrics."
@@ -1143,10 +1143,10 @@ metadata:
   name: zxporter-nodemon-gpu
   namespace: devzero-system
   labels:
-    helm.sh/chart: zxporter-nodemon-0.1.5
+    helm.sh/chart: zxporter-nodemon-0.1.6
     app.kubernetes.io/name: zxporter-nodemon
     app.kubernetes.io/instance: zxporter-nodemon-gpu
-    app.kubernetes.io/version: "0.1.5"
+    app.kubernetes.io/version: "0.1.6"
     app.kubernetes.io/managed-by: Helm
   annotations:
     ignore-check.kube-linter.io/privileged-container: "This daemon set needs to run DCGM Exporter as privileged to access the GPU metrics."

--- a/dist/install-lowpriv.yaml
+++ b/dist/install-lowpriv.yaml
@@ -833,10 +833,10 @@ metadata:
   name: zxporter-nodemon
   namespace: devzero-system
   labels:
-    helm.sh/chart: zxporter-nodemon-0.1.5
+    helm.sh/chart: zxporter-nodemon-0.1.6
     app.kubernetes.io/name: zxporter-nodemon
     app.kubernetes.io/instance: zxporter-nodemon
-    app.kubernetes.io/version: "0.1.5"
+    app.kubernetes.io/version: "0.1.6"
     app.kubernetes.io/managed-by: Helm
 ---
 # Source: zxporter-nodemon/templates/dcgm-exporter-configmap.yaml
@@ -909,10 +909,10 @@ kind: ClusterRole
 metadata:
   name: zxporter-nodemon
   labels:
-    helm.sh/chart: zxporter-nodemon-0.1.5
+    helm.sh/chart: zxporter-nodemon-0.1.6
     app.kubernetes.io/name: zxporter-nodemon
     app.kubernetes.io/instance: zxporter-nodemon
-    app.kubernetes.io/version: "0.1.5"
+    app.kubernetes.io/version: "0.1.6"
     app.kubernetes.io/managed-by: Helm
 rules:
 - apiGroups:
@@ -959,10 +959,10 @@ kind: ClusterRoleBinding
 metadata:
   name: zxporter-nodemon
   labels:
-    helm.sh/chart: zxporter-nodemon-0.1.5
+    helm.sh/chart: zxporter-nodemon-0.1.6
     app.kubernetes.io/name: zxporter-nodemon
     app.kubernetes.io/instance: zxporter-nodemon
-    app.kubernetes.io/version: "0.1.5"
+    app.kubernetes.io/version: "0.1.6"
     app.kubernetes.io/managed-by: Helm
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -980,10 +980,10 @@ metadata:
   name: zxporter-nodemon
   namespace: devzero-system
   labels:
-    helm.sh/chart: zxporter-nodemon-0.1.5
+    helm.sh/chart: zxporter-nodemon-0.1.6
     app.kubernetes.io/name: zxporter-nodemon
     app.kubernetes.io/instance: zxporter-nodemon
-    app.kubernetes.io/version: "0.1.5"
+    app.kubernetes.io/version: "0.1.6"
     app.kubernetes.io/managed-by: Helm
   annotations:
     ignore-check.kube-linter.io/privileged-container: "This daemon set needs to run DCGM Exporter as privileged to access the GPU metrics."
@@ -1127,10 +1127,10 @@ metadata:
   name: zxporter-nodemon-gpu
   namespace: devzero-system
   labels:
-    helm.sh/chart: zxporter-nodemon-0.1.5
+    helm.sh/chart: zxporter-nodemon-0.1.6
     app.kubernetes.io/name: zxporter-nodemon
     app.kubernetes.io/instance: zxporter-nodemon-gpu
-    app.kubernetes.io/version: "0.1.5"
+    app.kubernetes.io/version: "0.1.6"
     app.kubernetes.io/managed-by: Helm
   annotations:
     ignore-check.kube-linter.io/privileged-container: "This daemon set needs to run DCGM Exporter as privileged to access the GPU metrics."

--- a/dist/install.yaml
+++ b/dist/install.yaml
@@ -833,10 +833,10 @@ metadata:
   name: zxporter-nodemon
   namespace: devzero-system
   labels:
-    helm.sh/chart: zxporter-nodemon-0.1.5
+    helm.sh/chart: zxporter-nodemon-0.1.6
     app.kubernetes.io/name: zxporter-nodemon
     app.kubernetes.io/instance: zxporter-nodemon
-    app.kubernetes.io/version: "0.1.5"
+    app.kubernetes.io/version: "0.1.6"
     app.kubernetes.io/managed-by: Helm
 ---
 # Source: zxporter-nodemon/templates/dcgm-exporter-configmap.yaml
@@ -909,10 +909,10 @@ kind: ClusterRole
 metadata:
   name: zxporter-nodemon
   labels:
-    helm.sh/chart: zxporter-nodemon-0.1.5
+    helm.sh/chart: zxporter-nodemon-0.1.6
     app.kubernetes.io/name: zxporter-nodemon
     app.kubernetes.io/instance: zxporter-nodemon
-    app.kubernetes.io/version: "0.1.5"
+    app.kubernetes.io/version: "0.1.6"
     app.kubernetes.io/managed-by: Helm
 rules:
 - apiGroups:
@@ -960,10 +960,10 @@ kind: ClusterRoleBinding
 metadata:
   name: zxporter-nodemon
   labels:
-    helm.sh/chart: zxporter-nodemon-0.1.5
+    helm.sh/chart: zxporter-nodemon-0.1.6
     app.kubernetes.io/name: zxporter-nodemon
     app.kubernetes.io/instance: zxporter-nodemon
-    app.kubernetes.io/version: "0.1.5"
+    app.kubernetes.io/version: "0.1.6"
     app.kubernetes.io/managed-by: Helm
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -981,10 +981,10 @@ metadata:
   name: zxporter-nodemon
   namespace: devzero-system
   labels:
-    helm.sh/chart: zxporter-nodemon-0.1.5
+    helm.sh/chart: zxporter-nodemon-0.1.6
     app.kubernetes.io/name: zxporter-nodemon
     app.kubernetes.io/instance: zxporter-nodemon
-    app.kubernetes.io/version: "0.1.5"
+    app.kubernetes.io/version: "0.1.6"
     app.kubernetes.io/managed-by: Helm
   annotations:
     ignore-check.kube-linter.io/privileged-container: "This daemon set needs to run DCGM Exporter as privileged to access the GPU metrics."
@@ -1133,10 +1133,10 @@ metadata:
   name: zxporter-nodemon-gpu
   namespace: devzero-system
   labels:
-    helm.sh/chart: zxporter-nodemon-0.1.5
+    helm.sh/chart: zxporter-nodemon-0.1.6
     app.kubernetes.io/name: zxporter-nodemon
     app.kubernetes.io/instance: zxporter-nodemon-gpu
-    app.kubernetes.io/version: "0.1.5"
+    app.kubernetes.io/version: "0.1.6"
     app.kubernetes.io/managed-by: Helm
   annotations:
     ignore-check.kube-linter.io/privileged-container: "This daemon set needs to run DCGM Exporter as privileged to access the GPU metrics."

--- a/dist/installer_updater-gcp-lowpriv.yaml
+++ b/dist/installer_updater-gcp-lowpriv.yaml
@@ -767,10 +767,10 @@ metadata:
   name: zxporter-nodemon
   namespace: '{{.zxporter_namespace}}'
   labels:
-    helm.sh/chart: zxporter-nodemon-0.1.5
+    helm.sh/chart: zxporter-nodemon-0.1.6
     app.kubernetes.io/name: zxporter-nodemon
     app.kubernetes.io/instance: zxporter-nodemon
-    app.kubernetes.io/version: "0.1.5"
+    app.kubernetes.io/version: "0.1.6"
     app.kubernetes.io/managed-by: Helm
 ---
 # Source: zxporter-nodemon/templates/dcgm-exporter-configmap.yaml
@@ -843,10 +843,10 @@ kind: ClusterRole
 metadata:
   name: zxporter-nodemon
   labels:
-    helm.sh/chart: zxporter-nodemon-0.1.5
+    helm.sh/chart: zxporter-nodemon-0.1.6
     app.kubernetes.io/name: zxporter-nodemon
     app.kubernetes.io/instance: zxporter-nodemon
-    app.kubernetes.io/version: "0.1.5"
+    app.kubernetes.io/version: "0.1.6"
     app.kubernetes.io/managed-by: Helm
 rules:
   - apiGroups:
@@ -893,10 +893,10 @@ kind: ClusterRoleBinding
 metadata:
   name: zxporter-nodemon
   labels:
-    helm.sh/chart: zxporter-nodemon-0.1.5
+    helm.sh/chart: zxporter-nodemon-0.1.6
     app.kubernetes.io/name: zxporter-nodemon
     app.kubernetes.io/instance: zxporter-nodemon
-    app.kubernetes.io/version: "0.1.5"
+    app.kubernetes.io/version: "0.1.6"
     app.kubernetes.io/managed-by: Helm
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -914,10 +914,10 @@ metadata:
   name: zxporter-nodemon
   namespace: '{{.zxporter_namespace}}'
   labels:
-    helm.sh/chart: zxporter-nodemon-0.1.5
+    helm.sh/chart: zxporter-nodemon-0.1.6
     app.kubernetes.io/name: zxporter-nodemon
     app.kubernetes.io/instance: zxporter-nodemon
-    app.kubernetes.io/version: "0.1.5"
+    app.kubernetes.io/version: "0.1.6"
     app.kubernetes.io/managed-by: Helm
   annotations:
     ignore-check.kube-linter.io/privileged-container: "This daemon set needs to run DCGM Exporter as privileged to access the GPU metrics."
@@ -1071,10 +1071,10 @@ metadata:
   name: zxporter-nodemon-gpu
   namespace: '{{.zxporter_namespace}}'
   labels:
-    helm.sh/chart: zxporter-nodemon-0.1.5
+    helm.sh/chart: zxporter-nodemon-0.1.6
     app.kubernetes.io/name: zxporter-nodemon
     app.kubernetes.io/instance: zxporter-nodemon-gpu
-    app.kubernetes.io/version: "0.1.5"
+    app.kubernetes.io/version: "0.1.6"
     app.kubernetes.io/managed-by: Helm
   annotations:
     ignore-check.kube-linter.io/privileged-container: "This daemon set needs to run DCGM Exporter as privileged to access the GPU metrics."

--- a/dist/installer_updater-gcp.yaml
+++ b/dist/installer_updater-gcp.yaml
@@ -767,10 +767,10 @@ metadata:
   name: zxporter-nodemon
   namespace: '{{.zxporter_namespace}}'
   labels:
-    helm.sh/chart: zxporter-nodemon-0.1.5
+    helm.sh/chart: zxporter-nodemon-0.1.6
     app.kubernetes.io/name: zxporter-nodemon
     app.kubernetes.io/instance: zxporter-nodemon
-    app.kubernetes.io/version: "0.1.5"
+    app.kubernetes.io/version: "0.1.6"
     app.kubernetes.io/managed-by: Helm
 ---
 # Source: zxporter-nodemon/templates/dcgm-exporter-configmap.yaml
@@ -843,10 +843,10 @@ kind: ClusterRole
 metadata:
   name: zxporter-nodemon
   labels:
-    helm.sh/chart: zxporter-nodemon-0.1.5
+    helm.sh/chart: zxporter-nodemon-0.1.6
     app.kubernetes.io/name: zxporter-nodemon
     app.kubernetes.io/instance: zxporter-nodemon
-    app.kubernetes.io/version: "0.1.5"
+    app.kubernetes.io/version: "0.1.6"
     app.kubernetes.io/managed-by: Helm
 rules:
   - apiGroups:
@@ -894,10 +894,10 @@ kind: ClusterRoleBinding
 metadata:
   name: zxporter-nodemon
   labels:
-    helm.sh/chart: zxporter-nodemon-0.1.5
+    helm.sh/chart: zxporter-nodemon-0.1.6
     app.kubernetes.io/name: zxporter-nodemon
     app.kubernetes.io/instance: zxporter-nodemon
-    app.kubernetes.io/version: "0.1.5"
+    app.kubernetes.io/version: "0.1.6"
     app.kubernetes.io/managed-by: Helm
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -915,10 +915,10 @@ metadata:
   name: zxporter-nodemon
   namespace: '{{.zxporter_namespace}}'
   labels:
-    helm.sh/chart: zxporter-nodemon-0.1.5
+    helm.sh/chart: zxporter-nodemon-0.1.6
     app.kubernetes.io/name: zxporter-nodemon
     app.kubernetes.io/instance: zxporter-nodemon
-    app.kubernetes.io/version: "0.1.5"
+    app.kubernetes.io/version: "0.1.6"
     app.kubernetes.io/managed-by: Helm
   annotations:
     ignore-check.kube-linter.io/privileged-container: "This daemon set needs to run DCGM Exporter as privileged to access the GPU metrics."
@@ -1077,10 +1077,10 @@ metadata:
   name: zxporter-nodemon-gpu
   namespace: '{{.zxporter_namespace}}'
   labels:
-    helm.sh/chart: zxporter-nodemon-0.1.5
+    helm.sh/chart: zxporter-nodemon-0.1.6
     app.kubernetes.io/name: zxporter-nodemon
     app.kubernetes.io/instance: zxporter-nodemon-gpu
-    app.kubernetes.io/version: "0.1.5"
+    app.kubernetes.io/version: "0.1.6"
     app.kubernetes.io/managed-by: Helm
   annotations:
     ignore-check.kube-linter.io/privileged-container: "This daemon set needs to run DCGM Exporter as privileged to access the GPU metrics."

--- a/dist/installer_updater-lowpriv.yaml
+++ b/dist/installer_updater-lowpriv.yaml
@@ -767,10 +767,10 @@ metadata:
   name: zxporter-nodemon
   namespace: '{{.zxporter_namespace}}'
   labels:
-    helm.sh/chart: zxporter-nodemon-0.1.5
+    helm.sh/chart: zxporter-nodemon-0.1.6
     app.kubernetes.io/name: zxporter-nodemon
     app.kubernetes.io/instance: zxporter-nodemon
-    app.kubernetes.io/version: "0.1.5"
+    app.kubernetes.io/version: "0.1.6"
     app.kubernetes.io/managed-by: Helm
 ---
 # Source: zxporter-nodemon/templates/dcgm-exporter-configmap.yaml
@@ -843,10 +843,10 @@ kind: ClusterRole
 metadata:
   name: zxporter-nodemon
   labels:
-    helm.sh/chart: zxporter-nodemon-0.1.5
+    helm.sh/chart: zxporter-nodemon-0.1.6
     app.kubernetes.io/name: zxporter-nodemon
     app.kubernetes.io/instance: zxporter-nodemon
-    app.kubernetes.io/version: "0.1.5"
+    app.kubernetes.io/version: "0.1.6"
     app.kubernetes.io/managed-by: Helm
 rules:
   - apiGroups:
@@ -893,10 +893,10 @@ kind: ClusterRoleBinding
 metadata:
   name: zxporter-nodemon
   labels:
-    helm.sh/chart: zxporter-nodemon-0.1.5
+    helm.sh/chart: zxporter-nodemon-0.1.6
     app.kubernetes.io/name: zxporter-nodemon
     app.kubernetes.io/instance: zxporter-nodemon
-    app.kubernetes.io/version: "0.1.5"
+    app.kubernetes.io/version: "0.1.6"
     app.kubernetes.io/managed-by: Helm
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -914,10 +914,10 @@ metadata:
   name: zxporter-nodemon
   namespace: '{{.zxporter_namespace}}'
   labels:
-    helm.sh/chart: zxporter-nodemon-0.1.5
+    helm.sh/chart: zxporter-nodemon-0.1.6
     app.kubernetes.io/name: zxporter-nodemon
     app.kubernetes.io/instance: zxporter-nodemon
-    app.kubernetes.io/version: "0.1.5"
+    app.kubernetes.io/version: "0.1.6"
     app.kubernetes.io/managed-by: Helm
   annotations:
     ignore-check.kube-linter.io/privileged-container: "This daemon set needs to run DCGM Exporter as privileged to access the GPU metrics."
@@ -1061,10 +1061,10 @@ metadata:
   name: zxporter-nodemon-gpu
   namespace: '{{.zxporter_namespace}}'
   labels:
-    helm.sh/chart: zxporter-nodemon-0.1.5
+    helm.sh/chart: zxporter-nodemon-0.1.6
     app.kubernetes.io/name: zxporter-nodemon
     app.kubernetes.io/instance: zxporter-nodemon-gpu
-    app.kubernetes.io/version: "0.1.5"
+    app.kubernetes.io/version: "0.1.6"
     app.kubernetes.io/managed-by: Helm
   annotations:
     ignore-check.kube-linter.io/privileged-container: "This daemon set needs to run DCGM Exporter as privileged to access the GPU metrics."

--- a/dist/installer_updater.yaml
+++ b/dist/installer_updater.yaml
@@ -767,10 +767,10 @@ metadata:
   name: zxporter-nodemon
   namespace: '{{.zxporter_namespace}}'
   labels:
-    helm.sh/chart: zxporter-nodemon-0.1.5
+    helm.sh/chart: zxporter-nodemon-0.1.6
     app.kubernetes.io/name: zxporter-nodemon
     app.kubernetes.io/instance: zxporter-nodemon
-    app.kubernetes.io/version: "0.1.5"
+    app.kubernetes.io/version: "0.1.6"
     app.kubernetes.io/managed-by: Helm
 ---
 # Source: zxporter-nodemon/templates/dcgm-exporter-configmap.yaml
@@ -843,10 +843,10 @@ kind: ClusterRole
 metadata:
   name: zxporter-nodemon
   labels:
-    helm.sh/chart: zxporter-nodemon-0.1.5
+    helm.sh/chart: zxporter-nodemon-0.1.6
     app.kubernetes.io/name: zxporter-nodemon
     app.kubernetes.io/instance: zxporter-nodemon
-    app.kubernetes.io/version: "0.1.5"
+    app.kubernetes.io/version: "0.1.6"
     app.kubernetes.io/managed-by: Helm
 rules:
   - apiGroups:
@@ -894,10 +894,10 @@ kind: ClusterRoleBinding
 metadata:
   name: zxporter-nodemon
   labels:
-    helm.sh/chart: zxporter-nodemon-0.1.5
+    helm.sh/chart: zxporter-nodemon-0.1.6
     app.kubernetes.io/name: zxporter-nodemon
     app.kubernetes.io/instance: zxporter-nodemon
-    app.kubernetes.io/version: "0.1.5"
+    app.kubernetes.io/version: "0.1.6"
     app.kubernetes.io/managed-by: Helm
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -915,10 +915,10 @@ metadata:
   name: zxporter-nodemon
   namespace: '{{.zxporter_namespace}}'
   labels:
-    helm.sh/chart: zxporter-nodemon-0.1.5
+    helm.sh/chart: zxporter-nodemon-0.1.6
     app.kubernetes.io/name: zxporter-nodemon
     app.kubernetes.io/instance: zxporter-nodemon
-    app.kubernetes.io/version: "0.1.5"
+    app.kubernetes.io/version: "0.1.6"
     app.kubernetes.io/managed-by: Helm
   annotations:
     ignore-check.kube-linter.io/privileged-container: "This daemon set needs to run DCGM Exporter as privileged to access the GPU metrics."
@@ -1067,10 +1067,10 @@ metadata:
   name: zxporter-nodemon-gpu
   namespace: '{{.zxporter_namespace}}'
   labels:
-    helm.sh/chart: zxporter-nodemon-0.1.5
+    helm.sh/chart: zxporter-nodemon-0.1.6
     app.kubernetes.io/name: zxporter-nodemon
     app.kubernetes.io/instance: zxporter-nodemon-gpu
-    app.kubernetes.io/version: "0.1.5"
+    app.kubernetes.io/version: "0.1.6"
     app.kubernetes.io/managed-by: Helm
   annotations:
     ignore-check.kube-linter.io/privileged-container: "This daemon set needs to run DCGM Exporter as privileged to access the GPU metrics."

--- a/dist/nodemon-gcp-lowpriv.yaml
+++ b/dist/nodemon-gcp-lowpriv.yaml
@@ -6,10 +6,10 @@ metadata:
   name: zxporter-nodemon
   namespace: devzero-system
   labels:
-    helm.sh/chart: zxporter-nodemon-0.1.5
+    helm.sh/chart: zxporter-nodemon-0.1.6
     app.kubernetes.io/name: zxporter-nodemon
     app.kubernetes.io/instance: zxporter-nodemon
-    app.kubernetes.io/version: "0.1.5"
+    app.kubernetes.io/version: "0.1.6"
     app.kubernetes.io/managed-by: Helm
 ---
 # Source: zxporter-nodemon/templates/dcgm-exporter-configmap.yaml
@@ -82,10 +82,10 @@ kind: ClusterRole
 metadata:
   name: zxporter-nodemon
   labels:
-    helm.sh/chart: zxporter-nodemon-0.1.5
+    helm.sh/chart: zxporter-nodemon-0.1.6
     app.kubernetes.io/name: zxporter-nodemon
     app.kubernetes.io/instance: zxporter-nodemon
-    app.kubernetes.io/version: "0.1.5"
+    app.kubernetes.io/version: "0.1.6"
     app.kubernetes.io/managed-by: Helm
 rules:
 - apiGroups:
@@ -132,10 +132,10 @@ kind: ClusterRoleBinding
 metadata:
   name: zxporter-nodemon
   labels:
-    helm.sh/chart: zxporter-nodemon-0.1.5
+    helm.sh/chart: zxporter-nodemon-0.1.6
     app.kubernetes.io/name: zxporter-nodemon
     app.kubernetes.io/instance: zxporter-nodemon
-    app.kubernetes.io/version: "0.1.5"
+    app.kubernetes.io/version: "0.1.6"
     app.kubernetes.io/managed-by: Helm
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -153,10 +153,10 @@ metadata:
   name: zxporter-nodemon
   namespace: devzero-system
   labels:
-    helm.sh/chart: zxporter-nodemon-0.1.5
+    helm.sh/chart: zxporter-nodemon-0.1.6
     app.kubernetes.io/name: zxporter-nodemon
     app.kubernetes.io/instance: zxporter-nodemon
-    app.kubernetes.io/version: "0.1.5"
+    app.kubernetes.io/version: "0.1.6"
     app.kubernetes.io/managed-by: Helm
   annotations:
     ignore-check.kube-linter.io/privileged-container: "This daemon set needs to run DCGM Exporter as privileged to access the GPU metrics."
@@ -310,10 +310,10 @@ metadata:
   name: zxporter-nodemon-gpu
   namespace: devzero-system
   labels:
-    helm.sh/chart: zxporter-nodemon-0.1.5
+    helm.sh/chart: zxporter-nodemon-0.1.6
     app.kubernetes.io/name: zxporter-nodemon
     app.kubernetes.io/instance: zxporter-nodemon-gpu
-    app.kubernetes.io/version: "0.1.5"
+    app.kubernetes.io/version: "0.1.6"
     app.kubernetes.io/managed-by: Helm
   annotations:
     ignore-check.kube-linter.io/privileged-container: "This daemon set needs to run DCGM Exporter as privileged to access the GPU metrics."

--- a/dist/nodemon-gcp.yaml
+++ b/dist/nodemon-gcp.yaml
@@ -6,10 +6,10 @@ metadata:
   name: zxporter-nodemon
   namespace: devzero-system
   labels:
-    helm.sh/chart: zxporter-nodemon-0.1.5
+    helm.sh/chart: zxporter-nodemon-0.1.6
     app.kubernetes.io/name: zxporter-nodemon
     app.kubernetes.io/instance: zxporter-nodemon
-    app.kubernetes.io/version: "0.1.5"
+    app.kubernetes.io/version: "0.1.6"
     app.kubernetes.io/managed-by: Helm
 ---
 # Source: zxporter-nodemon/templates/dcgm-exporter-configmap.yaml
@@ -82,10 +82,10 @@ kind: ClusterRole
 metadata:
   name: zxporter-nodemon
   labels:
-    helm.sh/chart: zxporter-nodemon-0.1.5
+    helm.sh/chart: zxporter-nodemon-0.1.6
     app.kubernetes.io/name: zxporter-nodemon
     app.kubernetes.io/instance: zxporter-nodemon
-    app.kubernetes.io/version: "0.1.5"
+    app.kubernetes.io/version: "0.1.6"
     app.kubernetes.io/managed-by: Helm
 rules:
 - apiGroups:
@@ -133,10 +133,10 @@ kind: ClusterRoleBinding
 metadata:
   name: zxporter-nodemon
   labels:
-    helm.sh/chart: zxporter-nodemon-0.1.5
+    helm.sh/chart: zxporter-nodemon-0.1.6
     app.kubernetes.io/name: zxporter-nodemon
     app.kubernetes.io/instance: zxporter-nodemon
-    app.kubernetes.io/version: "0.1.5"
+    app.kubernetes.io/version: "0.1.6"
     app.kubernetes.io/managed-by: Helm
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -154,10 +154,10 @@ metadata:
   name: zxporter-nodemon
   namespace: devzero-system
   labels:
-    helm.sh/chart: zxporter-nodemon-0.1.5
+    helm.sh/chart: zxporter-nodemon-0.1.6
     app.kubernetes.io/name: zxporter-nodemon
     app.kubernetes.io/instance: zxporter-nodemon
-    app.kubernetes.io/version: "0.1.5"
+    app.kubernetes.io/version: "0.1.6"
     app.kubernetes.io/managed-by: Helm
   annotations:
     ignore-check.kube-linter.io/privileged-container: "This daemon set needs to run DCGM Exporter as privileged to access the GPU metrics."
@@ -316,10 +316,10 @@ metadata:
   name: zxporter-nodemon-gpu
   namespace: devzero-system
   labels:
-    helm.sh/chart: zxporter-nodemon-0.1.5
+    helm.sh/chart: zxporter-nodemon-0.1.6
     app.kubernetes.io/name: zxporter-nodemon
     app.kubernetes.io/instance: zxporter-nodemon-gpu
-    app.kubernetes.io/version: "0.1.5"
+    app.kubernetes.io/version: "0.1.6"
     app.kubernetes.io/managed-by: Helm
   annotations:
     ignore-check.kube-linter.io/privileged-container: "This daemon set needs to run DCGM Exporter as privileged to access the GPU metrics."

--- a/dist/nodemon-lowpriv.yaml
+++ b/dist/nodemon-lowpriv.yaml
@@ -6,10 +6,10 @@ metadata:
   name: zxporter-nodemon
   namespace: devzero-system
   labels:
-    helm.sh/chart: zxporter-nodemon-0.1.5
+    helm.sh/chart: zxporter-nodemon-0.1.6
     app.kubernetes.io/name: zxporter-nodemon
     app.kubernetes.io/instance: zxporter-nodemon
-    app.kubernetes.io/version: "0.1.5"
+    app.kubernetes.io/version: "0.1.6"
     app.kubernetes.io/managed-by: Helm
 ---
 # Source: zxporter-nodemon/templates/dcgm-exporter-configmap.yaml
@@ -82,10 +82,10 @@ kind: ClusterRole
 metadata:
   name: zxporter-nodemon
   labels:
-    helm.sh/chart: zxporter-nodemon-0.1.5
+    helm.sh/chart: zxporter-nodemon-0.1.6
     app.kubernetes.io/name: zxporter-nodemon
     app.kubernetes.io/instance: zxporter-nodemon
-    app.kubernetes.io/version: "0.1.5"
+    app.kubernetes.io/version: "0.1.6"
     app.kubernetes.io/managed-by: Helm
 rules:
 - apiGroups:
@@ -132,10 +132,10 @@ kind: ClusterRoleBinding
 metadata:
   name: zxporter-nodemon
   labels:
-    helm.sh/chart: zxporter-nodemon-0.1.5
+    helm.sh/chart: zxporter-nodemon-0.1.6
     app.kubernetes.io/name: zxporter-nodemon
     app.kubernetes.io/instance: zxporter-nodemon
-    app.kubernetes.io/version: "0.1.5"
+    app.kubernetes.io/version: "0.1.6"
     app.kubernetes.io/managed-by: Helm
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -153,10 +153,10 @@ metadata:
   name: zxporter-nodemon
   namespace: devzero-system
   labels:
-    helm.sh/chart: zxporter-nodemon-0.1.5
+    helm.sh/chart: zxporter-nodemon-0.1.6
     app.kubernetes.io/name: zxporter-nodemon
     app.kubernetes.io/instance: zxporter-nodemon
-    app.kubernetes.io/version: "0.1.5"
+    app.kubernetes.io/version: "0.1.6"
     app.kubernetes.io/managed-by: Helm
   annotations:
     ignore-check.kube-linter.io/privileged-container: "This daemon set needs to run DCGM Exporter as privileged to access the GPU metrics."
@@ -300,10 +300,10 @@ metadata:
   name: zxporter-nodemon-gpu
   namespace: devzero-system
   labels:
-    helm.sh/chart: zxporter-nodemon-0.1.5
+    helm.sh/chart: zxporter-nodemon-0.1.6
     app.kubernetes.io/name: zxporter-nodemon
     app.kubernetes.io/instance: zxporter-nodemon-gpu
-    app.kubernetes.io/version: "0.1.5"
+    app.kubernetes.io/version: "0.1.6"
     app.kubernetes.io/managed-by: Helm
   annotations:
     ignore-check.kube-linter.io/privileged-container: "This daemon set needs to run DCGM Exporter as privileged to access the GPU metrics."

--- a/dist/nodemon.yaml
+++ b/dist/nodemon.yaml
@@ -6,10 +6,10 @@ metadata:
   name: zxporter-nodemon
   namespace: devzero-system
   labels:
-    helm.sh/chart: zxporter-nodemon-0.1.5
+    helm.sh/chart: zxporter-nodemon-0.1.6
     app.kubernetes.io/name: zxporter-nodemon
     app.kubernetes.io/instance: zxporter-nodemon
-    app.kubernetes.io/version: "0.1.5"
+    app.kubernetes.io/version: "0.1.6"
     app.kubernetes.io/managed-by: Helm
 ---
 # Source: zxporter-nodemon/templates/dcgm-exporter-configmap.yaml
@@ -82,10 +82,10 @@ kind: ClusterRole
 metadata:
   name: zxporter-nodemon
   labels:
-    helm.sh/chart: zxporter-nodemon-0.1.5
+    helm.sh/chart: zxporter-nodemon-0.1.6
     app.kubernetes.io/name: zxporter-nodemon
     app.kubernetes.io/instance: zxporter-nodemon
-    app.kubernetes.io/version: "0.1.5"
+    app.kubernetes.io/version: "0.1.6"
     app.kubernetes.io/managed-by: Helm
 rules:
 - apiGroups:
@@ -133,10 +133,10 @@ kind: ClusterRoleBinding
 metadata:
   name: zxporter-nodemon
   labels:
-    helm.sh/chart: zxporter-nodemon-0.1.5
+    helm.sh/chart: zxporter-nodemon-0.1.6
     app.kubernetes.io/name: zxporter-nodemon
     app.kubernetes.io/instance: zxporter-nodemon
-    app.kubernetes.io/version: "0.1.5"
+    app.kubernetes.io/version: "0.1.6"
     app.kubernetes.io/managed-by: Helm
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -154,10 +154,10 @@ metadata:
   name: zxporter-nodemon
   namespace: devzero-system
   labels:
-    helm.sh/chart: zxporter-nodemon-0.1.5
+    helm.sh/chart: zxporter-nodemon-0.1.6
     app.kubernetes.io/name: zxporter-nodemon
     app.kubernetes.io/instance: zxporter-nodemon
-    app.kubernetes.io/version: "0.1.5"
+    app.kubernetes.io/version: "0.1.6"
     app.kubernetes.io/managed-by: Helm
   annotations:
     ignore-check.kube-linter.io/privileged-container: "This daemon set needs to run DCGM Exporter as privileged to access the GPU metrics."
@@ -306,10 +306,10 @@ metadata:
   name: zxporter-nodemon-gpu
   namespace: devzero-system
   labels:
-    helm.sh/chart: zxporter-nodemon-0.1.5
+    helm.sh/chart: zxporter-nodemon-0.1.6
     app.kubernetes.io/name: zxporter-nodemon
     app.kubernetes.io/instance: zxporter-nodemon-gpu
-    app.kubernetes.io/version: "0.1.5"
+    app.kubernetes.io/version: "0.1.6"
     app.kubernetes.io/managed-by: Helm
   annotations:
     ignore-check.kube-linter.io/privileged-container: "This daemon set needs to run DCGM Exporter as privileged to access the GPU metrics."

--- a/go.mod
+++ b/go.mod
@@ -92,7 +92,7 @@ require (
 	cel.dev/expr v0.25.2 // indirect
 	github.com/expr-lang/expr v1.17.8 // indirect
 	github.com/google/btree v1.1.3 // indirect
-	github.com/kedacore/keda/v2 v2.20.1
+	github.com/kedacore/keda/v2 v2.20.2
 	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 // indirect
 	go.opentelemetry.io/auto/sdk v1.2.1 // indirect
 	gopkg.in/evanphx/json-patch.v4 v4.13.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -165,8 +165,8 @@ github.com/jsimonetti/rtnetlink/v2 v2.0.1 h1:xda7qaHDSVOsADNouv7ukSuicKZO7GgVUCX
 github.com/jsimonetti/rtnetlink/v2 v2.0.1/go.mod h1:7MoNYNbb3UaDHtF8udiJo/RH6VsTKP1pqKLUTVCvToE=
 github.com/json-iterator/go v1.1.12 h1:PV8peI4a0ysnczrg+LtxykD8LfKY9ML6u2jnxaEnrnM=
 github.com/json-iterator/go v1.1.12/go.mod h1:e30LSqwooZae/UwlEbR2852Gd8hjQvJoHmT4TnhNGBo=
-github.com/kedacore/keda/v2 v2.20.1 h1:0Bb2zX/s+RSPtU2W+/Jk24A/aFl8MO79UuU0C4lA8ts=
-github.com/kedacore/keda/v2 v2.20.1/go.mod h1:wrV1MP6buZQ1S5/J/R7UyBeJr857x92E43LADVoSajs=
+github.com/kedacore/keda/v2 v2.20.2 h1:SR60v8uIcelbveS8n/1jcl8tLdBBIbHMxmdOHw8tKqA=
+github.com/kedacore/keda/v2 v2.20.2/go.mod h1:wrV1MP6buZQ1S5/J/R7UyBeJr857x92E43LADVoSajs=
 github.com/klauspost/compress v1.19.1 h1:VsB4HPswih7mmZ8WleSFQ75c/Ui1M4trX5oAsJnhSlk=
 github.com/klauspost/compress v1.19.1/go.mod h1:cwPg85FWrGar70rWktvGQj8/hthj3wpl0PGDogxkrSQ=
 github.com/kr/pretty v0.3.1 h1:flRD4NNwYAUpkphVc1HcthR4KEIFJ65n8Mw5qdRn3LE=

--- a/helm-chart/zxporter-netmon/Chart.yaml
+++ b/helm-chart/zxporter-netmon/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: zxporter-netmon
 description: A Helm chart for zxporter network monitor daemonset
 type: application
-version: 0.1.5
-appVersion: "0.1.5"
+version: 0.1.6
+appVersion: "0.1.6"

--- a/helm-chart/zxporter-netmon/values.yaml
+++ b/helm-chart/zxporter-netmon/values.yaml
@@ -2,7 +2,7 @@ image:
   repository: devzeroinc/zxporter-netmon
   pullPolicy: IfNotPresent
   # Overrides the image tag whose default is the chart appVersion.
-  tag: "v0.1.5"
+  tag: "v0.1.6"
 imagePullSecrets: []
 nameOverride: ""
 fullnameOverride: ""

--- a/helm-chart/zxporter-nodemon/Chart.yaml
+++ b/helm-chart/zxporter-nodemon/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: zxporter-nodemon
 description: A Helm chart for Kubernetes
 type: application
-version: 0.1.5
-appVersion: "0.1.5"
+version: 0.1.6
+appVersion: "0.1.6"

--- a/helm-chart/zxporter-nodemon/values.yaml
+++ b/helm-chart/zxporter-nodemon/values.yaml
@@ -13,7 +13,7 @@ serviceAccount:
 image:
   repository: public.ecr.aws/devzeroinc/zxporter-nodemon
   pullPolicy: IfNotPresent
-  tag: "v0.1.5"
+  tag: "v0.1.6"
 nodemon:
   # nodemon.affinity -- optional pod affinity/anti-affinity. Leave empty so nodemon schedules on
   # EVERY node (it is the sole source of node/container metrics). Only set this if you intentionally

--- a/helm-chart/zxporter/Chart.lock
+++ b/helm-chart/zxporter/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: zxporter-nodemon
   repository: file://../zxporter-nodemon
-  version: 0.1.5
-digest: sha256:83bc77246829846e128e0842eeded20811e78cf8be36ea80d6ce9017813c89cb
-generated: "2026-08-04T05:45:12.753317046Z"
+  version: 0.1.6
+digest: sha256:6d5a88673e5b4997a8f2e75733aa6fce062b81bff4110d2e0042a343e1e12f27
+generated: "2026-08-04T08:42:16.511514311Z"

--- a/helm-chart/zxporter/Chart.yaml
+++ b/helm-chart/zxporter/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v2
 name: zxporter
 description: A Helm chart for DevZero ZXPorter - Kubernetes resource monitoring and optimization
-version: 0.1.5
-appVersion: "0.1.5"
+version: 0.1.6
+appVersion: "0.1.6"
 home: https://github.com/devzero-inc/zxporter
 sources:
   - https://github.com/devzero-inc/zxporter
@@ -17,5 +17,5 @@ keywords:
   - devzero
 dependencies:
   - name: zxporter-nodemon
-    version: "0.1.5"
+    version: "0.1.6"
     repository: "file://../zxporter-nodemon"

--- a/helm-chart/zxporter/values.yaml
+++ b/helm-chart/zxporter/values.yaml
@@ -11,7 +11,7 @@
 image:
   repository: public.ecr.aws/devzeroinc/zxporter
   pullPolicy: IfNotPresent
-  tag: "v0.1.5"
+  tag: "v0.1.6"
 # ZXPorter configuration
 zxporter:
   dakrUrl: "https://dakr.devzero.io"

--- a/internal/collector/snap/snapshot_namespace.go
+++ b/internal/collector/snap/snapshot_namespace.go
@@ -24,7 +24,7 @@ func (c *ClusterSnapshotter) captureNamespaces(
 			DaemonSets:               make(map[string]*ResourceIdentifier),
 			ReplicaSets:              make(map[string]*ResourceIdentifier),
 			Services:                 make(map[string]*ResourceIdentifier),
-			Secrets:                  make(map[string]*ResourceIdentifier),
+			Secrets:                  make(map[string]*ResourceIdentifier), // Never populated; see uncollectedWireTypes
 			Pvcs:                     make(map[string]*ResourceIdentifier),
 			Jobs:                     make(map[string]*ResourceIdentifier),
 			CronJobs:                 make(map[string]*ResourceIdentifier),
@@ -144,12 +144,11 @@ func (c *ClusterSnapshotter) captureOtherResources(
 		}
 	}
 
-	if secrets, err := c.client.CoreV1().Secrets(namespace).List(ctx, metav1.ListOptions{}); err == nil {
-		for _, secret := range secrets.Items {
-			uid := string(secret.UID)
-			nsData.Secrets[uid] = &ResourceIdentifier{Name: secret.Name}
-		}
-	}
+	// nsData.Secrets is left empty on purpose; secrets are an uncollected wire
+	// type (see uncollectedWireTypes). The list that used to run here was
+	// denied by RBAC on every cycle, and this call site swallowed the 403
+	// rather than reporting it — which is why the gap stayed invisible until
+	// the streaming path began surfacing per-type listing failures.
 
 	if pvcs, err := c.client.CoreV1().PersistentVolumeClaims(namespace).List(ctx, metav1.ListOptions{}); err == nil {
 		for _, pvc := range pvcs.Items {

--- a/internal/collector/snap/stream_capture.go
+++ b/internal/collector/snap/stream_capture.go
@@ -248,6 +248,31 @@ func optionalWalk(walk func(ctx context.Context, emit func([]*gen.SnapshotEntry)
 	}
 }
 
+// uncollectedWireTypes are wire resource types this agent has no collector
+// for; their slots in the collector enum exist only to keep the numbering
+// stable (see collector.Secret, collector.ConfigMap). Listing them in
+// streamSources is always a mistake, for two reasons that hold for every type
+// here:
+//
+//  1. It cannot converge anything. dakr diffs a type only against rows this
+//     agent sent, and no collector ever sends these, so the snapshot can only
+//     report the cluster's entire inventory as "missing" — and
+//     missingResourceHandlerKey has no handler to refresh it with.
+//  2. It starves real work. dakr caps the missing-resources response globally
+//     across all types, so thousands of unrefreshable entries (Helm keeps one
+//     Secret per release revision) would crowd out the types that do have
+//     refresh handlers and appear later in the source order.
+//
+// Secrets additionally cannot be listed at all: the manager ClusterRole grants
+// only resourceName-scoped access to the agent's own token Secret, by design.
+// A list verb cannot be narrowed to metadata — PartialObjectMetadata is a
+// response projection applied after authorization, so listing secret metadata
+// demands the same permission as reading every secret value in the cluster.
+var uncollectedWireTypes = map[gen.ResourceType]string{
+	gen.ResourceType_RESOURCE_TYPE_SECRET:     "secrets",
+	gen.ResourceType_RESOURCE_TYPE_CONFIG_MAP: "configmaps",
+}
+
 // streamSources builds the ordered resource-type table. Owners come before
 // dependents (namespaces, nodes, workload owners, replicasets/jobs, pods)
 // so the receiver's missing-resources response is naturally parent-first,
@@ -287,7 +312,7 @@ func (c *ClusterSnapshotter) streamSources() []snapshotSource {
 
 		// Remaining namespaced types.
 		{rt: gen.ResourceType_RESOURCE_TYPE_SERVICE, name: "services", walk: c.metadataWalk(core("services"), true, nil)},
-		{rt: gen.ResourceType_RESOURCE_TYPE_SECRET, name: "secrets", walk: c.metadataWalk(core("secrets"), true, nil)},
+		// Secrets are deliberately absent here: see uncollectedWireTypes.
 		{rt: gen.ResourceType_RESOURCE_TYPE_PERSISTENT_VOLUME_CLAIM, name: "persistentvolumeclaims", walk: c.metadataWalk(core("persistentvolumeclaims"), true, nil)},
 		{rt: gen.ResourceType_RESOURCE_TYPE_INGRESS, name: "ingresses", walk: c.metadataWalk(schema.GroupVersionResource{Group: "networking.k8s.io", Version: "v1", Resource: "ingresses"}, true, nil)},
 		{rt: gen.ResourceType_RESOURCE_TYPE_NETWORK_POLICY, name: "networkpolicies", walk: c.metadataWalk(schema.GroupVersionResource{Group: "networking.k8s.io", Version: "v1", Resource: "networkpolicies"}, true, nil)},

--- a/internal/collector/snap/stream_capture_test.go
+++ b/internal/collector/snap/stream_capture_test.go
@@ -217,6 +217,46 @@ func TestStreamSources_EmissionOrderParentsFirst(t *testing.T) {
 	assert.Less(t, pos[gen.ResourceType_RESOURCE_TYPE_POD], pos[gen.ResourceType_RESOURCE_TYPE_SERVICE], "remaining types after pods")
 }
 
+func TestStreamSources_ExcludesUncollectedWireTypes(t *testing.T) {
+	k8s := k8sfake.NewSimpleClientset()
+	md := metadatafake.NewSimpleMetadataClient(testScheme)
+	c := newTestSnapshotter(t, k8s, md, nil, nil, nil)
+
+	for _, s := range c.streamSources() {
+		if name, uncollected := uncollectedWireTypes[s.rt]; uncollected {
+			t.Errorf("streamSources includes %q, which no collector ever sends: dakr "+
+				"can only answer with an unrefreshable missing list that crowds out "+
+				"the types that do have refresh handlers", name)
+		}
+	}
+}
+
+func TestStreamClusterState_NeverListsSecrets(t *testing.T) {
+	k8s := k8sfake.NewSimpleClientset()
+	md := metadatafake.NewSimpleMetadataClient(testScheme,
+		partialMeta(schema.GroupVersionKind{Version: "v1", Kind: "Secret"}, "prod", "example-tls", "s1"),
+		partialMeta(schema.GroupVersionKind{Group: "apps", Version: "v1", Kind: "Deployment"}, "prod", "web", "d1"),
+	)
+	c := newTestSnapshotter(t, k8s, md, nil, nil, nil)
+
+	stream := &fakeBatchStream{}
+	_, err := c.streamClusterState(context.Background(), stream)
+	require.NoError(t, err)
+
+	// The API call itself must not happen: RBAC denies it, so issuing it costs
+	// an audit-logged 403 every cycle even though the result is discarded.
+	for _, a := range md.Actions() {
+		assert.NotEqual(t, "secrets", a.GetResource().Resource,
+			"the snapshot must never issue a secrets list")
+	}
+	assert.Empty(t, stream.forType(gen.ResourceType_RESOURCE_TYPE_SECRET),
+		"no secret batch reaches the wire even when secrets exist in the cluster")
+
+	// Guard against the trivial pass where nothing was streamed at all.
+	assert.NotEmpty(t, stream.forType(gen.ResourceType_RESOURCE_TYPE_DEPLOYMENT),
+		"other namespaced metadata types still stream")
+}
+
 func TestStreamClusterState_PodsFlatWithExclusions(t *testing.T) {
 	k8s := k8sfake.NewSimpleClientset(
 		pod("prod", "keep-scheduled", "p1", "node-a"),


### PR DESCRIPTION
Release v0.1.6 of zxporter, published from the internal services monorepo.

The `v0.1.6` tag has already been created and points at this branch's tip — ArgoCD and other tag consumers can use it immediately. This PR is only to advance public main to the released commit for browser convenience.